### PR TITLE
Landing Page Work Plan Re-route - Bug fix

### DIFF
--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -19,7 +19,7 @@ export default {
       downloadText: "",
       link: {
         text: "Enter Work Plan online",
-        route: "mp/get-started",
+        route: "wp",
       },
       accordion: {
         buttonLabel: "When is the Work Plan due?",


### PR DESCRIPTION
### Description
Small bug fix to set the landing page "Work Plan" card to route to /wp 
