### PR TITLE
WP Initiative Alert Cleanup

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -650,14 +650,14 @@
               "exportSectionHeader": "exportSectionHeader"
             },
             "addEntityButtonText": "Add Initiative",
-            "editEntityButtonText": "Edit name",
+            "editEntityButtonText": "Edit name/topic",
             "addEditModalAddTitle": "Add initiative",
             "addEditModalEditTitle": "Edit initiative",
             "deleteModalTitle": "Are you sure you want to delete this initiative?",
             "deleteModalConfirmButtonText": "Yes, delete initiative",
             "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this initiative in the Work Plan. The initiative will remain in previously submitted Semi-Annual Reports if applicable. <br/><br/>To close a completed initiative out, select “Cancel” and then the “Close out” button in the listing.",
             "enterEntityDetailsButtonText": "Edit",
-            "dashboardTitle": "Initiative total count",
+            "dashboardTitle": "Initiative total count:",
             "countEntitiesInTitle": true,
             "tableHeader": "Initiative name <br/> Work Plan topic",
             "addEditModalHint": "Provide the name of one initiative. You will be then be asked to complete details for this initiative including description, evaluation plan and funding sources.",
@@ -696,7 +696,7 @@
                     },
                     {
                       "id": "8CpFrev6sMfRijIhafMj7V",
-                      "label": "Self-direction(*if applicable)"
+                      "label": "Self-direction (*if applicable)"
                     },
                     {
                       "id": "tVURShWTPfVKGU94QmIwDn",

--- a/services/ui-src/src/components/alerts/getWPAlertStatus.test.tsx
+++ b/services/ui-src/src/components/alerts/getWPAlertStatus.test.tsx
@@ -2,6 +2,18 @@ import { ReportShape } from "types";
 import { getWPAlertStatus } from "./getWPAlertStatus";
 
 describe("Test WP Alerts", () => {
+  const topics = [
+    "Transitions and transition coordination services*",
+    "Housing-related supports*",
+    "Quality measurement and improvement*",
+    "Self-direction (*if applicable)",
+    "Tribal Initiative (*if applicable)",
+  ];
+
+  const initiative_wpTopic = topics.map((topic) => {
+    return { value: topic };
+  });
+
   test("Test checkInitiativesTopics not filled", () => {
     const report: ReportShape = {
       fieldData: {
@@ -17,20 +29,10 @@ describe("Test WP Alerts", () => {
     expect(getWPAlertStatus(report, "initiatives")).toBeTruthy();
   });
   test("Test checkInitiativesTopics filled", () => {
-    const topics = [
-      "Transitions and transition coordination services*",
-      "Housing-related supports*",
-      "Quality measurement and improvement*",
-      "Self-direction(*if applicable)",
-      "Tribal Initiative (*if applicable)",
-    ];
-
-    const initiative_wpTopic = topics.map((topic) => {
-      return { value: topic };
-    });
-
     const report: ReportShape = {
       fieldData: {
+        firstquestion: { value: "Yes" },
+        secondquestion: { value: "Yes" },
         initiatives: [
           {
             initiative_wpTopic: initiative_wpTopic,
@@ -41,5 +43,19 @@ describe("Test WP Alerts", () => {
 
     //turn off alertbox
     expect(getWPAlertStatus(report, "initiatives")).toBeFalsy();
+  });
+  test("Test checkInitiativesTopics if previous questions were not fileed", () => {
+    const report: ReportShape = {
+      fieldData: {
+        initiatives: [
+          {
+            initiative_wpTopic: initiative_wpTopic,
+          },
+        ],
+      },
+    } as unknown as ReportShape;
+
+    //alertbox will still be active
+    expect(getWPAlertStatus(report, "initiatives")).toBeTruthy();
   });
 });

--- a/services/ui-src/src/components/alerts/getWPAlertStatus.tsx
+++ b/services/ui-src/src/components/alerts/getWPAlertStatus.tsx
@@ -8,13 +8,13 @@ export const checkInitiativesTopics = (fieldData: any, entities: any[]) => {
     "Quality measurement and improvement*",
   ];
 
-  if (fieldData?.firstquestion && fieldData?.firstquestion[0]?.value === "Yes")
-    topics.push("Self-direction(*if applicable)");
+  //if user did not answer previous question, alert stays on
+  if (!fieldData?.firstquestion || !fieldData?.secondquestion) return true;
 
-  if (
-    fieldData?.secondquestion &&
-    fieldData?.secondquestion[0]?.value === "Yes"
-  )
+  if (fieldData?.firstquestion[0]?.value === "Yes")
+    topics.push("Self-direction (*if applicable)");
+
+  if (fieldData?.secondquestion[0]?.value === "Yes")
     topics.push("Tribal Initiative (*if applicable)");
 
   //filter down to the values of the radio selection

--- a/services/ui-src/src/verbiage/pages/wp/wp-alerts.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-alerts.ts
@@ -2,6 +2,6 @@ export default {
   initiatives: {
     title: "Your initiatives do not meet the topic requirements",
     description:
-      "Initiatives must meet the following requirements at least once across all the initiatives: <li>Transitions and transition coordination services</li><li>Housing-related supports</li><li>Quality measurement and improvement</li><li>Self-direction (If applicable)</li><li>Tribal (if applicable)</li>To correct this, ensure you add at least one initiative for each of these topics. This alert will disappear once they're met. ",
+      "Initiatives must meet the following requirements at least once across all the initiatives: <li>Transitions and transition coordination services</li><li>Housing-related supports</li><li>Quality measurement and improvement</li><li>Self-direction (If applicable)</li><li>Tribal (if applicable)</li>To correct this, ensure you answer the 2 questions at the bottom of <i>State- or Territory-Specific Initiatives Instructions</i> (the previous page), and add at least one initiative for each of these topics. This alert will disappear once they’re met.",
   },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
More of less a final clean up for the alert box, I had talked to Megan about the conditional and made some updates. 
If the previous page questions were not answered, the alert box will stay up no matter what the user has entered. Also some text updates to match the figma.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2795

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP
2) Go to "State and Territory-Specific Initiatives" page
3) Do not answer the questions in "State & Territory Specific Initiatives Instructions"
4) Start adding one of each topic that has a * (5 total)
5) Answer the questions, the alert box will go away.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
