### PR TITLE
Make nested choices show again

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -4,7 +4,12 @@ import { useFormContext } from "react-hook-form";
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
 // utils
-import { labelTextWithOptional, parseCustomHtml } from "utils";
+import {
+  formFieldFactory,
+  labelTextWithOptional,
+  parseCustomHtml,
+  useStore,
+} from "utils";
 import {
   AnyObject,
   Choice,
@@ -28,6 +33,13 @@ export const ChoiceListField = ({
   const defaultValue: Choice[] = [];
   const [displayValue, setDisplayValue] = useState<Choice[]>(defaultValue);
 
+  const { state: userIsReadOnly, userIsAdmin } = useStore().user ?? {};
+
+  const report = useStore().report;
+
+  const shouldDisableChildFields =
+    ((userIsAdmin || userIsReadOnly) && !!props?.disabled) || report?.locked;
+
   // get form context and register field
   const form = useFormContext();
 
@@ -36,6 +48,15 @@ export const ChoiceListField = ({
     return choices.map((choice: FieldChoice) => {
       setCheckedOrUnchecked(choice);
       const choiceObject: FieldChoice = { ...choice };
+      const choiceChildren = choice?.children;
+      if (choiceChildren) {
+        const isNested = true;
+        const formattedChildren = formFieldFactory(choiceChildren, {
+          disabled: shouldDisableChildFields,
+          nested: isNested,
+        });
+        choiceObject.checkedChildren = formattedChildren;
+      }
       delete choiceObject.children;
       return choiceObject;
     });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -34,13 +34,13 @@ export const formFieldFactory = (
   const fieldToComponentMap: AnyObject = {
     checkboxSingle: ChoiceField,
     checkbox: CheckboxField,
-    radio: RadioField,
-    text: TextField,
-    textarea: TextAreaField,
     date: DateField,
     dropdown: DropdownField,
     dynamic: DynamicField,
     number: NumberField,
+    radio: RadioField,
+    text: TextField,
+    textarea: TextAreaField,
   };
   fields = initializeChoiceListFields(fields);
   return fields.map((field) => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/fb0bf878-19be-4f6d-b8fd-9a824da270e3


---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a WP
Go to a page with nested choices (Like the first page's drawer!)
See the nested choices appear

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
