### PR TITLE
MDCT-2794: Update submission name

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -8,9 +8,12 @@ import {
   ReportType,
   TableContentShape,
 } from "types";
-import { convertDateUtcToEt } from "utils";
+import { convertDateUtcToEt, calculatePeriod } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
+
+// Year will be displayed as part of the report name
+const year = new Date().getFullYear();
 
 export const DashboardTable = ({
   reportsByState,
@@ -43,7 +46,10 @@ export const DashboardTable = ({
         )}
         {/* Report Name */}
         <Td sx={sxOverride.programNameText}>
-          {report.programName ?? report.submissionName}
+          {report.state} {report.submissionName ?? report.programName} {"{"}
+          {year} {" - Period"}{" "}
+          {calculatePeriod(convertDateUtcToEt(report.createdAt))}
+          {"}"}
         </Td>
         {/* Date Fields */}
         <DateFields report={report} reportType={reportType} />

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -45,12 +45,7 @@ export const DashboardTable = ({
           <Td></Td>
         )}
         {/* Report Name */}
-        <Td sx={sxOverride.programNameText}>
-          {report.state} {report.submissionName ?? report.programName} {"{"}
-          {year} {" - Period"}{" "}
-          {calculatePeriod(convertDateUtcToEt(report.createdAt))}
-          {"}"}
-        </Td>
+        <Td sx={sxOverride.programNameText}>{getReportName(report)}</Td>
         {/* Date Fields */}
         <DateFields report={report} reportType={reportType} />
         {/* Last Altered By */}
@@ -130,6 +125,14 @@ interface DashboardTableProps {
   releasing?: boolean | undefined;
   sxOverride: AnyObject;
 }
+
+const getReportName = (report: ReportMetadataShape) => {
+  const reportName = report.submissionName
+    ? report.submissionName
+    : report.programName;
+  const period = calculatePeriod(convertDateUtcToEt(report.createdAt));
+  return `${report.state} ${reportName} {${year} - Period ${period}}`;
+};
 
 export const getStatus = (
   reportType: ReportType,

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -1,5 +1,6 @@
 import {
   calculateDueDate,
+  calculatePeriod,
   calculateRemainingSeconds,
   calculateTimeByType,
   checkDateRangeStatus,
@@ -131,5 +132,25 @@ describe("Test calculateTimeLeft", () => {
   it("something else", () => {
     const expirationTime = "2050-11-18T12:53:11-05:00";
     expect(calculateRemainingSeconds(expirationTime)).toBeGreaterThan(0);
+  });
+});
+
+describe("Test calculatePeriod", () => {
+  it("calculatePeriod given due date of 01/01/2022", () => {
+    const dueDate = "01/01/2022";
+    const period = 1;
+    expect(calculatePeriod(dueDate)).toBe(period);
+  });
+
+  it("calculatePeriod given due date of 10/01/2022", () => {
+    const dueDate = "10/01/2022";
+    const period = 2;
+    expect(calculatePeriod(dueDate)).toBe(period);
+  });
+
+  it("calculatePeriod given due date of 04/01/2023", () => {
+    const dueDate = "04/01/2023";
+    const period = 1;
+    expect(calculatePeriod(dueDate)).toBe(period);
   });
 });

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -138,19 +138,19 @@ describe("Test calculateTimeLeft", () => {
 describe("Test calculatePeriod", () => {
   it("calculatePeriod given due date of 01/01/2022", () => {
     const dueDate = "01/01/2022";
-    const period = 1;
+    const period = "1";
     expect(calculatePeriod(dueDate)).toBe(period);
   });
 
   it("calculatePeriod given due date of 10/01/2022", () => {
     const dueDate = "10/01/2022";
-    const period = 2;
+    const period = "2";
     expect(calculatePeriod(dueDate)).toBe(period);
   });
 
   it("calculatePeriod given due date of 04/01/2023", () => {
     const dueDate = "04/01/2023";
-    const period = 1;
+    const period = "1";
     expect(calculatePeriod(dueDate)).toBe(period);
   });
 });

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -170,7 +170,7 @@ export const calculatePeriod = (dueDate: string) => {
 };
 
 /*
- * Converts a date string to UTC and calculates the due date based on the "Period".
+ * Converts a date string to UTC + 180 days
  * returns -> UTC datetime in format 'ms since Unix epoch'
  * Ex: 6/30/22 Becomes 1483603200000
  */

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -14,24 +14,6 @@ export const noon: TimeShape = {
   second: 0,
 };
 
-/*
- * Defines the beginning and end of Period 1 and Period 2.
- *     Period 1 is from 01/01 to 06/30.
- *     Period 2 is from 07/01 to 12/31.
- */
-export const beginningPeriodOne = (date: string) => {
-  return new Date(new Date(date).getFullYear(), 0, 1);
-};
-export const endPeriodOne = (date: string) => {
-  return new Date(new Date(date).getFullYear(), 5, 30);
-};
-export const beginningPeriodTwo = (date: string) => {
-  return new Date(new Date(date).getFullYear(), 6, 1);
-};
-export const endPeriodTwo = (date: string) => {
-  return new Date(new Date(date).getFullYear(), 11, 31);
-};
-
 export const calculateTimeByType = (timeType?: string): TimeShape => {
   const timeMap: any = {
     startDate: midnight,
@@ -159,14 +141,16 @@ export const checkDateRangeStatus = (
   return currentTime >= startDate && currentTime <= endDate;
 };
 
+/*
+ * Calculates the period given a due date.
+ * The periods are defined as follows:
+ *     Period 1 is from 01/01 to 06/30.
+ *     Period 2 is from 07/01 to 12/31.
+ */
 export const calculatePeriod = (dueDate: string) => {
   const dueDateAsDate = new Date(dueDate);
-  if (
-    dueDateAsDate >= beginningPeriodOne(dueDate) &&
-    dueDateAsDate <= endPeriodOne(dueDate)
-  )
-    return "1";
-  return "2";
+  const period = Math.ceil((dueDateAsDate.getMonth() + 1) / 6);
+  return period.toString();
 };
 
 /*

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -14,6 +14,24 @@ export const noon: TimeShape = {
   second: 0,
 };
 
+/*
+ * Defines the beginning and end of Period 1 and Period 2.
+ *     Period 1 is from 01/01 to 06/30.
+ *     Period 2 is from 07/01 to 12/31.
+ */
+export const beginningPeriodOne = (date: string) => {
+  return new Date(new Date(date).getFullYear(), 0, 1);
+};
+export const endPeriodOne = (date: string) => {
+  return new Date(new Date(date).getFullYear(), 5, 30);
+};
+export const beginningPeriodTwo = (date: string) => {
+  return new Date(new Date(date).getFullYear(), 6, 1);
+};
+export const endPeriodTwo = (date: string) => {
+  return new Date(new Date(date).getFullYear(), 11, 31);
+};
+
 export const calculateTimeByType = (timeType?: string): TimeShape => {
   const timeMap: any = {
     startDate: midnight,
@@ -141,8 +159,18 @@ export const checkDateRangeStatus = (
   return currentTime >= startDate && currentTime <= endDate;
 };
 
+export const calculatePeriod = (dueDate: string) => {
+  const dueDateAsDate = new Date(dueDate);
+  if (
+    dueDateAsDate >= beginningPeriodOne(dueDate) &&
+    dueDateAsDate <= endPeriodOne(dueDate)
+  )
+    return 1;
+  return 2;
+};
+
 /*
- * Converts a date string to UTC + 180 days
+ * Converts a date string to UTC and calculates the due date based on the "Period".
  * returns -> UTC datetime in format 'ms since Unix epoch'
  * Ex: 6/30/22 Becomes 1483603200000
  */

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -165,8 +165,8 @@ export const calculatePeriod = (dueDate: string) => {
     dueDateAsDate >= beginningPeriodOne(dueDate) &&
     dueDateAsDate <= endPeriodOne(dueDate)
   )
-    return 1;
-  return 2;
+    return "1";
+  return "2";
 };
 
 /*


### PR DESCRIPTION
### Description
This change updates the name of the Work Plan as displayed on the Dashboard page. (i.e. revises it from `<program name> // <submission name>` to `{State} <program name> {<year> - Period <period>})`

Note: The requirement is to add the "State" to the submission name. I pulled the state from the `report`. Given that the mocks show that {State} should also appear in the **Page Title**, I assumed this was the correct value to fetch? Open to thoughts!! 🙏

![Screenshot 2023-09-14 at 11 40 20 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/bcbbbcc8-cd5e-4d27-9439-b4a687dc9c19)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2794

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Log in as a state user
2. Navigate to work plan page (i.e. /wp)
3. Create a new work plan 
4. Confirm that the work plan name matches the requirements ({State} <program name> {<year> - Period <period>})

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [✅ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
