### PR TITLE
clean up admin dashboard first page

### DIFF
--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -17,28 +17,6 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
   const navigate = useNavigate();
   const [reportSelected, setReportSelected] = useState<boolean>(false);
 
-  const { userIsAdmin } = useStore().user ?? {};
-
-  // create radio options
-  const reportChoices = [
-    {
-      id: "WP",
-      label: "Work Plan",
-    },
-  ];
-  const reportChoice = {
-    id: "SAR",
-    label: "...",
-  };
-
-  // assemble and inject report choices depending on whether report is enabled
-  const workPlan = true;
-  if (workPlan) {
-    reportChoices.push(reportChoice);
-  }
-  const reportField = formJson.fields.find((field) => field.id === "report")!;
-  reportField.props.choices = reportChoices;
-
   // add validation to formJson
   const form: FormJson = formJson;
 
@@ -58,12 +36,8 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
     let selectedReport = formData["report"][0].key;
     selectedReport = selectedReport.replace("report-", "").toLowerCase();
     localStorage.setItem("selectedReportType", selectedReport);
-
-    if (userIsAdmin) {
-      const selectedState = formData["state"].value;
-      localStorage.setItem("selectedState", selectedState);
-    }
-
+    const selectedState = formData["state"].value;
+    localStorage.setItem("selectedState", selectedState);
     navigate(`/${selectedReport}`);
   };
 

--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -9,10 +9,15 @@ const dropdownOptions: DropdownOptions[] = Object.keys(States).map((value) => {
   };
 });
 
+// create radio options
 const reportChoices = [
   {
     id: "WP",
-    label: "MFP Program Work Plan (WP)",
+    label: "Work Plan (WP)",
+  },
+  {
+    id: "SAR",
+    label: "Semi-Annual Report (SAR)",
   },
 ];
 
@@ -28,7 +33,7 @@ export default {
       type: "dropdown",
       validation: "dropdown",
       props: {
-        hint: "Select state to view reports:",
+        hint: "Select state or territory:",
         options: dropdownOptions,
         ariaLabel:
           "List of states, including District of Columbia and Puerto Rico",

--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -50,7 +50,7 @@ export default {
     },
   },
   readOnly: {
-    header: "View State Reports",
+    header: "View State/Territory Reports",
     buttonLabel: "Go to Report Dashboard",
   },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
clean up the AdminDashboardSelector files .
Admin user should be able to select the state and report they would like to view. This shouldn't change the State User's experience.

<img width="1453" alt="Screenshot 2023-10-05 at 2 41 46 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/45506768-fb16-4607-aaec-a9c01265423f">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2991

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- log in as an admin, you should be redirected to this selection page
- upon selecting a report, the button becomes enabled (following the pattern of MCR)
- if button is clicked before selecting a state, the validation msg is show asking the admin to select a state
- once a state and a report is selected, you should be brought to that specific dashboard


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
