### PR TITLE
Mdct 2992 - static text for admin dashboard instructions

### DIFF
--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -1,0 +1,110 @@
+import { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+// components
+import { Box, Button, Flex, Heading } from "@chakra-ui/react";
+import { Form, ReportContext } from "components";
+// types
+import { AnyObject, FormJson, InputChangeEvent } from "types";
+// form
+import formJson from "forms/adminDashSelector/adminDashSelector";
+// utils
+import { useStore } from "utils";
+
+export const AdminDashSelector = ({ verbiage }: Props) => {
+  const { clearReportSelection } = useContext(ReportContext);
+  const { reportsByState } = useStore();
+
+  const navigate = useNavigate();
+  const [reportSelected, setReportSelected] = useState<boolean>(false);
+
+  const { userIsAdmin } = useStore().user ?? {};
+
+  // create radio options
+  const reportChoices = [
+    {
+      id: "WP",
+      label: "Work Plan",
+    },
+  ];
+  const reportChoice = {
+    id: "SAR",
+    label: "...",
+  };
+
+  // assemble and inject report choices depending on whether report is enabled
+  const workPlan = true;
+  if (workPlan) {
+    reportChoices.push(reportChoice);
+  }
+  const reportField = formJson.fields.find((field) => field.id === "report")!;
+  reportField.props.choices = reportChoices;
+
+  // add validation to formJson
+  const form: FormJson = formJson;
+
+  useEffect(() => {
+    if (reportsByState) {
+      clearReportSelection();
+    }
+  }, []);
+
+  const onChange = (event: InputChangeEvent) => {
+    if (event.target.name === "report") {
+      setReportSelected(true);
+    }
+  };
+
+  const onSubmit = (formData: AnyObject) => {
+    let selectedReport = formData["report"][0].key;
+    selectedReport = selectedReport.replace("report-", "").toLowerCase();
+    localStorage.setItem("selectedReportType", selectedReport);
+
+    if (userIsAdmin) {
+      const selectedState = formData["state"].value;
+      localStorage.setItem("selectedState", selectedState);
+    }
+
+    navigate(`/${selectedReport}`);
+  };
+
+  return (
+    <Box sx={sx.root} data-testid="read-only-view">
+      <Heading as="h1" sx={sx.headerText}>
+        {verbiage.header}
+      </Heading>
+      <Form
+        id={form.id}
+        formJson={form}
+        onSubmit={onSubmit}
+        onChange={onChange}
+        validateOnRender={false}
+        dontReset={false}
+      />
+      <Flex sx={sx.navigationButton}>
+        <Button type="submit" form={formJson.id} isDisabled={!reportSelected}>
+          {verbiage.buttonLabel}
+        </Button>
+      </Flex>
+    </Box>
+  );
+};
+
+interface Props {
+  verbiage: AnyObject;
+}
+
+const sx = {
+  root: {
+    ".ds-c-field__hint": {
+      fontSize: "md",
+      color: "palette.base",
+    },
+  },
+  headerText: {
+    fontSize: "2rem",
+    fontWeight: "normal",
+  },
+  navigationButton: {
+    padding: "1.5rem 0 2rem 0",
+  },
+};

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -41,6 +41,7 @@ export { NumberField } from "./fields/NumberField";
 // forms
 export { AdminBannerForm } from "./forms/AdminBannerForm";
 export { Form } from "./forms/Form";
+export { AdminDashSelector } from "./forms/AdminDashSelector";
 // layout
 export { Footer } from "./layout/Footer";
 export { Header } from "./layout/Header";

--- a/services/ui-src/src/components/pages/Home/HomePage.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.tsx
@@ -1,7 +1,12 @@
 import { useFlags } from "launchdarkly-react-client-sdk";
 // components
 import { Box, Collapse, Heading, Link, Text } from "@chakra-ui/react";
-import { Banner, PageTemplate, TemplateCard } from "components";
+import {
+  AdminDashSelector,
+  Banner,
+  PageTemplate,
+  TemplateCard,
+} from "components";
 // utils
 import verbiage from "verbiage/pages/home";
 import { useEffect } from "react";
@@ -9,6 +14,7 @@ import { checkDateRangeStatus, useStore } from "utils";
 
 export const HomePage = () => {
   const { bannerData, bannerActive, setBannerActive } = useStore();
+  const { userIsEndUser } = useStore().user ?? {};
 
   useEffect(() => {
     let bannerActivity = false;
@@ -34,31 +40,37 @@ export const HomePage = () => {
         <Banner bannerData={bannerData} />
       </Collapse>
       <PageTemplate sx={sx.layout} data-testid="home-view">
-        <Box sx={sx.introTextBox}>
-          <Heading as="h1" sx={sx.headerText}>
-            {intro.header}
-          </Heading>
-          <Text>
-            {intro.body.preLinkText}
-            <Link href={intro.body.linkLocation} isExternal>
-              {intro.body.linkText}
-            </Link>
-            {intro.body.postLinkText}
-          </Text>
-          <Text></Text>
-        </Box>
-        <TemplateCard
-          templateName="WP"
-          verbiage={cards.WP}
-          cardprops={sx.card}
-          isHidden={!wpReport}
-        />
-        <TemplateCard
-          templateName="SAR"
-          verbiage={cards.SAR}
-          cardprops={sx.card}
-          isHidden={!sarReport}
-        />
+        {userIsEndUser ? (
+          <>
+            <Box sx={sx.introTextBox}>
+              <Heading as="h1" sx={sx.headerText}>
+                {intro.header}
+              </Heading>
+              <Text>
+                {intro.body.preLinkText}
+                <Link href={intro.body.linkLocation} isExternal>
+                  {intro.body.linkText}
+                </Link>
+                {intro.body.postLinkText}
+              </Text>
+              <Text></Text>
+            </Box>
+            <TemplateCard
+              templateName="WP"
+              verbiage={cards.WP}
+              cardprops={sx.card}
+              isHidden={!wpReport}
+            />
+            <TemplateCard
+              templateName="SAR"
+              verbiage={cards.SAR}
+              cardprops={sx.card}
+              isHidden={!sarReport}
+            />
+          </>
+        ) : (
+          <AdminDashSelector verbiage={verbiage.readOnly} />
+        )}
       </PageTemplate>
     </>
   );

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -52,7 +52,7 @@ export default {
         "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission. The status will change to “In revision”.",
         "Submission count is shown in the # column. Submissions started and submitted once have a count of 1. When a state resubmits a previous submission, the count increases by 1.",
         "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”.",
-        "To approve a submission, review the submission, go to the Review & Submit page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR.",
+        "To approve a submission, review the submission, go to the Review & Submit page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR and will be available for view-only reference.",
       ],
       text: "",
     },

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -6,53 +6,7 @@ export default {
         {
           type: "text",
           as: "header",
-          content: "State or Territory User Instructions",
-        },
-        {
-          type: "text",
-          as: "span",
-          content:
-            "This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
-        },
-        {
-          type: "externalLink",
-          content: "User Guide",
-          props: {
-            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-            target: "_blank",
-            ariaLabel: "Link opens in new tab",
-          },
-        },
-        {
-          type: "text",
-          as: "span",
-          content: " and ",
-        },
-        {
-          type: "externalLink",
-          content: "Help File",
-          props: {
-            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-            target: "_blank",
-            ariaLabel: "Link opens in new tab",
-          },
-        },
-        {
-          type: "text",
-          as: "span",
-          content: ".",
-        },
-      ],
-      list: [],
-      text: "",
-    },
-    stateUserDashboard: {
-      buttonLabel: "Instructions",
-      intro: [
-        {
-          type: "text",
-          as: "span",
-          content: "<strong>State or Territory User Instructions</strong><br>",
+          content: "<strong>State or Territory User Instructions<strong>",
         },
         {
           type: "text",
@@ -100,6 +54,47 @@ export default {
         "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”.",
         "To approve a submission, review the submission, go to the Review & Submit page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR.",
       ],
+      text: "",
+    },
+    stateUserDashboard: {
+      buttonLabel: "Instructions",
+      intro: [
+        {
+          type: "text",
+          as: "span",
+          content:
+            "This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
+        },
+        {
+          type: "externalLink",
+          content: "User Guide",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+            target: "_blank",
+            ariaLabel: "Link opens in new tab",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: " and ",
+        },
+        {
+          type: "externalLink",
+          content: "Help File",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+            target: "_blank",
+            ariaLabel: "Link opens in new tab",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: ".<br>",
+        },
+      ],
+      list: [],
       text: "",
     },
     formIntro: {

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -5,6 +5,11 @@ export default {
       intro: [
         {
           type: "text",
+          as: "header",
+          content: "State or Territory User Instructions",
+        },
+        {
+          type: "text",
           as: "span",
           content:
             "This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
@@ -47,8 +52,13 @@ export default {
         {
           type: "text",
           as: "span",
+          content: "<strong>State or Territory User Instructions</strong><br>",
+        },
+        {
+          type: "text",
+          as: "span",
           content:
-            "This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
+            "<br>This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
         },
         {
           type: "externalLink",
@@ -76,10 +86,20 @@ export default {
         {
           type: "text",
           as: "span",
-          content: ".",
+          content: ".<br>",
+        },
+        {
+          type: "text",
+          as: "span",
+          content: "<br><strong>Admin Instructions</strong>",
         },
       ],
-      list: [],
+      list: [
+        "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission. The status will change to “In revision”.",
+        "Submission count is shown in the # column. Submissions started and submitted once have a count of 1. When a state resubmits a previous submission, the count increases by 1.",
+        "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”.",
+        "To approve a submission, review the submission, go to the Review & Submit page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR.",
+      ],
       text: "",
     },
     formIntro: {


### PR DESCRIPTION
### Description
This PR is to add the admin dashboard instructions:
![Screenshot 2023-10-04 at 2 53 50 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/7183727c-07d6-4691-9f58-5590429f0146)

But in order to show up I had to add the `AdminDashSelector` component from MFP and modify it a little for MFP so the user can select a state. I can remove that file and associated code after this is reviewed.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2992

---
### How to test
Login as an admin user, select a state, expand the `instructions` accordion and see the text matches the spec; login as a state user and see the instructions are unchanged.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
