### PR TITLE
fix bug involving nested fields correctly clearing out and also repopulating with data

### DIFF
--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -39,6 +39,7 @@ import {
   getEntriesToClear,
   setClearedEntriesToDefaultValue,
   entityWasUpdated,
+  resetClearProp,
 } from "utils";
 
 export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
@@ -113,6 +114,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeDrawer = () => {
     setSelectedEntity(undefined);
+    resetClearProp(drawerForm.fields);
     drawerOnCloseHandler();
   };
 

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -29,6 +29,7 @@ import {
   entityWasUpdated,
   filterFormData,
   getEntriesToClear,
+  resetClearProp,
   setClearedEntriesToDefaultValue,
   useBreakpoint,
   useStore,
@@ -103,6 +104,7 @@ export const ModalOverlayReportPage = ({
 
   const closeAddEditEntityModal = () => {
     setCurrentEntity(undefined);
+    resetClearProp(modalForm.fields);
     addEditEntityModalOnCloseHandler();
   };
 

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -20,7 +20,7 @@ import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 // types
 import { EntityShape, OverlayModalPageShape } from "types";
 // utils
-import { getFormattedEntityData, useStore } from "utils";
+import { getFormattedEntityData, resetClearProp, useStore } from "utils";
 
 export const OverlayModalPage = ({
   entity,
@@ -82,6 +82,7 @@ export const OverlayModalPage = ({
 
   const openDeleteEntityModal = (entity?: EntityShape) => {
     setSelectedEntity(entity);
+    resetClearProp(modalForm.fields);
     deleteEntityModalOnOpenHandler();
   };
 

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -203,3 +203,28 @@ export const flattenFormFields = (formFields: FormField[]): FormField[] => {
   compileFields(formFields);
   return flattenedFields;
 };
+
+/*
+ * This function resets the 'clear' prop on each field after a ChoiceListField calls
+ * clearUncheckedNestedFields(). Upon re-entering a drawer or modal, the field values will
+ * be correctly hydrated.
+ */
+export const resetClearProp = (fields: (FormField | FormLayoutElement)[]) => {
+  fields.forEach((field: FormField | FormLayoutElement) => {
+    switch (field.type) {
+      case "radio":
+      case "checkbox":
+        field.props?.choices.forEach((childField: FieldChoice) => {
+          if (childField?.children) {
+            resetClearProp(childField.children);
+          }
+        });
+        field.props = { ...field.props, clear: false };
+        resetClearProp(field.props?.choices);
+        break;
+      default:
+        field.props = { ...field.props, clear: false };
+        break;
+    }
+  });
+};


### PR DESCRIPTION
### Description
The nested fields in our choice lists weren't correctly hydrating when a user selected a different radio option, exited the modal or drawer, and then re-entered it. This code fixes that issue. It's not pretty but the plan is to let Zustand take care of state management issues like these so this code won't be around long-term.

This is a cleaned up version of [this closed PR ](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/150) that had some extra code from a merge conflict.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
https://jiraent.cms.gov/browse/CMDCT-2

---
### How to test
Go into a drawer that has radio options (like the initiatives).

1. See that it saves correctly and hydrates correctly when you re-enter
2. Choose a different selection, go back to the original selection, see that all data has been cleared out.
    Don't save, just exit. Re-enter and see that the original saved selection has correctly hydrated.



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
