### PR TITLE
replace non-existent banner status code to 200 from 404

### DIFF
--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -27,12 +27,6 @@ const testEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test fetchBanner API method", () => {
-  test("Test Report not found Fetch", async () => {
-    mockDocumentClient.get.promise.mockReturnValueOnce({ Item: undefined });
-    const res = await fetchBanner(testEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
-  });
-
   test("Test Successful Banner Fetch", async () => {
     mockDocumentClient.get.promise.mockReturnValueOnce({
       Item: mockBannerResponse,
@@ -44,6 +38,16 @@ describe("Test fetchBanner API method", () => {
     expect(res.body).toContain("testTitle");
   });
 
+  test("Test successful empty banner found fetch", async () => {
+    mockDocumentClient.get.promise.mockReturnValueOnce({
+      Item: { key: "admin-banner-id" },
+    });
+    const res = await fetchBanner(testEvent, null);
+
+    expect(res.body).not.toContain("testTitle");
+    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+  });
+
   test("Test bannerKey not provided throws 500 error", async () => {
     const noKeyEvent: APIGatewayProxyEvent = {
       ...testEvent,
@@ -51,7 +55,7 @@ describe("Test fetchBanner API method", () => {
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -62,7 +66,7 @@ describe("Test fetchBanner API method", () => {
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -17,9 +17,6 @@ export const fetchBanner = handler(async (event, _context) => {
   };
   const response = await dynamoDb.get(params);
 
-  let status = StatusCodes.SUCCESS;
-  if (!response?.Item) {
-    status = StatusCodes.NOT_FOUND;
-  }
+  const status = StatusCodes.SUCCESS;
   return { status: status, body: response };
 });

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -32,10 +32,7 @@ export const AdminBannerProvider = ({ children }: Props) => {
       setAdminBanner(newBannerData);
     } catch (e: any) {
       setIsLoading(false);
-      // 404 expected when no current banner exists
-      if (!e.toString().includes("404")) {
-        setError(bannerErrors.GET_BANNER_FAILED);
-      }
+      setError(bannerErrors.GET_BANNER_FAILED);
     }
     setIsLoading(false);
   };


### PR DESCRIPTION
### Description
Successful retrieval of an empty banner returns a 200 status code instead of a 404 error.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-

---
### How to test
Open inspect -> Network tab. Login and see that the adminBanner request results in a 200 status code with an empty object in the body.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
