### PR TITLE
[MDCT-2964 + 2965] Admin Banner Handler Validation + Zustand Integration

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.test.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.test.tsx
@@ -6,7 +6,11 @@ import { createMemoryHistory } from "history";
 import { AppRoutes } from "components";
 // utils
 import { useStore, UserProvider } from "utils";
-import { mockStateUserStore, mockLDFlags } from "utils/testing/setupJest";
+import {
+  mockStateUserStore,
+  mockLDFlags,
+  mockBannerStore,
+} from "utils/testing/setupJest";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
@@ -25,7 +29,10 @@ let history: any;
 
 describe("Test AppRoutes 404 handling", () => {
   beforeEach(async () => {
-    mockedUseStore.mockReturnValue(mockStateUserStore);
+    mockedUseStore.mockReturnValue({
+      ...mockStateUserStore,
+      ...mockBannerStore,
+    });
     history = createMemoryHistory();
     history.push("/obviously-fake-route");
     await act(async () => {

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -27,7 +27,6 @@ const TestComponent = () => {
       <button onClick={() => context.deleteAdminBanner(mockBannerData.key)}>
         Delete
       </button>
-      {context.errorMessage && <p>{context.errorMessage}</p>}
     </div>
   );
 };

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -6,6 +6,7 @@ import { act } from "react-dom/test-utils";
 import { AdminBannerContext, AdminBannerProvider } from "./AdminBannerProvider";
 // utils
 import { mockBannerData } from "utils/testing/mockBanner";
+import { useStore } from "utils";
 import { bannerErrors } from "verbiage/errors";
 
 jest.mock("utils/api/requestMethods/banner", () => ({
@@ -69,7 +70,9 @@ describe("Test AdminBannerProvider fetchAdminBanner method", () => {
     await act(async () => {
       await render(testComponent);
     });
-    expect(screen.queryByText(bannerErrors.GET_BANNER_FAILED)).toBeVisible();
+    expect(useStore.getState().bannerErrorMessage).toBe(
+      bannerErrors.GET_BANNER_FAILED
+    );
   });
 });
 
@@ -88,7 +91,27 @@ describe("Test AdminBannerProvider deleteAdminBanner method", () => {
     });
     expect(mockAPI.deleteBanner).toHaveBeenCalledTimes(1);
     expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
-    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
+  });
+
+  test("Shows error if deleteBanner throws error", async () => {
+    mockAPI.deleteBanner.mockImplementation(() => {
+      throw new Error();
+    });
+    await act(async () => {
+      await render(testComponent);
+    });
+    await act(async () => {
+      const deleteButton = screen.getByText("Delete");
+      await userEvent.click(deleteButton);
+    });
+    expect(mockAPI.deleteBanner).toHaveBeenCalledTimes(1);
+    expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
+
+    expect(useStore.getState().bannerErrorMessage).toBe(
+      bannerErrors.DELETE_BANNER_FAILED
+    );
   });
 });
 

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -4,7 +4,13 @@ import { AdminBannerData, AdminBannerShape } from "types/banners";
 import { bannerId } from "../../constants";
 import { bannerErrors } from "verbiage/errors";
 // api
-import { deleteBanner, getBanner, useStore, writeBanner } from "utils";
+import {
+  checkDateRangeStatus,
+  deleteBanner,
+  getBanner,
+  useStore,
+  writeBanner,
+} from "utils";
 
 const ADMIN_BANNER_ID = bannerId;
 
@@ -64,6 +70,17 @@ export const AdminBannerProvider = ({ children }: Props) => {
     }
     await fetchAdminBanner();
   };
+
+  useEffect(() => {
+    let bannerActivity = false;
+    if (bannerData) {
+      bannerActivity = checkDateRangeStatus(
+        bannerData.startDate,
+        bannerData.endDate
+      );
+    }
+    setIsBannerActive(bannerActivity);
+  }, [bannerData]);
 
   useEffect(() => {
     fetchAdminBanner();

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -25,6 +25,8 @@ export const AdminBannerProvider = ({ children }: Props) => {
     setIsBannerLoading,
     bannerErrorMessage,
     setBannerErrorMessage,
+    isBannerDeleting,
+    setIsBannerDeleting,
   } = useStore();
 
   const fetchAdminBanner = async () => {
@@ -33,8 +35,8 @@ export const AdminBannerProvider = ({ children }: Props) => {
       const currentBanner = await getBanner(ADMIN_BANNER_ID);
       const newBannerData = currentBanner?.Item || {};
       setBannerData(newBannerData);
+      setBannerErrorMessage("");
     } catch (e: any) {
-      setIsBannerLoading(false);
       // 404 expected when no current banner exists
       if (!e.toString().includes("404")) {
         setBannerErrorMessage(bannerErrors.GET_BANNER_FAILED);
@@ -44,12 +46,22 @@ export const AdminBannerProvider = ({ children }: Props) => {
   };
 
   const deleteAdminBanner = async () => {
-    await deleteBanner(ADMIN_BANNER_ID);
-    setBannerData(undefined);
+    setIsBannerDeleting(true);
+    try {
+      await deleteBanner(ADMIN_BANNER_ID);
+      await fetchAdminBanner();
+    } catch (error: any) {
+      setBannerErrorMessage(bannerErrors.DELETE_BANNER_FAILED);
+    }
+    setIsBannerDeleting(false);
   };
 
   const writeAdminBanner = async (newBannerData: AdminBannerData) => {
-    await writeBanner(newBannerData);
+    try {
+      await writeBanner(newBannerData);
+    } catch (e: any) {
+      setBannerErrorMessage(bannerErrors.CREATE_BANNER_FAILED);
+    }
     await fetchAdminBanner();
   };
 
@@ -71,12 +83,21 @@ export const AdminBannerProvider = ({ children }: Props) => {
       // Banner Error State
       bannerErrorMessage,
       setBannerErrorMessage,
+      // Banner Deleting State
+      isBannerDeleting,
+      setIsBannerDeleting,
       // Banner API calls
       fetchAdminBanner,
       writeAdminBanner,
       deleteAdminBanner,
     }),
-    [bannerData, isBannerActive, isBannerLoading, bannerErrorMessage]
+    [
+      bannerData,
+      isBannerActive,
+      isBannerLoading,
+      bannerErrorMessage,
+      isBannerDeleting,
+    ]
   );
 
   return (

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -25,18 +25,18 @@ export const AdminBannerProvider = ({ children }: Props) => {
   const {
     bannerData,
     setBannerData,
-    isBannerActive,
-    setIsBannerActive,
-    isBannerLoading,
-    setIsBannerLoading,
+    bannerActive,
+    setBannerActive,
+    bannerLoading,
+    setBannerLoading,
     bannerErrorMessage,
     setBannerErrorMessage,
-    isBannerDeleting,
-    setIsBannerDeleting,
+    bannerDeleting,
+    setBannerDeleting,
   } = useStore();
 
   const fetchAdminBanner = async () => {
-    setIsBannerLoading(true);
+    setBannerLoading(true);
     try {
       const currentBanner = await getBanner(ADMIN_BANNER_ID);
       const newBannerData = currentBanner?.Item || {};
@@ -48,18 +48,18 @@ export const AdminBannerProvider = ({ children }: Props) => {
         setBannerErrorMessage(bannerErrors.GET_BANNER_FAILED);
       }
     }
-    setIsBannerLoading(false);
+    setBannerLoading(false);
   };
 
   const deleteAdminBanner = async () => {
-    setIsBannerDeleting(true);
+    setBannerDeleting(true);
     try {
       await deleteBanner(ADMIN_BANNER_ID);
       await fetchAdminBanner();
     } catch (error: any) {
       setBannerErrorMessage(bannerErrors.DELETE_BANNER_FAILED);
     }
-    setIsBannerDeleting(false);
+    setBannerDeleting(false);
   };
 
   const writeAdminBanner = async (newBannerData: AdminBannerData) => {
@@ -79,7 +79,7 @@ export const AdminBannerProvider = ({ children }: Props) => {
         bannerData.endDate
       );
     }
-    setIsBannerActive(bannerActivity);
+    setBannerActive(bannerActivity);
   }, [bannerData]);
 
   useEffect(() => {
@@ -92,17 +92,17 @@ export const AdminBannerProvider = ({ children }: Props) => {
       bannerData,
       setBannerData,
       // Banner showing
-      isBannerActive,
-      setIsBannerActive,
+      bannerActive,
+      setBannerActive,
       // Banner Loading
-      isBannerLoading,
-      setIsBannerLoading,
+      bannerLoading,
+      setBannerLoading,
       // Banner Error State
       bannerErrorMessage,
       setBannerErrorMessage,
       // Banner Deleting State
-      isBannerDeleting,
-      setIsBannerDeleting,
+      bannerDeleting,
+      setBannerDeleting,
       // Banner API calls
       fetchAdminBanner,
       writeAdminBanner,
@@ -110,10 +110,10 @@ export const AdminBannerProvider = ({ children }: Props) => {
     }),
     [
       bannerData,
-      isBannerActive,
-      isBannerLoading,
+      bannerActive,
+      bannerLoading,
       bannerErrorMessage,
-      isBannerDeleting,
+      bannerDeleting,
     ]
   );
 

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -17,15 +17,21 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
   // add validation to formJson
   const form: FormJson = formJson;
 
-  const onSubmit = async () => {
+  const onSubmit = async (formData: any) => {
     setSubmitting(true);
     const newBannerData = {
       key: bannerId,
-      title: "TEST NEW BANNER",
-      description: "BANNER DESCRIPTION",
-      link: "EXAMPLE LINK" || undefined,
-      startDate: convertDatetimeStringToNumber("11/11/2011", "startDate"),
-      endDate: convertDatetimeStringToNumber("11/11/2024", "endDate"),
+      title: formData["bannerTitle"],
+      description: formData["bannerDescription"],
+      link: formData["bannerLink"] || undefined,
+      startDate: convertDatetimeStringToNumber(
+        formData["bannerStartDate"],
+        "startDate"
+      ),
+      endDate: convertDatetimeStringToNumber(
+        formData["bannerEndDate"],
+        "endDate"
+      ),
     };
     try {
       await writeAdminBanner(newBannerData);
@@ -41,10 +47,9 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
       <ErrorAlert error={error} sxOverride={sx.errorAlert} />
       <Form
         id={form.id}
-        formJson={formJson}
+        formJson={form}
         onSubmit={onSubmit}
         validateOnRender={false}
-        onError={onSubmit}
         dontReset={false}
         {...props}
       >

--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -11,23 +11,12 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { mockBannerData } from "utils/testing/mockBanner";
+import { bannerErrors } from "verbiage/errors";
 
 const mockBannerMethods = {
   fetchAdminBanner: jest.fn(() => {}),
   writeAdminBanner: jest.fn(() => {}),
   deleteAdminBanner: jest.fn(() => {}),
-};
-
-const mockContextWithoutBanner = {
-  ...mockBannerMethods,
-  isLoading: false,
-  errorData: null,
-};
-
-const mockContextWithBanner = {
-  ...mockBannerMethods,
-  isLoading: false,
-  errorData: null,
 };
 
 jest.mock("utils/state/useStore");
@@ -45,12 +34,12 @@ describe("Test AdminPage banner manipulation functionality", () => {
   it("Deletes current banner on delete button click", async () => {
     await act(async () => {
       mockedUseStore.mockReturnValue(mockBannerStore);
-      await render(adminView(mockContextWithBanner));
+      await render(adminView(mockBannerMethods));
     });
     const deleteButton = screen.getByText("Delete Current Banner");
     await userEvent.click(deleteButton);
     await waitFor(() =>
-      expect(mockContextWithBanner.deleteAdminBanner).toHaveBeenCalled()
+      expect(mockBannerMethods.deleteAdminBanner).toHaveBeenCalled()
     );
   });
 });
@@ -62,7 +51,7 @@ describe("Test AdminPage without banner", () => {
         ...mockBannerStore,
         bannerData: undefined,
       });
-      await render(adminView(mockContextWithoutBanner));
+      await render(adminView(mockBannerMethods));
     });
   });
 
@@ -84,7 +73,7 @@ describe("Test AdminPage with banner", () => {
   beforeEach(async () => {
     await act(async () => {
       mockedUseStore.mockReturnValue(mockBannerStore);
-      await render(adminView(mockContextWithBanner));
+      await render(adminView(mockBannerMethods));
     });
   });
 
@@ -110,7 +99,7 @@ describe("Test AdminPage with banner", () => {
 describe("Test AdminPage with active/inactive banner", () => {
   const currentTime = Date.now(); // 'current' time in ms since unix epoch
   const oneDay = 1000 * 60 * 60 * 24; // 1000ms * 60s * 60m * 24h = 86,400,000ms
-  const context = mockContextWithBanner;
+  const context = mockBannerMethods;
   mockedUseStore.mockReturnValue(mockBannerStore);
 
   test("Active banner shows 'active' status", async () => {
@@ -151,32 +140,31 @@ describe("Test AdminPage with active/inactive banner", () => {
   });
 });
 
-describe("Test AdminPage delete banner error handling", () => {
+describe("Test AdminPage displays banner error when state has set an error", () => {
   it("Displays error if deleteBanner throws error", async () => {
-    window.HTMLElement.prototype.scrollIntoView = jest.fn();
-    const context = mockContextWithBanner;
-    context.deleteAdminBanner = jest.fn(() => {
-      throw new Error();
+    mockedUseStore.mockReturnValue({
+      ...mockBannerStore,
+      bannerErrorMessage: bannerErrors.DELETE_BANNER_FAILED,
     });
+
     await act(async () => {
-      await render(adminView(context));
+      await render(adminView(mockBannerMethods));
     });
-    const deleteButton = screen.getByText("Delete Current Banner");
-    await userEvent.click(deleteButton);
+
     expect(screen.getByText("Error")).toBeVisible();
   });
 });
 
 describe("Test AdminPage accessibility", () => {
   it("Should not have basic accessibility issues without banner", async () => {
-    const { container } = render(adminView(mockContextWithoutBanner));
+    const { container } = render(adminView(mockBannerMethods));
     await act(async () => {
       expect(await axe(container)).toHaveNoViolations();
     });
   });
 
   it("Should not have basic accessibility issues with banner", async () => {
-    const { container } = render(adminView(mockContextWithBanner));
+    const { container } = render(adminView(mockBannerMethods));
     await act(async () => {
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -113,8 +113,7 @@ describe("Test AdminPage with active/inactive banner", () => {
       mockedUseStore.mockReturnValue({
         ...mockBannerStore,
         bannerData: activeBannerData,
-        // TODO: remove this next line
-        isBannerActive: true,
+        bannerActive: true,
       });
       await render(adminView(context));
     });

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -22,13 +22,19 @@ import { bannerErrors } from "verbiage/errors";
 import verbiage from "verbiage/pages/admin";
 
 export const AdminPage = () => {
-  const { deleteAdminBanner, writeAdminBanner, isLoading, errorMessage } =
+  const { deleteAdminBanner, writeAdminBanner } =
     useContext(AdminBannerContext);
-  const [error, setError] = useState<string | undefined>(errorMessage);
   const [deleting, setDeleting] = useState<boolean>(false);
 
   // state management
-  const { bannerData, isBannerActive, setIsBannerActive } = useStore();
+  const {
+    bannerData,
+    isBannerActive,
+    setIsBannerActive,
+    isBannerLoading,
+    bannerErrorMessage,
+    setBannerErrorMessage,
+  } = useStore();
 
   useEffect(() => {
     let bannerActivity = false;
@@ -41,23 +47,23 @@ export const AdminPage = () => {
     setIsBannerActive(bannerActivity);
   }, [bannerData]);
 
-  useEffect(() => {
-    setError(errorMessage);
-  }, [errorMessage]);
+  // useEffect(() => {
+  //   setError(errorMessage);
+  // }, [errorMessage]);
 
   const deleteBanner = async () => {
     setDeleting(true);
     try {
       await deleteAdminBanner();
     } catch (error: any) {
-      setError(bannerErrors.DELETE_BANNER_FAILED);
+      setBannerErrorMessage(bannerErrors.DELETE_BANNER_FAILED);
     }
     setDeleting(false);
   };
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">
-      <ErrorAlert error={error} sxOverride={sx.errorAlert} />
+      <ErrorAlert error={bannerErrorMessage} sxOverride={sx.errorAlert} />
       <Box sx={sx.introTextBox}>
         <Heading as="h1" id="AdminHeader" tabIndex={-1} sx={sx.headerText}>
           {verbiage.intro.header}
@@ -66,7 +72,7 @@ export const AdminPage = () => {
       </Box>
       <Box sx={sx.currentBannerSectionBox}>
         <Text sx={sx.sectionHeader}>Current Banner</Text>
-        {isLoading ? (
+        {isBannerLoading ? (
           <Flex sx={sx.spinnerContainer}>
             <Spinner size="md" />
           </Flex>

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -17,7 +17,7 @@ import {
   PageTemplate,
 } from "components";
 // utils
-import { checkDateRangeStatus, convertDateUtcToEt, useStore } from "utils";
+import { convertDateUtcToEt, useStore } from "utils";
 // verbiage
 import verbiage from "verbiage/pages/admin";
 
@@ -29,22 +29,15 @@ export const AdminPage = () => {
   const {
     bannerData,
     isBannerActive,
-    setIsBannerActive,
     isBannerLoading,
     bannerErrorMessage,
+    setBannerErrorMessage,
     isBannerDeleting,
   } = useStore();
 
   useEffect(() => {
-    let bannerActivity = false;
-    if (bannerData) {
-      bannerActivity = checkDateRangeStatus(
-        bannerData.startDate,
-        bannerData.endDate
-      );
-    }
-    setIsBannerActive(bannerActivity);
-  }, [bannerData]);
+    setBannerErrorMessage("");
+  }, []);
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -28,11 +28,11 @@ export const AdminPage = () => {
   // state management
   const {
     bannerData,
-    isBannerActive,
-    isBannerLoading,
+    bannerActive,
+    bannerLoading,
     bannerErrorMessage,
     setBannerErrorMessage,
-    isBannerDeleting,
+    bannerDeleting,
   } = useStore();
 
   useEffect(() => {
@@ -50,7 +50,7 @@ export const AdminPage = () => {
       </Box>
       <Box sx={sx.currentBannerSectionBox}>
         <Text sx={sx.sectionHeader}>Current Banner</Text>
-        {isBannerLoading ? (
+        {bannerLoading ? (
           <Flex sx={sx.spinnerContainer}>
             <Spinner size="md" />
           </Flex>
@@ -62,8 +62,8 @@ export const AdminPage = () => {
                   <Flex sx={sx.currentBannerInfo}>
                     <Text sx={sx.currentBannerStatus}>
                       Status:{" "}
-                      <span className={isBannerActive ? "active" : "inactive"}>
-                        {isBannerActive ? "Active" : "Inactive"}
+                      <span className={bannerActive ? "active" : "inactive"}>
+                        {bannerActive ? "Active" : "Inactive"}
                       </span>
                     </Text>
                     <Text sx={sx.currentBannerDate}>
@@ -82,7 +82,7 @@ export const AdminPage = () => {
                       sx={sx.deleteBannerButton}
                       onClick={deleteAdminBanner as MouseEventHandler}
                     >
-                      {isBannerDeleting ? (
+                      {bannerDeleting ? (
                         <Spinner size="md" />
                       ) : (
                         "Delete Current Banner"

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, MouseEventHandler } from "react";
 // components
 import {
   Box,
@@ -18,13 +18,12 @@ import {
 } from "components";
 // utils
 import { checkDateRangeStatus, convertDateUtcToEt, useStore } from "utils";
-import { bannerErrors } from "verbiage/errors";
+// verbiage
 import verbiage from "verbiage/pages/admin";
 
 export const AdminPage = () => {
   const { deleteAdminBanner, writeAdminBanner } =
     useContext(AdminBannerContext);
-  const [deleting, setDeleting] = useState<boolean>(false);
 
   // state management
   const {
@@ -33,7 +32,7 @@ export const AdminPage = () => {
     setIsBannerActive,
     isBannerLoading,
     bannerErrorMessage,
-    setBannerErrorMessage,
+    isBannerDeleting,
   } = useStore();
 
   useEffect(() => {
@@ -46,20 +45,6 @@ export const AdminPage = () => {
     }
     setIsBannerActive(bannerActivity);
   }, [bannerData]);
-
-  // useEffect(() => {
-  //   setError(errorMessage);
-  // }, [errorMessage]);
-
-  const deleteBanner = async () => {
-    setDeleting(true);
-    try {
-      await deleteAdminBanner();
-    } catch (error: any) {
-      setBannerErrorMessage(bannerErrors.DELETE_BANNER_FAILED);
-    }
-    setDeleting(false);
-  };
 
   return (
     <PageTemplate sxOverride={sx.layout} data-testid="admin-view">
@@ -102,9 +87,9 @@ export const AdminPage = () => {
                     <Button
                       variant="danger"
                       sx={sx.deleteBannerButton}
-                      onClick={deleteBanner}
+                      onClick={deleteAdminBanner as MouseEventHandler}
                     >
-                      {deleting ? (
+                      {isBannerDeleting ? (
                         <Spinner size="md" />
                       ) : (
                         "Delete Current Banner"

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect, MouseEventHandler } from "react";
+import { useContext, useEffect, MouseEventHandler } from "react";
 // components
 import {
   Box,

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -1,11 +1,27 @@
 import { useFlags } from "launchdarkly-react-client-sdk";
 // components
-import { Box, Heading, Link, Text } from "@chakra-ui/react";
-import { PageTemplate, TemplateCard } from "components";
+import { Box, Collapse, Heading, Link, Text } from "@chakra-ui/react";
+import { Banner, PageTemplate, TemplateCard } from "components";
 // utils
 import verbiage from "verbiage/pages/home";
+import { useEffect } from "react";
+import { checkDateRangeStatus, useStore } from "utils";
 
 export const HomePage = () => {
+  const { bannerData, isBannerActive, setIsBannerActive } = useStore();
+
+  useEffect(() => {
+    let bannerActivity = false;
+    if (bannerData) {
+      bannerActivity = checkDateRangeStatus(
+        bannerData.startDate,
+        bannerData.endDate
+      );
+    }
+    setIsBannerActive(bannerActivity);
+  }, [bannerData]);
+
+  const showBanner = !!bannerData?.key && isBannerActive;
   const { intro, cards } = verbiage;
 
   // LaunchDarkly
@@ -13,33 +29,38 @@ export const HomePage = () => {
   const sarReport = useFlags().sarReport;
 
   return (
-    <PageTemplate sx={sx.layout} data-testid="home-view">
-      <Box sx={sx.introTextBox}>
-        <Heading as="h1" sx={sx.headerText}>
-          {intro.header}
-        </Heading>
-        <Text>
-          {intro.body.preLinkText}
-          <Link href={intro.body.linkLocation} isExternal>
-            {intro.body.linkText}
-          </Link>
-          {intro.body.postLinkText}
-        </Text>
-        <Text></Text>
-      </Box>
-      <TemplateCard
-        templateName="WP"
-        verbiage={cards.WP}
-        cardprops={sx.card}
-        isHidden={!wpReport}
-      />
-      <TemplateCard
-        templateName="SAR"
-        verbiage={cards.SAR}
-        cardprops={sx.card}
-        isHidden={!sarReport}
-      />
-    </PageTemplate>
+    <>
+      <Collapse in={showBanner}>
+        <Banner bannerData={bannerData} />
+      </Collapse>
+      <PageTemplate sx={sx.layout} data-testid="home-view">
+        <Box sx={sx.introTextBox}>
+          <Heading as="h1" sx={sx.headerText}>
+            {intro.header}
+          </Heading>
+          <Text>
+            {intro.body.preLinkText}
+            <Link href={intro.body.linkLocation} isExternal>
+              {intro.body.linkText}
+            </Link>
+            {intro.body.postLinkText}
+          </Text>
+          <Text></Text>
+        </Box>
+        <TemplateCard
+          templateName="WP"
+          verbiage={cards.WP}
+          cardprops={sx.card}
+          isHidden={!wpReport}
+        />
+        <TemplateCard
+          templateName="SAR"
+          verbiage={cards.SAR}
+          cardprops={sx.card}
+          isHidden={!sarReport}
+        />
+      </PageTemplate>
+    </>
   );
 };
 

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -8,7 +8,7 @@ import { useEffect } from "react";
 import { checkDateRangeStatus, useStore } from "utils";
 
 export const HomePage = () => {
-  const { bannerData, isBannerActive, setIsBannerActive } = useStore();
+  const { bannerData, bannerActive, setBannerActive } = useStore();
 
   useEffect(() => {
     let bannerActivity = false;
@@ -18,10 +18,10 @@ export const HomePage = () => {
         bannerData.endDate
       );
     }
-    setIsBannerActive(bannerActivity);
+    setBannerActive(bannerActivity);
   }, [bannerData]);
 
-  const showBanner = !!bannerData?.key && isBannerActive;
+  const showBanner = !!bannerData?.key && bannerActive;
   const { intro, cards } = verbiage;
 
   // LaunchDarkly

--- a/services/ui-src/src/types/banners.ts
+++ b/services/ui-src/src/types/banners.ts
@@ -20,7 +20,4 @@ export interface AdminBannerMethods {
   deleteAdminBanner: Function;
 }
 
-export interface AdminBannerShape extends AdminBannerMethods {
-  isLoading: boolean;
-  errorMessage?: string;
-}
+export interface AdminBannerShape extends AdminBannerMethods {}

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -20,10 +20,14 @@ export interface AdminBannerState {
   // INITIAL STATE
   bannerData: AdminBannerData | undefined;
   isBannerActive: boolean;
+  isBannerLoading: boolean;
+  bannerErrorMessage: string;
   // ACTIONS
-  setAdminBanner: (newBannerData: AdminBannerData | undefined) => void;
+  setBannerData: (newBannerData: AdminBannerData | undefined) => void;
   clearAdminBanner: () => void;
   setIsBannerActive: (bannerStatus: boolean) => void;
+  setIsBannerLoading: (isBannerLoading: boolean) => void;
+  setBannerErrorMessage: (bannerErrorMessage: string) => void;
 }
 
 // initial report state

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -22,12 +22,14 @@ export interface AdminBannerState {
   isBannerActive: boolean;
   isBannerLoading: boolean;
   bannerErrorMessage: string;
+  isBannerDeleting: boolean;
   // ACTIONS
   setBannerData: (newBannerData: AdminBannerData | undefined) => void;
   clearAdminBanner: () => void;
   setIsBannerActive: (bannerStatus: boolean) => void;
   setIsBannerLoading: (isBannerLoading: boolean) => void;
   setBannerErrorMessage: (bannerErrorMessage: string) => void;
+  setIsBannerDeleting: (isBannerDeleting: boolean) => void;
 }
 
 // initial report state

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -19,17 +19,17 @@ export interface MfpUserState {
 export interface AdminBannerState {
   // INITIAL STATE
   bannerData: AdminBannerData | undefined;
-  isBannerActive: boolean;
-  isBannerLoading: boolean;
+  bannerActive: boolean;
+  bannerLoading: boolean;
   bannerErrorMessage: string;
-  isBannerDeleting: boolean;
+  bannerDeleting: boolean;
   // ACTIONS
   setBannerData: (newBannerData: AdminBannerData | undefined) => void;
   clearAdminBanner: () => void;
-  setIsBannerActive: (bannerStatus: boolean) => void;
-  setIsBannerLoading: (isBannerLoading: boolean) => void;
+  setBannerActive: (bannerStatus: boolean) => void;
+  setBannerLoading: (bannerLoading: boolean) => void;
   setBannerErrorMessage: (bannerErrorMessage: string) => void;
-  setIsBannerDeleting: (isBannerDeleting: boolean) => void;
+  setBannerDeleting: (bannerDeleting: boolean) => void;
 }
 
 // initial report state

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -32,6 +32,7 @@ const bannerStore = (set: Function) => ({
   isBannerActive: false,
   isBannerLoading: false,
   bannerErrorMessage: "",
+  isBannerDeleting: false,
   // actions
   setBannerData: (newBanner: AdminBannerData | undefined) =>
     set(() => ({ bannerData: newBanner }), false, { type: "setBannerData" }),
@@ -48,6 +49,10 @@ const bannerStore = (set: Function) => ({
   setBannerErrorMessage: (errorMessage: string) =>
     set(() => ({ bannerErrorMessage: errorMessage }), false, {
       type: "setBannerErrorMessage",
+    }),
+  setIsBannerDeleting: (deleting: boolean) =>
+    set(() => ({ isBannerDeleting: deleting }), false, {
+      type: "setIsBannerDeleting",
     }),
 });
 

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -29,30 +29,30 @@ const userStore = (set: Function) => ({
 const bannerStore = (set: Function) => ({
   // initial state
   bannerData: undefined,
-  isBannerActive: false,
-  isBannerLoading: false,
+  bannerActive: false,
+  bannerLoading: false,
   bannerErrorMessage: "",
-  isBannerDeleting: false,
+  bannerDeleting: false,
   // actions
   setBannerData: (newBanner: AdminBannerData | undefined) =>
     set(() => ({ bannerData: newBanner }), false, { type: "setBannerData" }),
   clearAdminBanner: () =>
     set(() => ({ bannerData: undefined }), false, { type: "clearAdminBanner" }),
-  setIsBannerActive: (bannerStatus: boolean) =>
-    set(() => ({ isBannerActive: bannerStatus }), false, {
-      type: "setIsBannerActive",
+  setBannerActive: (bannerStatus: boolean) =>
+    set(() => ({ bannerActive: bannerStatus }), false, {
+      type: "setBannerActive",
     }),
-  setIsBannerLoading: (loading: boolean) =>
-    set(() => ({ isBannerLoading: loading }), false, {
-      type: "setIsBannerLoading",
+  setBannerLoading: (loading: boolean) =>
+    set(() => ({ bannerLoading: loading }), false, {
+      type: "setBannerLoading",
     }),
   setBannerErrorMessage: (errorMessage: string) =>
     set(() => ({ bannerErrorMessage: errorMessage }), false, {
       type: "setBannerErrorMessage",
     }),
-  setIsBannerDeleting: (deleting: boolean) =>
-    set(() => ({ isBannerDeleting: deleting }), false, {
-      type: "setIsBannerDeleting",
+  setBannerDeleting: (deleting: boolean) =>
+    set(() => ({ bannerDeleting: deleting }), false, {
+      type: "setBannerDeleting",
     }),
 });
 

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -30,14 +30,24 @@ const bannerStore = (set: Function) => ({
   // initial state
   bannerData: undefined,
   isBannerActive: false,
+  isBannerLoading: false,
+  bannerErrorMessage: "",
   // actions
-  setAdminBanner: (newBanner: AdminBannerData | undefined) =>
-    set(() => ({ bannerData: newBanner }), false, { type: "setAdminBanner" }),
+  setBannerData: (newBanner: AdminBannerData | undefined) =>
+    set(() => ({ bannerData: newBanner }), false, { type: "setBannerData" }),
   clearAdminBanner: () =>
     set(() => ({ bannerData: undefined }), false, { type: "clearAdminBanner" }),
   setIsBannerActive: (bannerStatus: boolean) =>
     set(() => ({ isBannerActive: bannerStatus }), false, {
       type: "setIsBannerActive",
+    }),
+  setIsBannerLoading: (loading: boolean) =>
+    set(() => ({ isBannerLoading: loading }), false, {
+      type: "setIsBannerLoading",
+    }),
+  setBannerErrorMessage: (errorMessage: string) =>
+    set(() => ({ bannerErrorMessage: errorMessage }), false, {
+      type: "setBannerErrorMessage",
     }),
 });
 

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -176,16 +176,16 @@ export const mockAdminUserStore: MfpUserState = {
 
 export const mockBannerStore: AdminBannerState = {
   bannerData: mockBannerData,
-  isBannerActive: false,
-  isBannerLoading: false,
+  bannerActive: false,
+  bannerLoading: false,
   bannerErrorMessage: "",
-  isBannerDeleting: false,
+  bannerDeleting: false,
   setBannerData: () => {},
   clearAdminBanner: () => {},
-  setIsBannerActive: () => {},
-  setIsBannerLoading: () => {},
+  setBannerActive: () => {},
+  setBannerLoading: () => {},
   setBannerErrorMessage: () => {},
-  setIsBannerDeleting: () => {},
+  setBannerDeleting: () => {},
 };
 
 // REPORT STATES / STORE

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -177,9 +177,13 @@ export const mockAdminUserStore: MfpUserState = {
 export const mockBannerStore: AdminBannerState = {
   bannerData: mockBannerData,
   isBannerActive: false,
-  setAdminBanner: () => {},
+  isBannerLoading: false,
+  bannerErrorMessage: "",
+  setBannerData: () => {},
   clearAdminBanner: () => {},
   setIsBannerActive: () => {},
+  setIsBannerLoading: () => {},
+  setBannerErrorMessage: () => {},
 };
 
 // REPORT STATES / STORE

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -179,11 +179,13 @@ export const mockBannerStore: AdminBannerState = {
   isBannerActive: false,
   isBannerLoading: false,
   bannerErrorMessage: "",
+  isBannerDeleting: false,
   setBannerData: () => {},
   clearAdminBanner: () => {},
   setIsBannerActive: () => {},
   setIsBannerLoading: () => {},
   setBannerErrorMessage: () => {},
+  setIsBannerDeleting: () => {},
 };
 
 // REPORT STATES / STORE

--- a/services/ui-src/src/verbiage/errors.ts
+++ b/services/ui-src/src/verbiage/errors.ts
@@ -4,6 +4,7 @@ export const bannerErrors = {
     "Current banner could not be replaced. Please contact support.",
   DELETE_BANNER_FAILED:
     "Current banner could not be deleted. Please contact support.",
+  CREATE_BANNER_FAILED: "Could not create a banner. Please contact support.",
 };
 
 export const validationErrors = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds validation to the Admin Banner create API call and then further integrates Zustand into it. You should now see the full Admin Banner experience!

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/424dd941-ebc2-431b-b14a-b3d7a355280a

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2964
MDCT-2965

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Login as an admin (adminuser@test.com)
Open My Account through the top right dropdown
Open the Banner Editor
Create/Delete banners and visit the home page to see it live!

### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
