### PR TITLE
MDCT-2953: Add HelpPage

### DIFF
--- a/services/ui-src/src/components/accordions/FaqAccordion.tsx
+++ b/services/ui-src/src/components/accordions/FaqAccordion.tsx
@@ -1,0 +1,36 @@
+// components
+import { Accordion, Box, Text } from "@chakra-ui/react";
+import { AccordionItem } from "components";
+// utils
+import { AnyObject } from "types";
+
+export const FaqAccordion = ({ accordionItems, ...props }: Props) => {
+  return (
+    <Accordion allowToggle={true} allowMultiple={true} {...props}>
+      {accordionItems.map((item: AnyObject, index: number) => (
+        <AccordionItem key={index} label={item.question} sx={sx.item}>
+          <Box sx={sx.answerBox}>
+            <Text>{item.answer}</Text>
+          </Box>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+};
+
+interface Props {
+  accordionItems: AnyObject;
+  [key: string]: any;
+}
+
+const sx = {
+  item: {
+    marginBottom: "1.5rem",
+    borderStyle: "none",
+  },
+  answerBox: {
+    ".mobile &": {
+      paddingLeft: "1rem",
+    },
+  },
+};

--- a/services/ui-src/src/components/accordions/FaqAccordion.tsx
+++ b/services/ui-src/src/components/accordions/FaqAccordion.tsx
@@ -20,7 +20,6 @@ export const FaqAccordion = ({ accordionItems, ...props }: Props) => {
 
 interface Props {
   accordionItems: AnyObject;
-  [key: string]: any;
 }
 
 const sx = {

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -5,6 +5,7 @@ import {
   AdminBannerProvider,
   AdminPage,
   HomePage,
+  HelpPage,
   NotFoundPage,
   DashboardPage,
   ProfilePage,
@@ -36,6 +37,7 @@ export const AppRoutes = () => {
             element={!userIsAdmin ? <Navigate to="/profile" /> : <AdminPage />}
           />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/help" element={<HelpPage />} />
           <Route path="*" element={<NotFoundPage />} />
           {/* MFP Report Routes */}
           {wpReport && (

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -1,5 +1,6 @@
 // accordions
 export { AccordionItem } from "./accordions/AccordionItem";
+export { FaqAccordion } from "./accordions/FaqAccordion";
 export { TemplateCardAccordion } from "./accordions/TemplateCardAccordion";
 export { InstructionsAccordion } from "./accordions/InstructionsAccordion";
 // alerts
@@ -63,6 +64,7 @@ export { DeleteEntityModal } from "./modals/DeleteEntityModal";
 // pages
 export { AdminPage } from "./pages/Admin/AdminPage";
 export { HomePage } from "./pages/Home/HomePage";
+export { HelpPage } from "./pages/HelpPage/HelpPage";
 export { NotFoundPage } from "./pages/NotFound/NotFoundPage";
 export { ProfilePage } from "./pages/Profile/ProfilePage";
 export { ReviewSubmitPage } from "./pages/ReviewSubmit/ReviewSubmitPage";

--- a/services/ui-src/src/components/pages/HelpPage/HelpPage.tsx
+++ b/services/ui-src/src/components/pages/HelpPage/HelpPage.tsx
@@ -1,0 +1,57 @@
+// components
+import { Box, Heading, Text } from "@chakra-ui/react";
+import { EmailCard, FaqAccordion, PageTemplate } from "components";
+import verbiage from "verbiage/pages/help";
+
+export const HelpPage = () => {
+  const { intro, cards, accordionItems } = verbiage;
+  return (
+    <PageTemplate>
+      <Box sx={sx.leadTextBox}>
+        <Heading as="h1" sx={sx.headerText}>
+          {intro.header}
+        </Heading>
+        <Text>{intro.body}</Text>
+      </Box>
+      <Box sx={sx.emailCardBox}>
+        <EmailCard
+          verbiage={cards.helpdesk}
+          icon="settings"
+          cardprops={sx.card}
+        />
+        <EmailCard
+          verbiage={cards.template}
+          icon="spreadsheet"
+          cardprops={sx.card}
+        />
+      </Box>
+      {accordionItems.length > 0 && (
+        <Box sx={sx.faqAccordionBox}>
+          <FaqAccordion accordionItems={accordionItems} />
+        </Box>
+      )}
+    </PageTemplate>
+  );
+};
+
+const sx = {
+  leadTextBox: {
+    marginBottom: "2.25rem",
+  },
+  headerText: {
+    marginBottom: "1rem",
+    fontSize: "2rem",
+    fontWeight: "normal",
+  },
+  emailCardBox: {
+    width: "100%",
+    marginBottom: "3rem",
+  },
+  card: {
+    marginBottom: "1.5rem",
+  },
+  faqAccordionBox: {
+    width: "100%",
+    marginBottom: "8rem",
+  },
+};

--- a/services/ui-src/src/components/pages/HelpPage/HelpPageTest.tsx
+++ b/services/ui-src/src/components/pages/HelpPage/HelpPageTest.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+// components
+import { HelpPage } from "components/pages/HelpPage/HelpPage";
+// utils
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+// verbiage
+import verbiage from "verbiage/pages/help";
+
+const helpView = (
+  <RouterWrappedComponent>
+    <HelpPage />
+  </RouterWrappedComponent>
+);
+
+describe("Test HelpPage", () => {
+  beforeEach(() => {
+    render(helpView);
+  });
+
+  test("Check that HelpPage renders", () => {
+    expect(screen.getByText(verbiage.intro.header)).toBeVisible();
+  });
+});
+
+describe("Test HelpPage accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(helpView);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/verbiage/pages/help.ts
+++ b/services/ui-src/src/verbiage/pages/help.ts
@@ -11,9 +11,9 @@ export default {
       },
     },
     template: {
-      body: "",
+      body: "For questions about the online form:",
       email: {
-        address: "",
+        address: "MFPDemo@cms.hhs.gov",
       },
     },
   },
@@ -25,5 +25,13 @@ export default {
      *    answer: "",
      *  }
      */
+    {
+      question: "How do I log into my IDM account?",
+      answer: "TBD",
+    },
+    {
+      question: "Question #2",
+      answer: "TBD",
+    },
   ],
 };


### PR DESCRIPTION
### Description
This change adds a HelpPage that a user can navigate to when they click `Get Help` on the MFP pages


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2953

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Log in as a user
2. Click 'Get Help' in the top right corner of the page 


https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/4ed21b80-e485-4bdc-8051-231ff6f6cc7d



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
