### PR TITLE
MDCT-2794 Dashboard Tests

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -1,0 +1,37 @@
+import { ReportType } from "types";
+import { getStatus } from "./DashboardTable";
+
+describe("Test getStatus utility", () => {
+  test("should render the correct status if report has been unlocked", () => {
+    expect(getStatus(ReportType.WP, "In progress", false, 1)).toBe(
+      "In revision"
+    );
+  });
+  test("should render the correct status if report has been unlocked", () => {
+    expect(getStatus(ReportType.WP, "In progress", false, 0)).toBe(
+      "In progress"
+    );
+  });
+  test("should render the correct status if report has been archived", () => {
+    expect(getStatus(ReportType.WP, "In progress", true, 1)).toBe("Archived");
+  });
+  test("should render the correct status if report has been unlocked", () => {
+    expect(getStatus(ReportType.WP, "Submitted", false, 1)).toBe("Submitted");
+  });
+
+  test("should render the correct status if report has been unlocked", () => {
+    expect(getStatus(ReportType.WP, "Not started", false, 1)).toBe(
+      "In revision"
+    );
+  });
+  test("should render the correct status for SAR reports", () => {
+    expect(getStatus(ReportType.SAR, "In progress", false, 1)).toBe(
+      "In progress"
+    );
+  });
+  test("should render the correct status for SAR reports", () => {
+    expect(getStatus(ReportType.SAR, "Not started", false, 1)).toBe(
+      "Not started"
+    );
+  });
+});


### PR DESCRIPTION
### Description
This PR replaces this other PR: https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/113

I updated the branch name so that the deployment can successfully create an S3 bucket. My previous branch name was too many characters, causing the deployment to fail 

The error from the previous PR: 
```
Deploying uploads to stage mdct-2794-submission-name-tests (***)

CREATE_FAILED: AttachmentsBucket (AWS::S3::Bucket)
Bucket name should be between 3 and 63 characters long
```

The test results: 
```
 PASS  src/components/pages/Dashboard/DashboardTable.test.tsx
  Test getStatus utility
    ✓ should render the correct status if report has been unlocked (1 ms)
    ✓ should render the correct status if report has been unlocked
    ✓ should render the correct status if report has been archived
    ✓ should render the correct status if report has been unlocked (1 ms)
    ✓ should render the correct status if report has been unlocked
    ✓ should render the correct status for SAR reports
    ✓ should render the correct status for SAR reports

```

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2794

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
change directories to /services/ui-src
run yarn test
validate that the tests passed


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
