### PR TITLE
Remove race condition between 

### DIFF
--- a/services/ui-src/src/index.tsx
+++ b/services/ui-src/src/index.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
-import { Amplify } from "aws-amplify";
+import { Amplify, Auth } from "aws-amplify";
 import config from "config";
 // utils
 import { ApiProvider, UserProvider } from "utils";
@@ -19,8 +19,21 @@ Amplify.configure({
     bucket: config.s3.BUCKET,
     identityPoolId: config.cognito.IDENTITY_POOL_ID,
   },
+  Auth: {
+    mandatorySignIn: true,
+    region: config.cognito.REGION,
+    userPoolId: config.cognito.USER_POOL_ID,
+    identityPoolId: config.cognito.IDENTITY_POOL_ID,
+    userPoolWebClientId: config.cognito.APP_CLIENT_ID,
+    oauth: {
+      domain: config.cognito.APP_CLIENT_DOMAIN,
+      redirectSignIn: config.cognito.REDIRECT_SIGNIN,
+      redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
+      scope: ["email", "openid", "profile"],
+      responseType: "code",
+    },
+  },
 });
-
 // LaunchDarkly configuration
 const ldClientId = config.REACT_APP_LD_SDK_CLIENT;
 (async () => {

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -104,24 +104,6 @@ export const UserProvider = ({ children }: Props) => {
     }
   }, [isProduction, location]);
 
-  // single run configuration
-  useEffect(() => {
-    Auth.configure({
-      mandatorySignIn: true,
-      region: config.cognito.REGION,
-      userPoolId: config.cognito.USER_POOL_ID,
-      identityPoolId: config.cognito.IDENTITY_POOL_ID,
-      userPoolWebClientId: config.cognito.APP_CLIENT_ID,
-      oauth: {
-        domain: config.cognito.APP_CLIENT_DOMAIN,
-        redirectSignIn: config.cognito.REDIRECT_SIGNIN,
-        redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
-        scope: ["email", "openid", "profile"],
-        responseType: "code",
-      },
-    });
-  }, []);
-
   // re-render on auth state change, checking router location
   useEffect(() => {
     checkAuthState();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A race condition exists  where Auth.configure hasn't been setup yet when requests start firing. Move it to alongside other amplify config.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->


---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
