### PR TITLE
make choice list fields correctly hydrate when re-opening a modal or drawer

### DIFF
--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -1,4 +1,3 @@
-import { MouseEventHandler } from "react";
 // components
 import {
   Button,
@@ -45,7 +44,7 @@ export const Drawer = ({
             sx={sx.drawerCloseButton}
             leftIcon={<CloseIcon />}
             variant="link"
-            onClick={onClose as MouseEventHandler}
+            onClick={onClose}
           >
             Close
           </Button>
@@ -64,7 +63,7 @@ interface Props {
   };
   drawerDisclosure: {
     isOpen: boolean;
-    onClose: Function;
+    onClose: any;
   };
   selectedEntity?: string;
   [key: string]: any;

--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -10,6 +10,7 @@ import {
   Box,
 } from "@chakra-ui/react";
 import { CloseIcon } from "@cmsgov/design-system";
+import { MouseEventHandler } from "react";
 // utils
 import { AnyObject, CustomHtmlElement } from "types";
 import { makeMediaQueryClasses, parseCustomHtml } from "utils";
@@ -44,7 +45,7 @@ export const Drawer = ({
             sx={sx.drawerCloseButton}
             leftIcon={<CloseIcon />}
             variant="link"
-            onClick={onClose}
+            onClick={onClose as MouseEventHandler}
           >
             Close
           </Button>
@@ -63,7 +64,7 @@ interface Props {
   };
   drawerDisclosure: {
     isOpen: boolean;
-    onClose: any;
+    onClose: Function;
   };
   selectedEntity?: string;
   [key: string]: any;

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -13,6 +13,7 @@ import {
 } from "types";
 // constants
 import { closeText, saveAndCloseText } from "../../constants";
+import { MouseEventHandler } from "react";
 
 export const ReportDrawer = ({
   entityType,
@@ -52,7 +53,10 @@ export const ReportDrawer = ({
       <Box sx={sx.footerBox}>
         <Flex sx={sx.buttonFlex}>
           {(!userIsAdmin || !userIsReadOnly) && (
-            <Button variant="outline" onClick={drawerDisclosure.onClose}>
+            <Button
+              variant="outline"
+              onClick={drawerDisclosure.onClose as MouseEventHandler}
+            >
               Cancel
             </Button>
           )}
@@ -84,7 +88,7 @@ interface Props {
   submitting?: boolean;
   drawerDisclosure: {
     isOpen: boolean;
-    onClose: any;
+    onClose: Function;
   };
   validateOnRender?: boolean;
 }

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -1,4 +1,3 @@
-import { MouseEventHandler } from "react";
 // Components
 import { Box, Button, Flex, Text, Spinner } from "@chakra-ui/react";
 import { Drawer, Form } from "components";
@@ -53,10 +52,7 @@ export const ReportDrawer = ({
       <Box sx={sx.footerBox}>
         <Flex sx={sx.buttonFlex}>
           {(!userIsAdmin || !userIsReadOnly) && (
-            <Button
-              variant="outline"
-              onClick={drawerDisclosure.onClose as MouseEventHandler}
-            >
+            <Button variant="outline" onClick={drawerDisclosure.onClose}>
               Cancel
             </Button>
           )}
@@ -88,7 +84,7 @@ interface Props {
   submitting?: boolean;
   drawerDisclosure: {
     isOpen: boolean;
-    onClose: Function;
+    onClose: any;
   };
   validateOnRender?: boolean;
 }

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -39,6 +39,7 @@ import {
   getEntriesToClear,
   setClearedEntriesToDefaultValue,
   entityWasUpdated,
+  resetClearProp,
 } from "utils";
 
 export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
@@ -113,6 +114,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeDrawer = () => {
     setSelectedEntity(undefined);
+    resetClearProp(drawerForm.fields);
     drawerOnCloseHandler();
   };
 

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -29,6 +29,7 @@ import {
   entityWasUpdated,
   filterFormData,
   getEntriesToClear,
+  resetClearProp,
   setClearedEntriesToDefaultValue,
   useBreakpoint,
   useStore,
@@ -103,6 +104,7 @@ export const ModalOverlayReportPage = ({
 
   const closeAddEditEntityModal = () => {
     setCurrentEntity(undefined);
+    resetClearProp(modalForm.fields);
     addEditEntityModalOnCloseHandler();
   };
 

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -20,7 +20,7 @@ import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 // types
 import { EntityShape, OverlayModalPageShape } from "types";
 // utils
-import { getFormattedEntityData, useStore } from "utils";
+import { getFormattedEntityData, resetClearProp, useStore } from "utils";
 
 export const OverlayModalPage = ({
   entity,
@@ -82,6 +82,7 @@ export const OverlayModalPage = ({
 
   const openDeleteEntityModal = (entity?: EntityShape) => {
     setSelectedEntity(entity);
+    resetClearProp(modalForm.fields);
     deleteEntityModalOnOpenHandler();
   };
 

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -19,6 +19,7 @@ import { DateField } from "components/fields/DateField";
 import { DropdownField } from "components/fields/DropdownField";
 import { DynamicField } from "components/fields/DynamicField";
 import { NumberField } from "components/fields/NumberField";
+import { ChoiceList } from "@cmsgov/design-system";
 
 // return created elements from provided fields
 export const formFieldFactory = (

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -252,3 +252,28 @@ export const getRepeatableChoiceLists = (
     return fields;
   }
 };
+
+/*
+ * This function resets the 'clear' prop on each field after a ChoiceListField calls
+ * clearUncheckedNestedFields(). Upon re-entering a drawer or modal, the field values will
+ * be correctly hydrated.
+ */
+export const resetClearProp = (fields: (FormField | FormLayoutElement)[]) => {
+  fields.forEach((field: FormField | FormLayoutElement) => {
+    switch (field.type) {
+      case "radio":
+      case "checkbox":
+        field.props?.choices.forEach((childField: FieldChoice) => {
+          if (childField?.children) {
+            resetClearProp(childField.children);
+          }
+        });
+        field.props = { ...field.props, clear: false };
+        resetClearProp(field.props?.choices);
+        break;
+      default:
+        field.props = { ...field.props, clear: false };
+        break;
+    }
+  });
+};


### PR DESCRIPTION
### Description
The nested fields in our choice lists weren't correctly hydrating when a user selected a different radio option, exited the modal or drawer, and then re-entered it. This code fixes that issue. It's not pretty but the plan is to let Zustand take care of state management issues like these so this code won't be around long-term.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
[CMDCT-2](https://jiraent.cms.gov/browse/CMDCT-2)

---
### How to test
Go into a drawer that has radio options (like the initiatives). 
1. See that it saves correctly and hydrates correctly when you re-enter
2. Choose a different selection, go back to the original selection, see that all data has been cleared out.
Don't save, just exit. Re-enter and see that the original saved selection has correctly hydrated.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
