### PR TITLE
Mdct 2815 - State and Territory Specific Initiatives: II. Evaluation Plan

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -949,7 +949,12 @@
               {
                 "id": "evaluationPlan_includesTargets",
                 "type": "radio",
-                "validation": "radio",
+                "validation": {
+                  "type": "radio",
+                  "nested": true,
+                  "parentFieldName": "evaluationPlan_targets",
+                  "parentOptionId": "745yghr57654rth"
+                },
                 "props": {
                   "label": "Does the performance measure include quantitative targets?",
                   "hint": "This element indicates if a remittance to the state or a payment to a plan is required in an MCO/PIHP/PAHP contract if a minimum MLR is not met.",
@@ -963,7 +968,7 @@
                       "label": "Yes",
                       "children": [
                         {
-                          "id": "gdfgdgdf",
+                          "id": "evaluationPlan_includesTargets2024Q1",
                           "type": "number",
                           "validation": {
                             "type": "number",
@@ -973,6 +978,138 @@
                           "props": {
                             "label": "2024 Q1",
                             "hint": "this functionality is waiting on BOs."
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2024Q2",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2024 Q2"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2024Q3",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2024 Q3"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2024Q4",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2024 Q4"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2025Q1",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2025 Q1"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2025Q2",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2025 Q2"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2025Q3",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2025 Q3"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2025Q4",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2025 Q4"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2026Q1",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2026 Q1"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2026Q2",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2026 Q2"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2026Q3",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2026 Q3"
+                          }
+                        },
+                        {
+                          "id": "evaluationPlan_includesTargets2026Q4",
+                          "type": "number",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
+                          "props": {
+                            "label": "2026 Q4"
                           }
                         }
                       ]

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -966,7 +966,7 @@
                     {
                       "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
                       "label": "Yes",
-                      "hint": "If 'Yes', fields use calendar year quarters",
+                      "hint": "Note: If 'Yes', fields use calendar year quarters.",
                       "children": [
                         {
                           "id": "evaluationPlan_includesTargets2024Q1",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -858,7 +858,8 @@
         {
           "name": "State and Territory Specific Initiatives: II. Evaluation Plan",
           "path": "/wp/state-and-territory-specific-initiatives/evaluation-plan",
-          "pageType": "modalDrawer",
+          "pageType": "overlayModal",
+          "entityType": "evaluationPlan",
           "verbiage": {
             "intro": {
               "section": "State and Territory Specific Initiatives: II. Evaluation Plan",
@@ -866,88 +867,69 @@
               "info": [
                 {
                   "type": "html",
-                  "content": "The evaluation plan captures expected results for each state or territory-specific initiative. Recipients should identify one or more objectives per initiative and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. In addition, recipients must articulate how they will achieve targets and meet milestones. For more information on developing objectives and identifying appropriate performance measures, see Using Data to Improve Money Follows the Person Program Performance."
-                },
-                {
-                  "type": "html",
-                  "content": "<p><strong>Please identify one or more objectives.</strong> Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones. As a reminder, SMART stands for:</p>"
-                },
-                {
-                  "type": "ul",
-                  "content": "",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1.5rem",
-                      "padding": "1rem"
-                    }
-                  },
-                  "children": [
-                    {
-                      "type": "li",
-                      "props": {
-                        "style": {
-                          "paddingBottom": "1rem"
-                        }
-                      },
-                      "content": "<bold>Specific:</bold> Specifies the activities, actors, and beneficiaries"
-                    },
-                    {
-                      "type": "li",
-                      "content": "Measurable: Defines how a change will be measured"
-                    },
-                    {
-                      "type": "li",
-                      "content": "Achievable: Confirms the feasibility of implementing the intervention as planned"
-                    },
-                    {
-                      "type": "li",
-                      "content": "Realistic/relevant: Ensures the intervention relates to the goal"
-                    },
-                    {
-                      "type": "li",
-                      "content": "Time-bound: Specifies when the results are expected"
-                    }
-                  ]
+                  "content": "Add evaluation plan, including measurable objectives. Select “Add objective” button for each objective you need to add to the system."
                 }
               ],
               "exportSectionHeader": "exportSectionHeader"
             },
+            "accordion": {
+              "buttonLabel": "Instructions",
+              "intro": [
+                {
+                  "type": "html",
+                  "content": "The evaluation plan captures expected results for each state or territory-specific initiative. Recipients should identify one or more objectives per initiative and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. In addition, recipients must articulate how they will achieve targets and meet milestones. For more information on developing objectives and identifying appropriate performance measures, see "
+                },
+                {
+                  "type": "externalLink",
+                  "content": "“Using Data to Improve Money Follows the Person Program Performance.“",
+                  "props": {
+                    "href": "https://www.medicaid.gov/sites/default/files/2023-01/MFP-Technical-Assistance-Brief.pdf",
+                    "target": "_blank",
+                    "ariaLabel": "Link opens in new tab"
+                  }
+                },
+                {
+                  "type": "html",
+                  "content": "<br><br><p><strong>Please identify one or more objectives.</strong> Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones. As a reminder, SMART stands for:</p>"
+                }
+              ],
+              "list": [
+                "<strong>Specific:</strong> Specifies the activities, actors, and beneficiaries",
+                "<strong>Measurable:</strong> Defines how a change will be measured",
+                "<strong>Achievable:</strong> Confirms the feasibility of implementing the intervention as planned",
+                "<strong>Realistic/relevant:</strong> Ensures the intervention relates to the goal",
+                "<strong>Time-bound:</strong> Specifies when the results are expected"
+              ],
+              "text": ""
+            },
+            "text": "Add evaluation plan, including measurable objectives. Select “Add objective” button for each objective you need to add to the system.",
             "addEntityButtonText": "Add objective +",
-            "editEntityButtonText": "Edit name",
-            "addEditModalAddTitle": "Add objective",
+            "editEntityButtonText": "Edit objective",
+            "addEditModalAddTitle": "Add objective for {Person-centered Planning}",
+            "addEditModalHint": "Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones.",
             "addEditModalEditTitle": "Edit objective",
-            "deleteModalTitle": "Are you sure you want to delete this objective?",
+            "deleteModalTitle": "Delete objective for this report?",
             "deleteModalConfirmButtonText": "Yes, delete objective",
-            "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this objective in the Work Plan. The objetive will remain in previously submitted Semi-Annual Reports if applicable. <br/><br/>To close a completed initiative out, select “Cancel” and then the “Close out” button in the listing.",
+            "deleteModalWarning": "You will lose all information entered for this objective. Objective will not be deleted from archived Work Plans and Semi-Annual Reports, but it will not be available in future Work Plans and Semi-Annual Reports.",
             "enterEntityDetailsButtonText": "Edit",
-            "dashboardTitle": "Objective total count:",
+            "dashboardTitle": "Objective total count: 2",
             "deleteEntityButtonAltText": "",
             "entityUnfinishedMessage": "",
-            "reviewPdfHint": "",
             "drawerTitle": ""
           },
           "modalForm": {
             "id": "tb-modal",
             "fields": [
               {
-                "id": "transitionBenchmarks_targetPopulationName",
-                "type": "text",
-                "validation": "text",
-                "props": {
-                  "label": "Add objective for {Person-centered Planning}",
-                  "hint": "Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones."
-                }
-              },
-              {
-                "id": "dghdfgdf",
+                "id": "evaluationPlan_objectiveName",
                 "type": "textarea",
                 "validation": "text",
                 "props": {
-                  "label": "Objective name"
+                  "label": "Objective"
                 }
               },
               {
-                "id": "sersres",
+                "id": "evaluationPlan_description",
                 "type": "textarea",
                 "validation": "text",
                 "props": {
@@ -956,16 +938,16 @@
                 }
               },
               {
-                "id": "liolj",
+                "id": "evaluationPlan_targets",
                 "type": "textarea",
                 "validation": "text",
                 "props": {
-                  "label": "Provide targets for the performance measures or indicators listed above. Please include milestones and expected time frames or or key deliverables.",
+                  "label": "Provide targets for the performance measures or indicators listed above. Please include milestones and expected time frames or key deliverables.",
                   "hint": "If a performance measure includes quantitative targets, complete the quarterly fields below."
                 }
               },
               {
-                "id": "quantitative_targets",
+                "id": "evaluationPlan_includesTargets",
                 "type": "radio",
                 "validation": "radio",
                 "props": {
@@ -983,11 +965,14 @@
                         {
                           "id": "gdfgdgdf",
                           "type": "number",
-                          "nested": true,
-                          "parentFieldName": "quantitative_targets",
-                          "parentOptionId": "7FP4jcg4jK7Ssqp3cCW5vQ",
+                          "validation": {
+                            "type": "number",
+                            "parentFieldName": "evaluationPlan_includesTargets",
+                            "nested": true
+                          },
                           "props": {
-                            "label": "YEAR Q#"
+                            "label": "2024 Q1",
+                            "hint": "this functionality is waiting on BOs."
                           }
                         }
                       ]
@@ -996,7 +981,7 @@
                 }
               },
               {
-                "id": "klilkh",
+                "id": "evaluationPlan_additionalDetails",
                 "type": "textarea",
                 "validation": "text",
                 "props": {
@@ -1005,12 +990,7 @@
                 }
               }
             ]
-          },
-          "drawerForm": {
-            "id": "tb-drawer",
-            "fields": [{}]
-          },
-          "entityType": "objectives"
+          }
         }
       ]
     },

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -957,7 +957,7 @@
                 },
                 "props": {
                   "label": "Does the performance measure include quantitative targets?",
-                  "hint": "This element indicates if a remittance to the state or a payment to a plan is required in an MCO/PIHP/PAHP contract if a minimum MLR is not met.",
+                  "hint": "Note: If 'Yes', fields use calendar year quarters.",
                   "choices": [
                     {
                       "id": "UL4dAeyyvCFAXttxZioacR",
@@ -966,7 +966,6 @@
                     {
                       "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
                       "label": "Yes",
-                      "hint": "Note: If 'Yes', fields use calendar year quarters.",
                       "children": [
                         {
                           "id": "evaluationPlan_includesTargets2024Q1",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -854,6 +854,163 @@
               }
             ]
           }
+        },
+        {
+          "name": "State and Territory Specific Initiatives: II. Evaluation Plan",
+          "path": "/wp/state-and-territory-specific-initiatives/evaluation-plan",
+          "pageType": "modalDrawer",
+          "verbiage": {
+            "intro": {
+              "section": "State and Territory Specific Initiatives: II. Evaluation Plan",
+              "subsection": "{Person-centered Planning}",
+              "info": [
+                {
+                  "type": "html",
+                  "content": "The evaluation plan captures expected results for each state or territory-specific initiative. Recipients should identify one or more objectives per initiative and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. In addition, recipients must articulate how they will achieve targets and meet milestones. For more information on developing objectives and identifying appropriate performance measures, see Using Data to Improve Money Follows the Person Program Performance."
+                },
+                {
+                  "type": "html",
+                  "content": "<p><strong>Please identify one or more objectives.</strong> Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones. As a reminder, SMART stands for:</p>"
+                },
+                {
+                  "type": "ul",
+                  "content": "",
+                  "props": {
+                    "style": {
+                      "marginLeft": "1.5rem",
+                      "padding": "1rem"
+                    }
+                  },
+                  "children": [
+                    {
+                      "type": "li",
+                      "props": {
+                        "style": {
+                          "paddingBottom": "1rem"
+                        }
+                      },
+                      "content": "<bold>Specific:</bold> Specifies the activities, actors, and beneficiaries"
+                    },
+                    {
+                      "type": "li",
+                      "content": "Measurable: Defines how a change will be measured"
+                    },
+                    {
+                      "type": "li",
+                      "content": "Achievable: Confirms the feasibility of implementing the intervention as planned"
+                    },
+                    {
+                      "type": "li",
+                      "content": "Realistic/relevant: Ensures the intervention relates to the goal"
+                    },
+                    {
+                      "type": "li",
+                      "content": "Time-bound: Specifies when the results are expected"
+                    }
+                  ]
+                }
+              ],
+              "exportSectionHeader": "exportSectionHeader"
+            },
+            "addEntityButtonText": "Add objective +",
+            "editEntityButtonText": "Edit name",
+            "addEditModalAddTitle": "Add objective",
+            "addEditModalEditTitle": "Edit objective",
+            "deleteModalTitle": "Are you sure you want to delete this objective?",
+            "deleteModalConfirmButtonText": "Yes, delete objective",
+            "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this objective in the Work Plan. The objetive will remain in previously submitted Semi-Annual Reports if applicable. <br/><br/>To close a completed initiative out, select “Cancel” and then the “Close out” button in the listing.",
+            "enterEntityDetailsButtonText": "Edit",
+            "dashboardTitle": "Objective total count:",
+            "deleteEntityButtonAltText": "",
+            "entityUnfinishedMessage": "",
+            "reviewPdfHint": "",
+            "drawerTitle": ""
+          },
+          "modalForm": {
+            "id": "tb-modal",
+            "fields": [
+              {
+                "id": "transitionBenchmarks_targetPopulationName",
+                "type": "text",
+                "validation": "text",
+                "props": {
+                  "label": "Add objective for {Person-centered Planning}",
+                  "hint": "Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones."
+                }
+              },
+              {
+                "id": "dghdfgdf",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "Objective name"
+                }
+              },
+              {
+                "id": "sersres",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "Describe the performance of measures or indicators your state or territory will use to monitor progress toward achieving this objective, including details on the calculation of measures if relevant. Please describe any key deliverables.",
+                  "hint": "(e.g., data sources and limitations)"
+                }
+              },
+              {
+                "id": "liolj",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "Provide targets for the performance measures or indicators listed above. Please include milestones and expected time frames or or key deliverables.",
+                  "hint": "If a performance measure includes quantitative targets, complete the quarterly fields below."
+                }
+              },
+              {
+                "id": "quantitative_targets",
+                "type": "radio",
+                "validation": "radio",
+                "props": {
+                  "label": "Does the performance measure include quantitative targets?",
+                  "hint": "This element indicates if a remittance to the state or a payment to a plan is required in an MCO/PIHP/PAHP contract if a minimum MLR is not met.",
+                  "choices": [
+                    {
+                      "id": "UL4dAeyyvCFAXttxZioacR",
+                      "label": "No"
+                    },
+                    {
+                      "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
+                      "label": "Yes",
+                      "children": [
+                        {
+                          "id": "gdfgdgdf",
+                          "type": "number",
+                          "nested": true,
+                          "parentFieldName": "quantitative_targets",
+                          "parentOptionId": "7FP4jcg4jK7Ssqp3cCW5vQ",
+                          "props": {
+                            "label": "YEAR Q#"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "klilkh",
+                "type": "textarea",
+                "validation": "text",
+                "props": {
+                  "label": "Please provide additional detail on strategies/approaches to the state or territory will use to achieve targets and/or milestones (building on the initiative description).",
+                  "hint": "Please list the responsible state or territory agency parties and the key external partners for achieving this objective."
+                }
+              }
+            ]
+          },
+          "drawerForm": {
+            "id": "tb-drawer",
+            "fields": [{}]
+          },
+          "entityType": "objectives"
         }
       ]
     },

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -966,6 +966,7 @@
                     {
                       "id": "7FP4jcg4jK7Ssqp3cCW5vQ",
                       "label": "Yes",
+                      "hint": "If 'Yes', fields use calendar year quarters",
                       "children": [
                         {
                           "id": "evaluationPlan_includesTargets2024Q1",
@@ -976,8 +977,7 @@
                             "nested": true
                           },
                           "props": {
-                            "label": "2024 Q1",
-                            "hint": "this functionality is waiting on BOs."
+                            "label": "2024 Q1"
                           }
                         },
                         {

--- a/services/ui-src/src/components/cards/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard.tsx
@@ -89,7 +89,6 @@ export const EntityCard = ({
         <EntityCardTopSection
           entityType={entityType}
           formattedEntityData={formattedEntityData}
-          printVersion={!!printVersion}
         />
         {openAddEditEntityModal && (
           <Button

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -1,10 +1,41 @@
 // components
-import { Text } from "@chakra-ui/react";
+import { Heading, Text } from "@chakra-ui/react";
 // utils
-import { AnyObject } from "types";
+import { AnyObject, OverlayModalEntityTypes } from "types";
 
-export const EntityCardTopSection = ({ entityType }: Props) => {
+export const EntityCardTopSection = ({
+  entityType,
+  formattedEntityData,
+}: Props) => {
   switch (entityType) {
+    case OverlayModalEntityTypes.EVALUATION_PLAN:
+      return (
+        <>
+          <Heading as="h4" sx={sx.heading}>
+            {formattedEntityData.objectiveName}
+          </Heading>
+          <Text sx={sx.subtitle}>
+            Performance measure description or indicators your state will use to
+            monitor progress towards achievement
+          </Text>
+          <Text sx={sx.description}>{formattedEntityData.description}</Text>
+          <Text sx={sx.subtitle}>Performance measure targets</Text>
+          <Text sx={sx.description}>{formattedEntityData.targets}</Text>
+          <Text sx={sx.subtitle}>
+            Does the performance measure include quantitative targets?
+          </Text>
+          <Text sx={sx.description}>{formattedEntityData.includesTargets}</Text>
+          <Text sx={sx.subtitle}>
+            Additional detail on strategies/approaches the state or territory
+            will use to achieve targets and/ or meet milestones
+          </Text>
+          <Text sx={sx.description}>
+            {formattedEntityData.additionalDetails}
+          </Text>{" "}
+        </>
+      );
+    case OverlayModalEntityTypes.FUNDING_SOURCES:
+      return <></>;
     default:
       return <Text>{entityType}</Text>;
   }
@@ -15,3 +46,26 @@ interface Props {
   formattedEntityData: AnyObject;
   printVersion?: boolean;
 }
+
+const sx = {
+  heading: {
+    fontSize: "sm",
+  },
+  description: {
+    marginTop: "0.75rem",
+    fontSize: "sm",
+  },
+  grid: {
+    gridTemplateColumns: "33% auto",
+    columnGap: "1rem",
+  },
+  subtitle: {
+    marginTop: "1rem",
+    fontSize: "xs",
+    fontWeight: "bold",
+  },
+  subtext: {
+    marginTop: "0.25rem",
+    fontSize: "sm",
+  },
+};

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -162,8 +162,10 @@ const sx = {
   ".ds-c-choice__checkedChild.nested": {
     paddingY: "0.25rem",
     paddingTop: 0,
+    // makes the blue line continuous
+    marginBottom: 0,
     ".ds-c-fieldset, label": {
-      marginTop: 0,
+      marginTop: "1rem",
     },
   },
   // optional text

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -76,6 +76,7 @@ export { ReportContext, ReportProvider } from "./reports/ReportProvider";
 export { EntityProvider } from "./reports/EntityProvider";
 export { DrawerReportPage } from "./reports/DrawerReportPage";
 export { ModalDrawerReportPage } from "./reports/ModalDrawerReportPage";
+export { OverlayModalPage } from "./reports/OverlayModalPage";
 export { ModalOverlayReportPage } from "./reports/ModalOverlayReportPage";
 // statusing
 export { StatusTable } from "./statusing/StatusTable";

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -192,7 +192,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           selectedEntity={selectedEntity!}
           verbiage={{
             ...verbiage,
-            drawerDetails: getFormattedEntityData(),
+            drawerDetails: getFormattedEntityData(entityType),
           }}
           form={drawerForm}
           onSubmit={() => {}}

--- a/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+// components
+import { OverlayModalPage } from "./OverlayModalPage";
+// utils
+import {
+  mockOverlayModalPageJson,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
+
+const mockUseNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockUseNavigate,
+  useLocation: jest.fn(() => ({
+    pathname: "/mock-route",
+  })),
+}));
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+const {
+  addEntityButtonText,
+  editEntityButtonText,
+  // deleteModalConfirmButtonText,
+} = mockOverlayModalPageJson.verbiage;
+
+const overlayModalPageComponentWithEntities = (
+  <RouterWrappedComponent>
+    <OverlayModalPage route={mockOverlayModalPageJson} />
+  </RouterWrappedComponent>
+);
+
+describe("Test overlayModalPage with entities", () => {
+  beforeEach(() => {
+    render(overlayModalPageComponentWithEntities);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("overlayModalPage should render the view", () => {
+    expect(screen.getByText(addEntityButtonText)).toBeVisible();
+  });
+
+  it("overlayModalPage Modal opens correctly", async () => {
+    const addEntityButton = screen.getByText(addEntityButtonText);
+    await userEvent.click(addEntityButton);
+    expect(screen.getByRole("dialog")).toBeVisible();
+
+    const editButton = screen.getAllByText(editEntityButtonText)[0];
+    await userEvent.click(editButton);
+    const closeButton = screen.getByText("Close");
+    await userEvent.click(closeButton);
+  });
+
+  // TODO: test delete modal + functionality
+});
+
+describe("Test ModalDrawerReportPage accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(overlayModalPageComponentWithEntities);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+// components
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Image,
+  Spinner,
+  useDisclosure,
+} from "@chakra-ui/react";
+import {
+  AddEditEntityModal,
+  DeleteEntityModal,
+  ReportPageIntro,
+} from "components";
+// assets
+import addIcon from "assets/icons/icon_add.png";
+// types
+import { EntityShape, OverlayModalPageShape } from "types";
+import { EntityCard } from "components/cards/EntityCard";
+import { getFormattedEntityData } from "utils/reports/entities";
+import { useStore } from "utils";
+// utils
+
+export const OverlayModalPage = ({ route }: Props) => {
+  const { entityType, verbiage, modalForm } = route;
+  const { report } = useStore();
+  const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
+    undefined
+  );
+  const submitting = false;
+
+  //display variables
+  let reportFieldDataEntities = report?.fieldData[entityType] || [];
+
+  ///TEMPORARY ENTITY//
+  let tempEntity: EntityShape = {
+    id: "mockid",
+    evaluationPlan_objectiveName: "{Objective Name}",
+    evaluationPlan_description: "description here",
+    evaluationPlan_targets: "targets here",
+    evaluationPlan_includesTargets: "No",
+    evaluationPlan_additionalDetails: "additional details",
+  };
+  reportFieldDataEntities = [tempEntity, tempEntity];
+
+  // add/edit entity modal disclosure and methods
+  const {
+    isOpen: addEditEntityModalIsOpen,
+    onOpen: addEditEntityModalOnOpenHandler,
+    onClose: addEditEntityModalOnCloseHandler,
+  } = useDisclosure();
+
+  const openAddEditEntityModal = (entity?: EntityShape) => {
+    if (entity) setSelectedEntity(entity);
+    addEditEntityModalOnOpenHandler();
+  };
+
+  const closeAddEditEntityModal = () => {
+    setSelectedEntity(undefined);
+    addEditEntityModalOnCloseHandler();
+  };
+
+  // delete modal disclosure and methods
+  const {
+    isOpen: deleteEntityModalIsOpen,
+    onOpen: deleteEntityModalOnOpenHandler,
+    onClose: deleteEntityModalOnCloseHandler,
+  } = useDisclosure();
+
+  const openDeleteEntityModal = () => {
+    setSelectedEntity({
+      id: "123",
+      name: "mock entity",
+    });
+    deleteEntityModalOnOpenHandler();
+  };
+
+  const closeDeleteEntityModal = () => {
+    setSelectedEntity(undefined);
+    deleteEntityModalOnCloseHandler();
+  };
+
+  return (
+    <Box>
+      {verbiage.intro && (
+        <ReportPageIntro text={verbiage.intro} accordion={verbiage.accordion} />
+      )}
+      <Box>
+        <Heading as="h3" sx={sx.dashboardTitle}>
+          {verbiage.dashboardTitle}
+        </Heading>
+        <Box>
+          {reportFieldDataEntities.map(
+            (entity: EntityShape, entityIndex: number) => (
+              <EntityCard
+                key={entity.id}
+                entity={entity}
+                entityIndex={entityIndex}
+                entityType={entityType}
+                verbiage={verbiage}
+                formattedEntityData={getFormattedEntityData(entityType, entity)}
+                openAddEditEntityModal={openAddEditEntityModal}
+                openDeleteEntityModal={openDeleteEntityModal}
+              />
+            )
+          )}
+          <Button
+            sx={sx.addEntityButton}
+            onClick={addEditEntityModalOnOpenHandler}
+            leftIcon={<Image sx={sx.buttonIcons} src={addIcon} alt="Add" />}
+          >
+            {verbiage.addEntityButtonText}
+          </Button>
+        </Box>
+        <hr />
+        {/* MODALS */}
+        <AddEditEntityModal
+          selectedEntity={selectedEntity}
+          verbiage={verbiage}
+          form={modalForm}
+          modalDisclosure={{
+            isOpen: addEditEntityModalIsOpen,
+            onClose: closeAddEditEntityModal,
+          }}
+        />
+        <DeleteEntityModal
+          selectedEntity={selectedEntity}
+          verbiage={verbiage}
+          modalDisclosure={{
+            isOpen: deleteEntityModalIsOpen,
+            onClose: closeDeleteEntityModal,
+          }}
+        />
+      </Box>
+      <Box>
+        <Flex sx={sx.buttonFlex}>
+          <Button type="submit" form={modalForm.id} sx={sx.saveButton}>
+            {submitting ? <Spinner size="md" /> : "Save & return"}
+          </Button>
+        </Flex>
+      </Box>
+    </Box>
+  );
+};
+
+interface Props {
+  route: OverlayModalPageShape;
+  validateOnRender?: boolean;
+}
+
+const sx = {
+  buttonIcons: {
+    height: "1rem",
+  },
+  dashboardTitle: {
+    paddingTop: "1rem",
+    paddingBottom: "0",
+    fontWeight: "bold",
+    color: "palette.gray_medium",
+  },
+  addEntityButton: {
+    marginTop: "1.5rem",
+    marginBottom: "2rem",
+  },
+  buttonFlex: {
+    justifyContent: "end",
+    marginY: "1.5rem",
+  },
+  saveButton: {
+    width: "8.25rem",
+  },
+};

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -6,7 +6,6 @@ import {
   Flex,
   Heading,
   Image,
-  Spinner,
   useDisclosure,
 } from "@chakra-ui/react";
 import {
@@ -29,7 +28,6 @@ export const OverlayModalPage = ({ route }: Props) => {
   const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
     undefined
   );
-  const submitting = false;
 
   //display variables
   let reportFieldDataEntities = report?.fieldData[entityType] || [];
@@ -38,10 +36,10 @@ export const OverlayModalPage = ({ route }: Props) => {
   let tempEntity: EntityShape = {
     id: "mockid",
     evaluationPlan_objectiveName: "{Objective Name}",
-    evaluationPlan_description: "description here",
-    evaluationPlan_targets: "targets here",
+    evaluationPlan_description: "Description here",
+    evaluationPlan_targets: "Targets here",
     evaluationPlan_includesTargets: "No",
-    evaluationPlan_additionalDetails: "additional details",
+    evaluationPlan_additionalDetails: "Additional details",
   };
   reportFieldDataEntities = [tempEntity, tempEntity];
 
@@ -137,7 +135,7 @@ export const OverlayModalPage = ({ route }: Props) => {
       <Box>
         <Flex sx={sx.buttonFlex}>
           <Button type="submit" form={modalForm.id} sx={sx.saveButton}>
-            {submitting ? <Spinner size="md" /> : "Save & return"}
+            Save & return"
           </Button>
         </Flex>
       </Box>

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -5,6 +5,7 @@ import {
   DrawerReportPage,
   ModalDrawerReportPage,
   ModalOverlayReportPage,
+  OverlayModalPage,
   PageTemplate,
   ReviewSubmitPage,
   Sidebar,
@@ -15,6 +16,7 @@ import {
   DrawerReportPageShape,
   ModalDrawerReportPageShape,
   ModalOverlayReportPageShape,
+  OverlayModalPageShape,
   PageTypes,
   ReportRoute,
   StandardReportPageShape,
@@ -36,6 +38,8 @@ export const ReportPageWrapper = () => {
         return (
           <ModalDrawerReportPage route={route as ModalDrawerReportPageShape} />
         );
+      case PageTypes.OVERLAY_MODAL:
+        return <OverlayModalPage route={route as OverlayModalPageShape} />;
       case PageTypes.MODAL_OVERLAY:
         return (
           <ModalOverlayReportPage

--- a/services/ui-src/src/types/formFields.ts
+++ b/services/ui-src/src/types/formFields.ts
@@ -19,6 +19,11 @@ export interface EntityShape {
   [key: string]: any;
 }
 
+export enum OverlayModalEntityTypes {
+  EVALUATION_PLAN = "evaluationPlan",
+  FUNDING_SOURCES = "fundingSources",
+}
+
 /**
  * General type for all form JSON.
  */

--- a/services/ui-src/src/types/other.ts
+++ b/services/ui-src/src/types/other.ts
@@ -33,6 +33,7 @@ export enum PageTypes {
   DRAWER = "drawer",
   MODAL_DRAWER = "modalDrawer",
   MODAL_OVERLAY = "modalOverlay",
+  OVERLAY_MODAL = "overlayModal",
   REVIEW_SUBMIT = "reviewSubmit",
 }
 

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -58,6 +58,13 @@ export interface ModalDrawerReportPageShape extends ReportPageShapeBase {
   form?: never;
 }
 
+export interface OverlayModalPageShape extends ReportPageShapeBase {
+  entityType: string;
+  verbiage: OverlayModalPageVerbiage;
+  modalForm: FormJson;
+  form?: never;
+}
+
 export interface ModalOverlayReportPageShape extends ReportPageShapeBase {
   entityType: string;
   verbiage: ModalOverlayReportPageVerbiage;
@@ -84,6 +91,7 @@ export type ReportRouteWithForm =
   | StandardReportPageShape
   | DrawerReportPageShape
   | ModalDrawerReportPageShape
+  | OverlayModalPageShape
   | ModalOverlayReportPageShape;
 
 export interface ReportRouteWithoutForm extends ReportRouteBase {
@@ -117,6 +125,23 @@ export interface ModalDrawerReportPageVerbiage
   enterEntityDetailsButtonText: string;
   reviewPdfHint: string;
   drawerTitle: string;
+}
+
+export interface OverlayModalPageVerbiage extends ReportPageVerbiage {
+  addEntityButtonText: string;
+  addEditModalHint: string;
+  editEntityButtonText: string;
+  addEditModalAddTitle: string;
+  addEditModalEditTitle: string;
+  deleteEntityButtonAltText: string;
+  deleteModalTitle: string;
+  deleteModalConfirmButtonText: string;
+  deleteModalWarning: string;
+  entityUnfinishedMessage: string;
+  enterEntityDetailsButtonText: string;
+  accordion: object;
+  dashboardTitle: string;
+  missingEntityMessage?: CustomHtmlElement[];
 }
 
 export interface ModalOverlayReportPageVerbiage extends ReportPageVerbiage {

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -14,6 +14,7 @@ export const getFormattedEntityData = (
         objectiveName: entity?.evaluationPlan_objectiveName,
         description: entity?.evaluationPlan_description,
         targets: entity?.evaluationPlan_targets,
+        // TODO: add this functionality after guidance from BOs (per Design)
         includesTargets: getRadioValue(
           entity,
           "evaluationPlan_includesTargets"

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,3 +1,28 @@
-export const getFormattedEntityData = () => {
-  return {};
+import { EntityShape, OverlayModalEntityTypes } from "types";
+
+const getRadioValue = (entity: EntityShape | undefined, label: string) => {
+  return entity?.[label].value;
+};
+
+export const getFormattedEntityData = (
+  entityType: string,
+  entity?: EntityShape
+) => {
+  switch (entityType) {
+    case OverlayModalEntityTypes.EVALUATION_PLAN:
+      return {
+        objectiveName: entity?.evaluationPlan_objectiveName,
+        description: entity?.evaluationPlan_description,
+        targets: entity?.evaluationPlan_targets,
+        includesTargets: getRadioValue(
+          entity,
+          "evaluationPlan_includesTargets"
+        ),
+        additionalDetails: entity?.evaluationPlan_additionalDetails,
+      };
+    case OverlayModalEntityTypes.FUNDING_SOURCES:
+      return {};
+    default:
+      return {};
+  }
 };

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -157,6 +157,18 @@ export const mockVerbiageIntro = {
   enterReportText: "Enter Details",
 };
 
+export const mockOverlayModalVerbiageIntro = {
+  section: "mock section",
+  subsection: "mock subsection",
+  info: [
+    {
+      type: "html",
+      content: "mock html",
+    },
+  ],
+  exportSectionHeader: "exportSectionHeader",
+};
+
 export const mockStandardReportPageJson = {
   name: "mock-route-1",
   path: "/mock/mock-route-1",
@@ -187,7 +199,6 @@ export const mockModalDrawerReportPageVerbiage = {
   editEntityButtonText: "Mock edit entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
   addEditModalEditTitle: "Mock add/edit entity modal edit title",
-  addEditModalMessage: "Mock add/edit entity modal message",
   deleteEntityButtonAltText: "Mock delete entity button alt text",
   deleteModalTitle: "Mock delete modal title",
   deleteModalConfirmButtonText: "Mock delete modal confirm button text",
@@ -199,6 +210,26 @@ export const mockModalDrawerReportPageVerbiage = {
   drawerNoFormMessage: "Mock no form fields here",
 };
 
+export const mockOverlayModalPageVerbiage = {
+  intro: mockOverlayModalVerbiageIntro,
+  accordion: mockAccordion,
+  text: "Mock instructions text",
+  dashboardTitle: "Mock dashboard title",
+  addEntityButtonText: "Mock add entity button text",
+  editEntityButtonText: "Mock edit entity button text",
+  addEditModalAddTitle: "Mock add/edit entity modal add title",
+  addEditModalEditTitle: "Mock add/edit entity modal edit title",
+  addEditModalHint: "Mock hint",
+  addEditModalMessage: "Mock add/edit entity modal message",
+  deleteEntityButtonAltText: "Mock delete entity button alt text",
+  deleteModalTitle: "Mock delete modal title",
+  deleteModalConfirmButtonText: "Mock delete modal confirm button text",
+  deleteModalWarning: "Mock delete modal warning",
+  entityUnfinishedMessage: "Mock entity unfinished messsage",
+  enterEntityDetailsButtonText: "Mock enter entity details button text",
+  drawerTitle: "Mock drawer title",
+};
+
 export const mockModalDrawerReportPageJson = {
   name: "mock-route-2b",
   path: "/mock/mock-route-2b",
@@ -207,6 +238,15 @@ export const mockModalDrawerReportPageJson = {
   verbiage: mockModalDrawerReportPageVerbiage,
   modalForm: mockModalForm,
   drawerForm: mockDrawerForm,
+};
+
+export const mockOverlayModalPageJson = {
+  name: "mock-route-2d",
+  path: "/mock/mock-route-2d",
+  pageType: "overlayModal",
+  entityType: "entityType",
+  verbiage: mockOverlayModalPageVerbiage,
+  modalForm: mockModalForm,
 };
 
 export const mockOptionalFormField = {


### PR DESCRIPTION


### Description
State and Territory Specific Initiatives: II. Evaluation Plan
This page is showing up in the sidebar right now but will be moved to open up from a dashboard (currently WIP). 
Everything should look like the spec except for the year and quarter numberfield data in the EntityCard -- per the card, we are waiting on BO feedback for that functionality. For the time being that data is not in the EntityCard, and I will create a separate Jira card to address this functionality. Also the hint text on the `yes` radio option has been changed to show up beneath the question itself, and says `Note: If 'Yes', fields use calendar year quarters.`. This is a Design-approved change.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2815

---
### How to test
Create a work plan, go to State and Territory Specific Initiatives: II. Evaluation Plan inside State and Territory Initiatives Instructions, see that you `add initiative` opens a new modal (difference will be in the title), `edit` opens the edit modal, and everything follows the spec. 


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
