### PR TITLE
Feature Flags for WP and SAR Reports

### DIFF
--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.test.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.test.tsx
@@ -9,7 +9,7 @@ import verbiage from "verbiage/pages/home";
 
 const accordionComponent = (
   <RouterWrappedComponent>
-    <TemplateCardAccordion verbiage={verbiage.cards.MP.accordion} />
+    <TemplateCardAccordion verbiage={verbiage.cards.WP.accordion} />
   </RouterWrappedComponent>
 );
 
@@ -20,30 +20,30 @@ describe("Test TemplateCardAccordion", () => {
 
   test("Accordion is visible", () => {
     expect(
-      screen.getByText(verbiage.cards.MP.accordion.buttonLabel)
+      screen.getByText(verbiage.cards.WP.accordion.buttonLabel)
     ).toBeVisible();
   });
 
   test("Accordion default closed state only shows the question", () => {
     expect(
-      screen.getByText(verbiage.cards.MP.accordion.buttonLabel)
+      screen.getByText(verbiage.cards.WP.accordion.buttonLabel)
     ).toBeVisible();
     expect(
-      screen.getByText(verbiage.cards.MP.accordion.text)
+      screen.getByText(verbiage.cards.WP.accordion.text)
     ).not.toBeVisible();
   });
 
   test("Accordion should show answer on click", async () => {
     const accordionQuestion = screen.getByText(
-      verbiage.cards.MP.accordion.buttonLabel
+      verbiage.cards.WP.accordion.buttonLabel
     );
     expect(accordionQuestion).toBeVisible();
     expect(
-      screen.getByText(verbiage.cards.MP.accordion.text)
+      screen.getByText(verbiage.cards.WP.accordion.text)
     ).not.toBeVisible();
     await userEvent.click(accordionQuestion);
     expect(accordionQuestion).toBeVisible();
-    expect(screen.getByText(verbiage.cards.MP.accordion.text)).toBeVisible();
+    expect(screen.getByText(verbiage.cards.WP.accordion.text)).toBeVisible();
   });
 });
 

--- a/services/ui-src/src/components/app/AppRoutes.test.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.test.tsx
@@ -6,12 +6,14 @@ import { createMemoryHistory } from "history";
 import { AppRoutes } from "components";
 // utils
 import { useUserStore, UserProvider } from "utils";
-import { mockStateUserStore } from "utils/testing/setupJest";
+import { mockStateUserStore, mockLDFlags } from "utils/testing/setupJest";
 
 jest.mock("utils/state/useUserStore");
 const mockedUseUserStore = useUserStore as jest.MockedFunction<
   typeof useUserStore
 >;
+
+mockLDFlags.setDefault({ wpReport: true, sarReport: true });
 
 const appRoutesComponent = (history: any) => (
   <Router location={history.location} navigator={history}>

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import {
   AdminBannerProvider,
@@ -18,6 +19,10 @@ import { ReportType } from "types";
 export const AppRoutes = () => {
   const { userIsAdmin } = useUserStore().user ?? {};
 
+  // LaunchDarkly
+  const wpReport = useFlags()?.wpReport;
+  const sarReport = useFlags().sarReport;
+
   return (
     <main id="main-content" tabIndex={-1}>
       <ScrollToTopComponent />
@@ -31,12 +36,20 @@ export const AppRoutes = () => {
           />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="*" element={<NotFoundPage />} />
-          {/* MFP ROUTES */}
-          <Route
-            path="/wp"
-            element={<DashboardPage reportType={ReportType.WP} />}
-          />
-          {/* Report Routes */}
+          {/* MFP Report Routes */}
+          {wpReport && (
+            <Route
+              path="/wp"
+              element={<DashboardPage reportType={ReportType.WP} />}
+            />
+          )}
+          {sarReport && (
+            <Route
+              path="/sar"
+              element={<DashboardPage reportType={ReportType.SAR} />}
+            />
+          )}
+          {/* General Report Routes */}
           <Route path="/standard" element={<ReportPageWrapper />} />
           <Route path="/reviewSubmit" element={<ReviewSubmitPage />} />
         </Routes>

--- a/services/ui-src/src/components/cards/TemplateCard.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.tsx
@@ -13,7 +13,7 @@ import spreadsheetIcon from "assets/icons/icon_spreadsheet.png";
 export const TemplateCard = ({
   verbiage,
   cardprops,
-  isDisabled,
+  isHidden,
   ...props
 }: Props) => {
   const { isDesktop } = useBreakpoint();
@@ -58,7 +58,7 @@ export const TemplateCard = ({
                 {verbiage.downloadText}
               </Button>
             )}
-            {!isDisabled && (
+            {!isHidden && (
               <Button
                 sx={sx.formLink}
                 onClick={() => navigate(verbiage.link.route)}
@@ -80,7 +80,7 @@ export const TemplateCard = ({
 interface Props {
   templateName: string;
   verbiage: AnyObject;
-  isDisabled?: boolean;
+  isHidden?: boolean;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/cards/TemplateCard.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.tsx
@@ -58,15 +58,17 @@ export const TemplateCard = ({
                 {verbiage.downloadText}
               </Button>
             )}
-
-            <Button
-              sx={sx.formLink}
-              isDisabled={isDisabled}
-              onClick={() => navigate(verbiage.link.route)}
-              rightIcon={<Image src={nextIcon} alt="Link Icon" height="1rem" />}
-            >
-              {verbiage.link.text}
-            </Button>
+            {!isDisabled && (
+              <Button
+                sx={sx.formLink}
+                onClick={() => navigate(verbiage.link.route)}
+                rightIcon={
+                  <Image src={nextIcon} alt="Link Icon" height="1rem" />
+                }
+              >
+                {verbiage.link.text}
+              </Button>
+            )}
           </Flex>
           <TemplateCardAccordion verbiage={verbiage.accordion} />
         </Flex>

--- a/services/ui-src/src/components/pages/Home/HomePage.test.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.test.tsx
@@ -3,13 +3,15 @@ import { axe } from "jest-axe";
 // components
 import { HomePage } from "components";
 // utils
-import { RouterWrappedComponent } from "utils/testing/setupJest";
+import { mockLDFlags, RouterWrappedComponent } from "utils/testing/setupJest";
 
 const homeView = (
   <RouterWrappedComponent>
     <HomePage />
   </RouterWrappedComponent>
 );
+
+mockLDFlags.setDefault({ wpReport: true, sarReport: true });
 
 describe("Test HomePage", () => {
   beforeEach(() => {

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -1,3 +1,4 @@
+import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import { Box, Heading, Link, Text } from "@chakra-ui/react";
 import { PageTemplate, TemplateCard } from "components";
@@ -6,6 +7,10 @@ import verbiage from "verbiage/pages/home";
 
 export const HomePage = () => {
   const { intro, cards } = verbiage;
+
+  // LaunchDarkly
+  const wpReport = useFlags()?.wpReport;
+  const sarReport = useFlags().sarReport;
 
   return (
     <PageTemplate sx={sx.layout} data-testid="home-view">
@@ -22,11 +27,17 @@ export const HomePage = () => {
         </Text>
         <Text></Text>
       </Box>
-      <TemplateCard templateName="MP" verbiage={cards.MP} cardprops={sx.card} />
+      <TemplateCard
+        templateName="WP"
+        verbiage={cards.WP}
+        cardprops={sx.card}
+        isDisabled={!wpReport}
+      />
       <TemplateCard
         templateName="SAR"
         verbiage={cards.SAR}
         cardprops={sx.card}
+        isDisabled={!sarReport}
       />
     </PageTemplate>
   );

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -31,13 +31,13 @@ export const HomePage = () => {
         templateName="WP"
         verbiage={cards.WP}
         cardprops={sx.card}
-        isDisabled={!wpReport}
+        isHidden={!wpReport}
       />
       <TemplateCard
         templateName="SAR"
         verbiage={cards.SAR}
         cardprops={sx.card}
-        isDisabled={!sarReport}
+        isHidden={!sarReport}
       />
     </PageTemplate>
   );

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -42,7 +42,7 @@ export const ReviewSubmitPage = () => {
       <Flex sx={sx.pageContainer} data-testid="review-submit-page">
         {ReportStatus.SUBMITTED ? (
           <SuccessMessage
-            reportType={ReportType.MFP}
+            reportType={ReportType.WP}
             name="placeholder"
             date={Date.now()} // this is a placeholder date
             submittedBy={"placeholder"}
@@ -67,7 +67,7 @@ export const ReviewSubmitPage = () => {
 
 const PrintButton = ({ reviewVerbiage }: { reviewVerbiage: AnyObject }) => {
   const { print } = reviewVerbiage;
-  const reportType = ReportType.MFP;
+  const reportType = ReportType.WP;
   const isSubmitted = false;
   return (
     <Button

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -8,7 +8,6 @@ import {
 
 // REPORT TYPES
 export enum ReportType {
-  MFP = "MFP",
   WP = "WP",
   SAR = "SAR",
 }

--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -10,7 +10,7 @@ export default {
     },
   },
   cards: {
-    MP: {
+    WP: {
       title: "MFP Work Plan (WP)",
       body: {
         available:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Wrapping each `TemplateCard` buttons behind a LaunchDarkly feature flag (WP and SAR) for deployments into higher environments.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user

You should see the `Enter WP report` buttons just fine for now, but once we're in higher environments those buttons won't show ❇️ 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
