### PR TITLE
[MFP] Add Reporting Period to Work Plan metadata

### DIFF
--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -32,7 +32,6 @@ const creationEvent: APIGatewayProxyEvent = {
   ...mockProxyEvent,
   body: JSON.stringify({
     fieldData: {
-      submissionName: "Work Plan",
       stateName: "New Jersey",
       submissionCount: 0,
       versionControl: [
@@ -95,7 +94,6 @@ describe("Test createReport API method", () => {
     expect(body.formTemplateId).not.toEqual(
       mockWPReport.metadata.formTemplateId
     );
-    expect(body.fieldData.submissionName).toBe("Work Plan");
     expect(body.formTemplate.validationJson).toMatchObject({
       transitionBenchmarks_targetPopulationName: "text",
     });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -14,7 +14,10 @@ import {
   error,
   reportTables,
   reportBuckets,
+  reportNames,
 } from "../../utils/constants/constants";
+import { calculatePeriod } from "../../utils/time/time";
+import { createReportName } from "../../utils/other/other";
 // types
 import {
   DynamoWrite,
@@ -69,6 +72,7 @@ export const createReport = handler(async (event, _context) => {
 
   const reportBucket = reportBuckets[reportType];
   const reportTable = reportTables[reportType];
+  const reportTypeExpanded = reportNames[reportType];
 
   let formTemplate, formTemplateVersion;
 
@@ -95,7 +99,6 @@ export const createReport = handler(async (event, _context) => {
   const fieldDataId: string = KSUID.randomSync().string;
   const formTemplateId: string = formTemplateVersion?.id;
   const creationValidationJson = {
-    submissionName: "text",
     stateName: "text",
     ["targetPopulation"]: "objectArray",
     submissionCount: "number",
@@ -144,6 +147,8 @@ export const createReport = handler(async (event, _context) => {
     };
   }
 
+  const currentDate = Date.now();
+
   // Create DyanmoDB record.
   const reportMetadataParams: DynamoWrite = {
     TableName: reportTable,
@@ -154,9 +159,11 @@ export const createReport = handler(async (event, _context) => {
       fieldDataId,
       status: "Not started",
       formTemplateId,
-      createdAt: Date.now(),
-      lastAltered: Date.now(),
+      createdAt: currentDate,
+      lastAltered: currentDate,
       versionNumber: formTemplateVersion?.versionNumber,
+      submissionName: createReportName(reportTypeExpanded, currentDate, state),
+      reportPeriod: calculatePeriod(currentDate),
     },
   };
 

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -29,6 +29,62 @@ export const buckets = {
   FIELD_DATA: "fieldData",
 };
 
+// STATES
+export enum States {
+  AL = "Alabama",
+  AK = "Alaska",
+  AZ = "Arizona",
+  AR = "Arkansas",
+  CA = "California",
+  CO = "Colorado",
+  CT = "Connecticut",
+  DE = "Delaware",
+  DC = "District of Columbia",
+  FL = "Florida",
+  GA = "Georgia",
+  HI = "Hawaii",
+  ID = "Idaho",
+  IL = "Illinois",
+  IN = "Indiana",
+  IA = "Iowa",
+  KS = "Kansas",
+  KY = "Kentucky",
+  LA = "Louisiana",
+  ME = "Maine",
+  MD = "Maryland",
+  MA = "Massachusetts",
+  MI = "Michigan",
+  MN = "Minnesota",
+  MS = "Mississippi",
+  MO = "Missouri",
+  MT = "Montana",
+  NE = "Nebraska",
+  NV = "Nevada",
+  NH = "New Hampshire",
+  NJ = "New Jersey",
+  NM = "New Mexico",
+  NY = "New York",
+  NC = "North Carolina",
+  ND = "North Dakota",
+  OH = "Ohio",
+  OK = "Oklahoma",
+  OR = "Oregon",
+  PA = "Pennsylvania",
+  PR = "Puerto Rico",
+  RI = "Rhode Island",
+  SC = "South Carolina",
+  SD = "South Dakota",
+  TN = "Tennessee",
+  TX = "Texas",
+  UT = "Utah",
+  VT = "Vermont",
+  VA = "Virginia",
+  WA = "Washington",
+  WV = "West Virginia",
+  WI = "Wisconsin",
+  WY = "Wyoming",
+}
+
 // REPORTS
 
 export const reportTables = {
@@ -39,6 +95,11 @@ export const reportTables = {
 export const reportBuckets = {
   SAR: process.env.SAR_FORM_BUCKET!,
   WP: process.env.WP_FORM_BUCKET!,
+};
+
+export const reportNames = {
+  SAR: "SAR",
+  WP: "Work Plan",
 };
 
 export const tableTopics = {

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -1,0 +1,16 @@
+import { States } from "../constants/constants";
+import { calculatePeriod, convertDateUtcToEt } from "../time/time";
+
+export const createReportName = (
+  reportType: string,
+  createdAt: number,
+  state: string
+) => {
+  const reportName = reportType;
+  const etDate = convertDateUtcToEt(createdAt);
+  const period = calculatePeriod(createdAt);
+  const year = new Date(etDate).getFullYear();
+
+  const fullStateName = States[state as keyof typeof States];
+  return `${fullStateName} ${reportName} ${year} - Period ${period}`;
+};

--- a/services/app-api/utils/testing/mocks/mockDynamo.ts
+++ b/services/app-api/utils/testing/mocks/mockDynamo.ts
@@ -47,6 +47,7 @@ export const mockDynamoDataWPLocked: WPReportMetadata = {
   locked: true,
   previousRevisions: [],
   isComplete: false,
+  reportPeriod: 2,
 };
 
 export const mockDynamoDataWPCompleted: WPReportMetadata = {
@@ -69,4 +70,5 @@ export const mockDynamoDataWPCompleted: WPReportMetadata = {
   submissionCount: 0,
   locked: false,
   previousRevisions: [],
+  reportPeriod: 2,
 };

--- a/services/app-api/utils/time/time.test.ts
+++ b/services/app-api/utils/time/time.test.ts
@@ -1,0 +1,21 @@
+import { calculatePeriod } from "./time";
+
+describe("Test calculatePeriod", () => {
+  it("calculatePeriod given due date of 01/01/2022", () => {
+    const dueDate = Date.parse("01/01/2022");
+    const period = "1";
+    expect(calculatePeriod(dueDate)).toBe(period);
+  });
+
+  it("calculatePeriod given due date of 10/01/2022", () => {
+    const dueDate = Date.parse("10/01/2022");
+    const period = "2";
+    expect(calculatePeriod(dueDate)).toBe(period);
+  });
+
+  it("calculatePeriod given due date of 04/01/2023", () => {
+    const dueDate = Date.parse("04/01/2023");
+    const period = "1";
+    expect(calculatePeriod(dueDate)).toBe(period);
+  });
+});

--- a/services/app-api/utils/time/time.ts
+++ b/services/app-api/utils/time/time.ts
@@ -20,6 +20,18 @@ export const convertDateUtcToEt = (date: number): string => {
 };
 
 /*
+ * Calculates the period given a due date.
+ * The periods are defined as follows:
+ *     Period 1 is from 01/01 to 06/30.
+ *     Period 2 is from 07/01 to 12/31.
+ */
+export const calculatePeriod = (dueDate: number) => {
+  const date = new Date(dueDate);
+  const period = Math.ceil((date.getMonth() + 1) / 6);
+  return period.toString();
+};
+
+/*
  * This code ensures the date has a preceeding 0 if the month/day is a single digit.
  * Ex: 7 becomes 07 while 10 stays 10
  */

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -157,6 +157,7 @@ export interface WPReportMetadata extends ReportMetadata {
   submissionName: string;
   locked: boolean;
   submissionCount: number;
+  reportPeriod: number;
   previousRevisions: string[];
 }
 

--- a/services/app-api/utils/validation/schemas.ts
+++ b/services/app-api/utils/validation/schemas.ts
@@ -2,6 +2,7 @@ import * as yup from "yup";
 
 export const metadataValidationSchema = yup.object().shape({
   submissionName: yup.string(),
+  reportPeriod: yup.number(),
   reportType: yup.string(),
   locked: yup.bool(),
   status: yup.string(),

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -64,7 +64,6 @@ export const AddEditReportModal = ({
         lastAlteredBy: full_name,
       },
       fieldData: {
-        submissionName,
         ["targetPopulation"]: targetPopulation,
       },
     };
@@ -73,7 +72,7 @@ export const AddEditReportModal = ({
   // SAR report payload
   const prepareSarPayload = (formData: any) => {
     const submissionName = formData["submissionName"];
-
+    const reportPeriod = formData["reportPeriod"];
     return {
       metadata: {
         submissionName: submissionName,
@@ -84,6 +83,7 @@ export const AddEditReportModal = ({
       },
       fieldData: {
         submissionName,
+        reportPeriod,
       },
     };
   };
@@ -92,7 +92,6 @@ export const AddEditReportModal = ({
     setSubmitting(true);
     const submitButton = document.querySelector("[form=" + form.id + "]");
     submitButton?.setAttribute("disabled", "true");
-
     const dataToWrite =
       reportType === "WP" ? prepareWpPayload() : prepareSarPayload(formData);
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -126,9 +126,6 @@ export const DashboardPage = ({ reportType }: Props) => {
         submittedOnDate = convertDateUtcToEt(report.submittedOnDate);
       }
       formData = {
-        fieldData: {
-          submissionName: report.submissionName,
-        },
         state: report.state,
         id: report.id,
         submittedBy: report.submittedBy,

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -8,8 +8,7 @@ import {
   ReportType,
   TableContentShape,
 } from "types";
-import { calculatePeriod, convertDateUtcToEt } from "utils";
-import { States } from "../../../constants";
+import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
 
@@ -43,7 +42,7 @@ export const DashboardTable = ({
           <Td></Td>
         )}
         {/* Report Name */}
-        <Td sx={sxOverride.submissionNameText}>{getReportName(report)}</Td>
+        <Td sx={sxOverride.submissionNameText}>{report.submissionName}</Td>
         {/* Date Fields */}
         <DateFields report={report} reportType={reportType} />
         {/* Last Altered By */}
@@ -123,16 +122,6 @@ interface DashboardTableProps {
   releasing?: boolean | undefined;
   sxOverride: AnyObject;
 }
-
-const getReportName = (report: ReportMetadataShape) => {
-  const reportName = report.submissionName;
-  const etDate = convertDateUtcToEt(report.createdAt);
-  const period = calculatePeriod(etDate);
-  const year = new Date(etDate).getFullYear();
-
-  const fullStateName = States[report.state as keyof typeof States];
-  return `${fullStateName} ${reportName} ${year} - Period ${period}`;
-};
 
 export const getStatus = (
   reportType: ReportType,

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -22,6 +22,7 @@ export interface ReportMetadataShape extends ReportKeys {
   archived?: boolean;
   locked?: boolean;
   dueDate: number;
+  reportPeriod: number;
 }
 
 export interface ReportShape extends ReportMetadataShape {

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -1,6 +1,5 @@
 import {
   calculateDueDate,
-  calculatePeriod,
   calculateRemainingSeconds,
   calculateTimeByType,
   checkDateRangeStatus,
@@ -132,25 +131,5 @@ describe("Test calculateTimeLeft", () => {
   it("something else", () => {
     const expirationTime = "2050-11-18T12:53:11-05:00";
     expect(calculateRemainingSeconds(expirationTime)).toBeGreaterThan(0);
-  });
-});
-
-describe("Test calculatePeriod", () => {
-  it("calculatePeriod given due date of 01/01/2022", () => {
-    const dueDate = "01/01/2022";
-    const period = "1";
-    expect(calculatePeriod(dueDate)).toBe(period);
-  });
-
-  it("calculatePeriod given due date of 10/01/2022", () => {
-    const dueDate = "10/01/2022";
-    const period = "2";
-    expect(calculatePeriod(dueDate)).toBe(period);
-  });
-
-  it("calculatePeriod given due date of 04/01/2023", () => {
-    const dueDate = "04/01/2023";
-    const period = "1";
-    expect(calculatePeriod(dueDate)).toBe(period);
   });
 });

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -142,18 +142,6 @@ export const checkDateRangeStatus = (
 };
 
 /*
- * Calculates the period given a due date.
- * The periods are defined as follows:
- *     Period 1 is from 01/01 to 06/30.
- *     Period 2 is from 07/01 to 12/31.
- */
-export const calculatePeriod = (dueDate: string) => {
-  const dueDateAsDate = new Date(dueDate);
-  const period = Math.ceil((dueDateAsDate.getMonth() + 1) / 6);
-  return period.toString();
-};
-
-/*
  * Converts a date string to UTC + 180 days
  * returns -> UTC datetime in format 'ms since Unix epoch'
  * Ex: 6/30/22 Becomes 1483603200000

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -1052,6 +1052,7 @@ export const reportShape: ReportShape = {
     submissionName: "test",
     stateName: "Minnesota",
   },
+  reportPeriod: 1,
 };
 
 export const reportByState = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -96,6 +96,7 @@ export const mockWPFullReport = {
     },
   },
   isComplete: false,
+  reportPeriod: 1,
 };
 
 export const mockReportsByState = [


### PR DESCRIPTION
### Description
This change 
1. sets the report name and the submission name in the `create` API
2. removes the `submission name` from the `fieldData`
3. moves the logic of setting the report name from the frontend to the backend (i.e. moved calculating the period and constructing the submission name into `app-api`)


https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/ac2a2525-f09e-40a2-88f5-3cfa74105948




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-3025

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Log in as a state user
2. Create a WP
3. Check the Network tab. Validate that the `reportPeriod` and `submissionName` are included as metadata in the response

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/cd6ab38a-01e4-4109-b5ce-87575aec609d



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
