### PR TITLE
CMDCT-159 UI tests (FaqAccordion and DashboardPage)

### DIFF
--- a/services/ui-src/src/components/accordions/FaqAccordion.test.tsx
+++ b/services/ui-src/src/components/accordions/FaqAccordion.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
+// utils
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+// components
+import { FaqAccordion } from "components";
+
+const accordionItems = [
+  {
+    question: "Question?",
+    answer: "Answer!",
+  },
+];
+
+const faqAccordionComponent = (
+  <RouterWrappedComponent>
+    <FaqAccordion accordionItems={accordionItems} />
+  </RouterWrappedComponent>
+);
+
+describe("Test FaqAccordion", () => {
+  beforeEach(() => {
+    render(faqAccordionComponent);
+  });
+
+  test("FaqAccordion is visible", () => {
+    expect(screen.getByText(accordionItems[0].question)).toBeVisible();
+  });
+
+  test("FaqAccordion default closed state only shows the question", () => {
+    expect(screen.getByText(accordionItems[0].question)).toBeVisible();
+    expect(screen.getByText(accordionItems[0].answer)).not.toBeVisible();
+  });
+
+  test("FaqAccordion should show answer on click", async () => {
+    const faqQuestion = screen.getByText(accordionItems[0].question);
+    expect(faqQuestion).toBeVisible();
+    expect(screen.getByText(accordionItems[0].answer)).not.toBeVisible();
+    await userEvent.click(faqQuestion);
+    expect(faqQuestion).toBeVisible();
+    expect(screen.getByText(accordionItems[0].answer)).toBeVisible();
+  });
+});
+
+describe("Test FaqAccordion accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(faqAccordionComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -114,7 +114,7 @@ describe("Test Report Dashboard view (Desktop)", () => {
     expect(screen.queryByText("Start new")).toBeVisible();
   });
 
-  test("Check that the SAR Dashboard view renders", async () => {
+  test("Check that the SAR Dashboard view renders", () => {
     mockedUseStore.mockReturnValue(mockReportStore);
     render(sarDashboardViewWithReports);
     expect(screen.getByText(sarVerbiage.intro.header)).toBeVisible();
@@ -127,7 +127,7 @@ describe("Test Report Dashboard view (Desktop)", () => {
 });
 
 describe("Test Report Dashboard with no reports", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     mockedUseUser.mockReturnValue(mockStateUser);
     mockedUseStore.mockReturnValue({
       reportsByState: undefined,
@@ -142,12 +142,12 @@ describe("Test Report Dashboard with no reports", () => {
     jest.clearAllMocks();
   });
 
-  test("WP Dashboard renders table with empty text", async () => {
+  test("WP Dashboard renders table with empty text", () => {
     render(wpDashboardWithNoReports);
     expect(screen.getByText(wpVerbiage.body.empty)).toBeVisible();
   });
 
-  test("SAR Dashboard renders table with empty text", async () => {
+  test("SAR Dashboard renders table with empty text", () => {
     render(sarDashboardWithNoReports);
     expect(screen.getByText(sarVerbiage.body.empty)).toBeVisible();
   });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -143,16 +143,12 @@ describe("Test Report Dashboard with no reports", () => {
   });
 
   test("WP Dashboard renders table with empty text", async () => {
-    await act(async () => {
-      await render(wpDashboardWithNoReports);
-    });
+    render(wpDashboardWithNoReports);
     expect(screen.getByText(wpVerbiage.body.empty)).toBeVisible();
   });
 
   test("SAR Dashboard renders table with empty text", async () => {
-    await act(async () => {
-      await render(sarDashboardWithNoReports);
-    });
+    render(sarDashboardWithNoReports);
     expect(screen.getByText(sarVerbiage.body.empty)).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -7,9 +7,12 @@ import { mockStateUser } from "utils/testing/mockUsers";
 import {
   mockDashboardReportContext,
   mockReportContextNoReports,
+  mockWpReportContext,
 } from "utils/testing/mockReport";
 import {
   mockReportStore,
+  mockUseAdminStore,
+  mockUseStore,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { useBreakpoint, useStore, makeMediaQueryClasses } from "utils";
@@ -18,6 +21,8 @@ import { ReportType } from "types";
 // verbiage
 import wpVerbiage from "verbiage/pages/wp/wp-dashboard";
 import sarVerbiage from "verbiage/pages/sar/sar-dashboard";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
@@ -43,17 +48,17 @@ jest.mock("react-router-dom", () => ({
   })),
 }));
 
-const wpDashboardWithNoReports = (
+const dashboardViewWithReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContextNoReports}>
+    <ReportContext.Provider value={mockDashboardReportContext}>
       <DashboardPage reportType={ReportType.WP} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-const wpDashboardViewWithReports = (
+const wpDashboardWithNoReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockDashboardReportContext}>
+    <ReportContext.Provider value={mockReportContextNoReports}>
       <DashboardPage reportType={ReportType.WP} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -74,6 +79,52 @@ const sarDashboardViewWithReports = (
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
+
+describe("Test Report Dashboard view (Desktop)", () => {
+  beforeEach(() => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    mockUseBreakpoint.mockReturnValue({
+      isMobile: false,
+    });
+    mockMakeMediaQueryClasses.mockReturnValue("desktop");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Check that WP Dashboard view renders", () => {
+    mockedUseStore.mockReturnValue(mockReportStore);
+    render(dashboardViewWithReports);
+
+    expect(screen.getByText(wpVerbiage.intro.header)).toBeVisible();
+    expect(
+      screen.queryByText(wpVerbiage.body.table.caption)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(wpVerbiage.body.empty)).not.toBeInTheDocument();
+    expect(screen.queryByText("Leave form")).not.toBeInTheDocument();
+  });
+
+  test("Clicking Call To Action text open add/edit modal", async () => {
+    mockedUseStore.mockReturnValue(mockUseStore);
+    render(dashboardViewWithReports);
+    const callToActionButton = screen.getByText(wpVerbiage.body.callToAction);
+    expect(callToActionButton).toBeVisible();
+    await userEvent.click(callToActionButton);
+    expect(screen.queryByText("Start new")).toBeVisible();
+  });
+
+  test("Check that the SAR Dashboard view renders", async () => {
+    mockedUseStore.mockReturnValue(mockReportStore);
+    render(sarDashboardViewWithReports);
+    expect(screen.getByText(sarVerbiage.intro.header)).toBeVisible();
+    expect(
+      screen.queryByText(sarVerbiage.body.table.caption)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(sarVerbiage.body.empty)).not.toBeInTheDocument();
+    expect(screen.queryByText("Leave form")).not.toBeInTheDocument();
+  });
+});
 
 describe("Test Report Dashboard with no reports", () => {
   beforeEach(async () => {
@@ -106,75 +157,118 @@ describe("Test Report Dashboard with no reports", () => {
   });
 });
 
-describe("Test Report Dashboard view (with reports, desktop view)", () => {
+describe("Test Report Dashboard (Mobile)", () => {
   beforeEach(() => {
-    mockedUseUser.mockReturnValue(mockStateUser);
-    mockUseBreakpoint.mockReturnValue({
-      isMobile: false,
-    });
-    mockMakeMediaQueryClasses.mockReturnValue("desktop");
-    mockedUseStore.mockReturnValue(mockReportStore);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test("Check that WP Dashboard view renders", async () => {
-    await act(async () => {
-      await render(wpDashboardViewWithReports);
-    });
-    expect(screen.getByText(wpVerbiage.intro.header)).toBeVisible();
-    expect(
-      screen.queryByText(wpVerbiage.body.table.caption)
-    ).toBeInTheDocument();
-    expect(screen.queryByText(wpVerbiage.body.empty)).not.toBeInTheDocument();
-    expect(screen.queryByText("Leave form")).not.toBeInTheDocument();
-  });
-
-  /* SAR Tests */
-  test("Check that the SAR Dashboard view renders", async () => {
-    await act(async () => {
-      await render(sarDashboardViewWithReports);
-    });
-    expect(screen.getByText(sarVerbiage.intro.header)).toBeVisible();
-    expect(
-      screen.queryByText(sarVerbiage.body.table.caption)
-    ).toBeInTheDocument();
-    expect(screen.queryByText(sarVerbiage.body.empty)).not.toBeInTheDocument();
-    expect(screen.queryByText("Leave form")).not.toBeInTheDocument();
-  });
-});
-
-describe("Test Report Dashboard view (with reports, mobile view)", () => {
-  beforeEach(async () => {
-    mockedUseUser.mockReturnValue(mockStateUser);
     mockUseBreakpoint.mockReturnValue({
       isMobile: true,
     });
-    mockedUseStore.mockReturnValue(mockReportStore);
-    mockMakeMediaQueryClasses.mockReturnValue("mobile");
+    mockedUseStore.mockReturnValue(mockUseStore);
+  });
+
+  test("Clicking Call To Action text open add/edit modal", async () => {
+    render(dashboardViewWithReports);
+    const callToActionButton = screen.getByText(wpVerbiage.body.callToAction);
+    expect(callToActionButton).toBeVisible();
+    await userEvent.click(callToActionButton);
+    expect(screen.queryByText("Start new")).toBeVisible();
+  });
+});
+
+describe("Test WP Admin Report Dashboard View (with reports, desktop view, mobile view)", () => {
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockUseAdminStore);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("WP Dashboard view renders", async () => {
-    await act(async () => {
-      await render(wpDashboardViewWithReports);
+  describe("Desktop view", () => {
+    beforeEach(() => {
+      mockUseBreakpoint.mockReturnValue({
+        isMobile: false,
+      });
+      mockMakeMediaQueryClasses.mockReturnValue("desktop");
+      render(dashboardViewWithReports);
     });
-    expect(screen.getByText(wpVerbiage.intro.header)).toBeVisible();
-    expect(screen.getAllByTestId("mobile-row")[0]).toBeVisible();
-    expect(screen.queryByText(wpVerbiage.body.empty)).not.toBeInTheDocument();
+
+    test("Check that Admin WP Dashboard view renders", () => {
+      expect(screen.getByText(wpVerbiage.intro.header)).toBeVisible();
+      expect(
+        screen.queryByText(wpVerbiage.body.table.caption)
+      ).toBeInTheDocument();
+      expect(screen.queryByText(wpVerbiage.body.empty)).not.toBeInTheDocument();
+    });
+
+    test("Clicking a disabled 'Unlock' button no modal opens", async () => {
+      const unlockButton = screen.getAllByText("Unlock")[0];
+      expect(unlockButton).toBeVisible();
+      await userEvent.click(unlockButton);
+
+      expect(
+        screen.queryByText(wpVerbiage.modalUnlock.actionButtonText)
+      ).not.toBeInTheDocument();
+    });
+
+    test("Clicking 'Unlock' button opens the unlock modal", async () => {
+      const unlockButton = screen.getAllByText("Unlock")[1];
+      expect(unlockButton).toBeVisible();
+      await userEvent.click(unlockButton);
+      await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
+      // once for render, once for release
+      await expect(
+        mockWpReportContext.fetchReportsByState
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    test("Clicking 'Archive' button will archive the form", async () => {
+      const archiveButton = screen.getAllByText("Archive")[1];
+      expect(archiveButton).toBeVisible();
+      await userEvent.click(archiveButton);
+      await expect(mockWpReportContext.archiveReport).toHaveBeenCalledTimes(1);
+      // once for render, once for archive
+      await expect(
+        mockWpReportContext.fetchReportsByState
+      ).toHaveBeenCalledTimes(2);
+    });
   });
 
-  test("SAR Dashboard view renders", async () => {
-    await act(async () => {
-      await render(sarDashboardViewWithReports);
+  describe("Mobile view", () => {
+    beforeEach(() => {
+      mockUseBreakpoint.mockReturnValue({
+        isMobile: true,
+      });
+      render(dashboardViewWithReports);
     });
-    expect(screen.getByText(sarVerbiage.intro.header)).toBeVisible();
-    expect(screen.getAllByTestId("mobile-row")[0]).toBeVisible();
-    expect(screen.queryByText(sarVerbiage.body.empty)).not.toBeInTheDocument();
+    it("Should not have basic accessibility issues (mobile)", async () => {
+      mockMakeMediaQueryClasses.mockReturnValue("mobile");
+      await act(async () => {
+        const { container } = render(dashboardViewWithReports);
+        const results = await axe(container);
+        expect(results).toHaveNoViolations();
+      });
+    });
+
+    test("Clicking 'Unlock' button opens the unlock modal", async () => {
+      const unlockButton = screen.getAllByText("Unlock")[1];
+      expect(unlockButton).toBeVisible();
+      await userEvent.click(unlockButton);
+      await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
+      // once for render, once for release
+      await expect(
+        mockWpReportContext.fetchReportsByState
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    test("Clicking 'Archive' button will archive the form", async () => {
+      const archiveButton = screen.getAllByText("Archive")[1];
+      expect(archiveButton).toBeVisible();
+      await userEvent.click(archiveButton);
+      await expect(mockWpReportContext.archiveReport).toHaveBeenCalledTimes(1);
+      // once for render, once for archive
+      await expect(
+        mockWpReportContext.fetchReportsByState
+      ).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/services/ui-src/src/forms/addEditMfpReport/addEditMfpReport.json
+++ b/services/ui-src/src/forms/addEditMfpReport/addEditMfpReport.json
@@ -13,7 +13,7 @@
       "type": "text",
       "validation": "text",
       "props": {
-        "label": "Program name"
+        "label": "Submission name"
       }
     }
   ]

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -28,7 +28,7 @@ export const mockFullReportJSON: ReportJson = {
               props: {
                 href: "https://www.govinfo.gov/content/pkg/PLAW-109publ171/pdf/PLAW-109publ171.pdf",
                 target: "_blank",
-                ariaLabel: "Link opens in new tab",
+                "aria-label": "Link opens in new tab",
               },
             },
             {
@@ -926,7 +926,7 @@ export const mockFullReportJSON: ReportJson = {
               props: {
                 href: "https://www.govinfo.gov/content/pkg/PLAW-109publ171/pdf/PLAW-109publ171.pdf",
                 target: "_blank",
-                ariaLabel: "Link opens in new tab",
+                "aria-label": "Link opens in new tab",
               },
             },
             {

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -28,7 +28,8 @@ export const mockFullReportJSON: ReportJson = {
               props: {
                 href: "https://www.govinfo.gov/content/pkg/PLAW-109publ171/pdf/PLAW-109publ171.pdf",
                 target: "_blank",
-                "aria-label": "Link opens in new tab",
+                "aria-label":
+                  "6071(a)(1) of the Deficit Reduction Act (DRA) (Link opens in new tab)",
               },
             },
             {
@@ -926,7 +927,8 @@ export const mockFullReportJSON: ReportJson = {
               props: {
                 href: "https://www.govinfo.gov/content/pkg/PLAW-109publ171/pdf/PLAW-109publ171.pdf",
                 target: "_blank",
-                "aria-label": "Link opens in new tab",
+                "aria-label":
+                  "6071(a)(1) of the Deficit Reduction Act (DRA) (Link opens in new tab)",
               },
             },
             {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -28,6 +28,7 @@ export const mockReportJson = {
   type: "mock",
   basePath: "/mock",
   routes: mockReportRoutes,
+  flatRoutes: mockFlattenedReportRoutes,
   validationSchema: {},
 };
 
@@ -97,6 +98,7 @@ export const mockWPFullReport = {
   },
   isComplete: false,
   reportPeriod: 1,
+  locked: false,
 };
 
 export const mockWPApprovedFullReport = {
@@ -148,11 +150,11 @@ export const mockReportMethods = {
 
 export const mockWpReportContext = {
   ...mockReportMethods,
-  ...mockWPFullReport,
+  report: mockWPFullReport,
   reportsByState: mockReportsByState,
   copyEligibleReportsByState: mockReportsByState,
   errorMessage: "",
-  lastSavedTime: "1:58 PM",
+  lastSavedTime: "2:00 PM",
 };
 
 export const mockDashboardReportContext = {
@@ -164,4 +166,9 @@ export const mockDashboardReportContext = {
       fieldData: undefined,
     },
   ],
+};
+
+export const mockReportContextNoReports = {
+  ...mockWpReportContext,
+  reportsByState: undefined,
 };


### PR DESCRIPTION
### Description
This change adds an FaqAccordion test and increases the test coverage on the DashboardPage tests. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
CMDCT-159

https://jiraent.cms.gov/projects/CMDCT/issues/CMDCT-159?filter=allopenissues
---
### How to test
1. change directories to `services/ui-src`
2. run `yarn test` and `yarn test --coverage`
Note: coverage for the DashboardPage is not at 100 percent, but I wanted to put this code out since multiple people are working in the same test package

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [✅] I have performed a self-review of my code
- [✅ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [N/A] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
