### PR TITLE
WP - Repeatable ChoiceList Options ( Total Population Logic)

### DIFF
--- a/services/ui-src/src/components/fields/CheckboxField.tsx
+++ b/services/ui-src/src/components/fields/CheckboxField.tsx
@@ -2,7 +2,6 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { ChoiceListField } from "components";
 // utils
-import { useStore } from "utils";
 import { ChoiceFieldProps } from "types";
 
 export const CheckboxField = ({
@@ -13,41 +12,6 @@ export const CheckboxField = ({
   sxOverride,
   ...props
 }: ChoiceFieldProps) => {
-  const { report } = useStore();
-
-  const getDynamicChoices = () => {
-    const isTargetPopulationChoices = choices.filter((choice) =>
-      choice.id.match("targetPopulations")
-    );
-    if (isTargetPopulationChoices) {
-      const targetPopulationChoices = report?.fieldData.targetPopulation;
-
-      const labelCustomTargetPopulationChoice = (choice: any) => {
-        if (targetPopulationChoices.indexOf(choice) >= 4) {
-          return `Other: {${choice.transitionBenchmarks_targetPopulationName}}`;
-        } else {
-          return choice.transitionBenchmarks_targetPopulationName;
-        }
-      };
-
-      const formatTargetPopulationChoices = targetPopulationChoices.map(
-        (choice: any) => {
-          return {
-            checked: choice.checked,
-            id: choice.id,
-            label: labelCustomTargetPopulationChoice(choice),
-            name: choice.transitionBenchmarks_targetPopulationName,
-            value: choice.transitionBenchmarks_targetPopulationName,
-          };
-        }
-      );
-
-      return formatTargetPopulationChoices;
-    } else {
-      return choices;
-    }
-  };
-
   return (
     <Box sx={sxOverride}>
       {/* SAR field sections */}
@@ -56,7 +20,7 @@ export const CheckboxField = ({
         type="checkbox"
         name={name}
         label={label}
-        choices={getDynamicChoices()}
+        choices={choices}
         {...props}
       />
     </Box>

--- a/services/ui-src/src/components/fields/CheckboxField.tsx
+++ b/services/ui-src/src/components/fields/CheckboxField.tsx
@@ -19,7 +19,6 @@ export const CheckboxField = ({
     const isTargetPopulationChoices = choices.filter((choice) =>
       choice.id.match("targetPopulations")
     );
-    // is target population choices the only choices that need to be dynamically pulled?
     if (isTargetPopulationChoices) {
       const targetPopulationChoices = report?.fieldData.targetPopulation;
 

--- a/services/ui-src/src/components/fields/CheckboxField.tsx
+++ b/services/ui-src/src/components/fields/CheckboxField.tsx
@@ -2,6 +2,7 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { ChoiceListField } from "components";
 // utils
+import { useStore } from "utils";
 import { ChoiceFieldProps } from "types";
 
 export const CheckboxField = ({
@@ -12,6 +13,42 @@ export const CheckboxField = ({
   sxOverride,
   ...props
 }: ChoiceFieldProps) => {
+  const { report } = useStore();
+
+  const getDynamicChoices = () => {
+    const isTargetPopulationChoices = choices.filter((choice) =>
+      choice.id.match("targetPopulations")
+    );
+    // is target population choices the only choices that need to be dynamically pulled?
+    if (isTargetPopulationChoices) {
+      const targetPopulationChoices = report?.fieldData.targetPopulation;
+
+      const labelCustomTargetPopulationChoice = (choice: any) => {
+        if (targetPopulationChoices.indexOf(choice) >= 4) {
+          return `Other: {${choice.transitionBenchmarks_targetPopulationName}}`;
+        } else {
+          return choice.transitionBenchmarks_targetPopulationName;
+        }
+      };
+
+      const formatTargetPopulationChoices = targetPopulationChoices.map(
+        (choice: any) => {
+          return {
+            checked: choice.checked,
+            id: choice.id,
+            label: labelCustomTargetPopulationChoice(choice),
+            name: choice.transitionBenchmarks_targetPopulationName,
+            value: choice.transitionBenchmarks_targetPopulationName,
+          };
+        }
+      );
+
+      return formatTargetPopulationChoices;
+    } else {
+      return choices;
+    }
+  };
+
   return (
     <Box sx={sxOverride}>
       {/* SAR field sections */}
@@ -20,7 +57,7 @@ export const CheckboxField = ({
         type="checkbox"
         name={name}
         label={label}
-        choices={choices}
+        choices={getDynamicChoices()}
         {...props}
       />
     </Box>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -82,46 +82,45 @@ export const Form = ({
     fieldToFocus?.focus({ preventScroll: true });
   };
 
+  const getRepeatableTargetPopulations = (fields: any) => {
+    const isRepeatableTargetPopulations = fields.filter((field: any) =>
+      field.id.match("stateTerritory_targetPopulations")
+    );
+    if (isRepeatableTargetPopulations) {
+      const targetPopulations = report?.fieldData.targetPopulation;
+
+      const createLabel = (field: any) => {
+        if (targetPopulations.indexOf(field) >= 4) {
+          return `Other: {${field.transitionBenchmarks_targetPopulationName}}`;
+        } else {
+          return field.transitionBenchmarks_targetPopulationName;
+        }
+      };
+
+      const formatTargetPopulations = targetPopulations.map((field: any) => {
+        return {
+          checked: false,
+          id: field.id,
+          label: createLabel(field),
+          name: field.transitionBenchmarks_targetPopulationName,
+          value: field.transitionBenchmarks_targetPopulationName,
+        };
+      });
+      // update choices with dynamic target population choices
+      if (fields[1]?.props) {
+        fields[1].props.choices = [];
+        fields[1]?.props?.choices.push(...formatTargetPopulations);
+      }
+      return fields;
+    } else {
+      return fields;
+    }
+  };
+
   // hydrate and create form fields using formFieldFactory
   const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
-    const getDynamicChoices = (fields: any) => {
-      const isTargetPopulationChoices = fields.filter((field: any) =>
-        field.id.match("stateTerritory_targetPopulations")
-      );
-      if (isTargetPopulationChoices) {
-        const targetPopulationChoices = report?.fieldData.targetPopulation;
-
-        const labelCustomTargetPopulationChoice = (field: any) => {
-          if (targetPopulationChoices.indexOf(field) >= 4) {
-            return `Other: {${field.transitionBenchmarks_targetPopulationName}}`;
-          } else {
-            return field.transitionBenchmarks_targetPopulationName;
-          }
-        };
-        const formatTargetPopulationChoices = targetPopulationChoices.map(
-          (field: any) => {
-            return {
-              checked: false,
-              id: field.id,
-              label: labelCustomTargetPopulationChoice(field),
-              name: field.transitionBenchmarks_targetPopulationName,
-              value: field.transitionBenchmarks_targetPopulationName,
-            };
-          }
-        );
-        // update choices with dynamic target population choices
-        if (fields[1]?.props) {
-          fields[1].props.choices = [];
-          fields[1]?.props?.choices.push(...formatTargetPopulationChoices);
-        }
-        return fields;
-      } else {
-        return fields;
-      }
-    };
-
     const fieldsToRender = hydrateFormFields(
-      getDynamicChoices(fields),
+      getRepeatableTargetPopulations(fields),
       formData
     );
     return formFieldFactory(fieldsToRender, {

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -18,6 +18,7 @@ import {
   mapValidationTypesToSchema,
   sortFormErrors,
   useStore,
+  getRepeatableChoiceLists,
 } from "utils";
 import {
   AnyObject,
@@ -47,6 +48,8 @@ export const Form = ({
   const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
 
   const { report } = useStore();
+  const targetPopulationChoiceList = report?.fieldData?.targetPopulation;
+
   let location = useLocation();
   const fieldInputDisabled =
     ((userIsAdmin || userIsReadOnly) && !formJson.editableByAdmins) ||
@@ -82,45 +85,10 @@ export const Form = ({
     fieldToFocus?.focus({ preventScroll: true });
   };
 
-  const getRepeatableTargetPopulations = (fields: any) => {
-    const isRepeatableTargetPopulations = fields.filter((field: any) =>
-      field.id.match("stateTerritory_targetPopulations")
-    );
-    if (isRepeatableTargetPopulations) {
-      const targetPopulations = report?.fieldData.targetPopulation;
-
-      const createLabel = (field: any) => {
-        if (targetPopulations.indexOf(field) >= 4) {
-          return `Other: {${field.transitionBenchmarks_targetPopulationName}}`;
-        } else {
-          return field.transitionBenchmarks_targetPopulationName;
-        }
-      };
-
-      const formatTargetPopulations = targetPopulations.map((field: any) => {
-        return {
-          checked: false,
-          id: field.id,
-          label: createLabel(field),
-          name: field.transitionBenchmarks_targetPopulationName,
-          value: field.transitionBenchmarks_targetPopulationName,
-        };
-      });
-      // update choices with dynamic target population choices
-      if (fields[1]?.props) {
-        fields[1].props.choices = [];
-        fields[1]?.props?.choices.push(...formatTargetPopulations);
-      }
-      return fields;
-    } else {
-      return fields;
-    }
-  };
-
   // hydrate and create form fields using formFieldFactory
   const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
     const fieldsToRender = hydrateFormFields(
-      getRepeatableTargetPopulations(fields),
+      getRepeatableChoiceLists(fields, targetPopulationChoiceList),
       formData
     );
     return formFieldFactory(fieldsToRender, {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -203,3 +203,50 @@ export const flattenFormFields = (formFields: FormField[]): FormField[] => {
   compileFields(formFields);
   return flattenedFields;
 };
+
+// repeatable target population choice list
+const repeatableTargetPopulationChoices = (
+  fields: (FormField | FormLayoutElement)[],
+  choiceList: any
+) => {
+  const createLabel = (field: any) => {
+    if (choiceList.indexOf(field) >= 4) {
+      return `Other: ${field.transitionBenchmarks_targetPopulationName}`;
+    } else {
+      return field.transitionBenchmarks_targetPopulationName;
+    }
+  };
+  const formatTargetPopulations = choiceList?.map((field: any) => {
+    return {
+      checked: false,
+      id: field.id,
+      label: createLabel(field),
+      name: field.transitionBenchmarks_targetPopulationName,
+      value: field.transitionBenchmarks_targetPopulationName,
+    };
+  });
+  // update choices with dynamic target population choices
+  if (fields[1]?.props) {
+    fields[1].props.choices = [];
+    fields[1]?.props?.choices.push(...formatTargetPopulations);
+  }
+};
+
+// returns repeated choice lists - reformatting logic is needed once fields are passed into this function
+export const getRepeatableChoiceLists = (
+  fields: (FormField | FormLayoutElement)[],
+  choiceList: any
+) => {
+  // check if fields have target population data
+  const isRepeatableTargetPopulations = fields.filter((field: any) =>
+    field.id.match("targetPopulations")
+  );
+
+  // add more conditional logic for other choice lists
+  if (isRepeatableTargetPopulations.length > 0) {
+    repeatableTargetPopulationChoices(fields, choiceList);
+    return fields;
+  } else {
+    return fields;
+  }
+};


### PR DESCRIPTION
### Description
The 'Define Initiative' page now reflects “other target populations” that are entered in the 'Benchmark Projections' section. There's only target population logic ( repeatableTargetPopulationChoices function in form.ts) to fufill the ticket but the *getRepeatableChoiceLists* function can be used as a utility to create other repeat other choice lists.

<img width="751" alt="Screenshot 2023-10-04 at 2 07 47 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/62afdbf1-93eb-4c50-b6e1-5f57f6a559d7">

<img width="607" alt="Screenshot 2023-10-04 at 2 08 08 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/8c2da4ba-f4b4-462b-bc9c-cf9c357ba7e6">

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/1624fa75-5902-4056-a5fb-d5c4e94afbca


### Related ticket(s)
MDCT-[https://qmacbis.atlassian.net/browse/MDCT-2813]

---
### How to test
1. Go to Transition Benchmark Projections
2. Create new target population and save
3. Go to State and Territory-Specific Initiatives: I. Define initiative
4. In the Target Populations section there should be a new Other option


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
