### PR TITLE
MDCT -  WP Admin Review and Submit (UI only)

### DIFF
--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -52,34 +52,36 @@ export const Modal = ({
           </Button>
         </Flex>
         <ModalBody sx={sx.modalBody}>{children}</ModalBody>
-        <ModalFooter sx={sx.modalFooter}>
-          {formId && content.actionButtonText !== "" && (
+        {content.actionButtonText && content.actionButtonText !== "" && (
+          <ModalFooter sx={sx.modalFooter}>
+            {formId && content.actionButtonText !== "" && (
+              <Button
+                sx={sx.action}
+                form={formId}
+                type="submit"
+                data-testid="modal-submit-button"
+              >
+                {submitting ? <Spinner size="md" /> : content.actionButtonText}
+              </Button>
+            )}
+            {onConfirmHandler && (
+              <Button
+                sx={sx.action}
+                onClick={() => onConfirmHandler()}
+                data-testid="modal-submit-button"
+              >
+                {submitting ? <Spinner size="md" /> : content.actionButtonText}
+              </Button>
+            )}
             <Button
-              sx={sx.action}
-              form={formId}
-              type="submit"
-              data-testid="modal-submit-button"
+              sx={sx.close}
+              variant="link"
+              onClick={modalDisclosure.onClose}
             >
-              {submitting ? <Spinner size="md" /> : content.actionButtonText}
+              {content.closeButtonText}
             </Button>
-          )}
-          {onConfirmHandler && (
-            <Button
-              sx={sx.action}
-              onClick={() => onConfirmHandler()}
-              data-testid="modal-submit-button"
-            >
-              {submitting ? <Spinner size="md" /> : content.actionButtonText}
-            </Button>
-          )}
-          <Button
-            sx={sx.close}
-            variant="link"
-            onClick={modalDisclosure.onClose}
-          >
-            {content.closeButtonText}
-          </Button>
-        </ModalFooter>
+          </ModalFooter>
+        )}
       </ModalContent>
     </ChakraModal>
   );

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+// components
+import { ReportContext } from "components";
+// utils
+import {
+  mockAdminUserStore,
+  mockLDFlags,
+  mockReportMethods,
+  mockUseStore,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
+import { useStore } from "utils";
+import reviewVerbiage from "verbiage/pages/mfp/mfp-review-and-submit";
+import { AdminReview } from "./AdminReview";
+// types
+import { ReportStatus } from "types";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+
+mockLDFlags.setDefault({ pdfExport: false });
+
+const WpReviewSubmitPage = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockReportMethods}>
+      <AdminReview
+        reviewVerbiage={reviewVerbiage}
+        submitting={false}
+        submitForm={() => {}}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+describe("MFP Review and Submit Page Functionality", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Review and Submit Page - Admin View", () => {
+    test("Show admin view when admin user is logged in", () => {
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        user: mockAdminUserStore,
+      });
+      render(WpReviewSubmitPage);
+      const { review } = reviewVerbiage;
+      const { adminInfo } = review;
+      expect(screen.getByText(adminInfo.submitLink.text)).toBeVisible();
+    });
+
+    test("Disable unlock and approve buttons when report is unlocked", () => {
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        report: {
+          status: ReportStatus.IN_PROGRESS,
+        },
+        user: mockAdminUserStore,
+      });
+      render(WpReviewSubmitPage);
+      const { review } = reviewVerbiage;
+      const { adminInfo } = review;
+      expect(screen.getByText(adminInfo.submitLink.text)).toBeDisabled();
+    });
+
+    test("Enable unlock and approve buttons when report is locked", () => {
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        report: {
+          status: ReportStatus.SUBMITTED,
+        },
+        user: mockAdminUserStore,
+      });
+      render(WpReviewSubmitPage);
+      const { review } = reviewVerbiage;
+      const { adminInfo } = review;
+      expect(screen.getByText(adminInfo.submitLink.text)).toBeEnabled();
+    });
+  });
+});

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
@@ -22,8 +22,8 @@ export const AdminReview = ({
 }: AdminReviewProps) => {
   const { review } = reviewVerbiage;
   const { adminInfo } = review;
-  const adminModal1 = useDisclosure();
-  const adminModal2 = useDisclosure();
+  const adminUnlockModal = useDisclosure();
+  const adminApproveModal = useDisclosure();
   const report = useStore().report;
 
   return (
@@ -38,7 +38,7 @@ export const AdminReview = ({
         <Button
           type="submit"
           id="adminUnlock"
-          onClick={adminModal1.onOpen as MouseEventHandler}
+          onClick={adminUnlockModal.onOpen as MouseEventHandler}
           sx={sx.submitButton && sx.adminUnlockBtn}
           variant="outline"
           disabled={report?.status !== ReportStatus.SUBMITTED ? true : false}
@@ -48,7 +48,7 @@ export const AdminReview = ({
         <Button
           type="submit"
           id="adminApprove"
-          onClick={adminModal2.onOpen as MouseEventHandler}
+          onClick={adminApproveModal.onOpen as MouseEventHandler}
           sx={sx.submitButton && sx.adminApproveBtn}
           disabled={report?.status !== ReportStatus.SUBMITTED ? true : false}
         >
@@ -59,8 +59,8 @@ export const AdminReview = ({
         onConfirmHandler={submitForm}
         submitting={submitting}
         modalDisclosure={{
-          isOpen: adminModal1.isOpen,
-          onClose: adminModal1.onClose,
+          isOpen: adminUnlockModal.isOpen,
+          onClose: adminUnlockModal.onClose,
         }}
         content={{
           heading: adminInfo.modal.unlockModal.heading,
@@ -74,8 +74,8 @@ export const AdminReview = ({
         onConfirmHandler={submitForm}
         submitting={submitting}
         modalDisclosure={{
-          isOpen: adminModal2.isOpen,
-          onClose: adminModal2.onClose,
+          isOpen: adminApproveModal.isOpen,
+          onClose: adminApproveModal.onClose,
         }}
         content={adminInfo.modal.approveModal}
       >
@@ -183,11 +183,6 @@ const sx = {
       opacity: 1,
       background: "palette.gray_lighter",
       color: "palette.gray",
-    },
-    "&disabled:hover": {
-      opacity: 1,
-      background: "white",
-      color: "palette.gray_lighter",
     },
   },
 };

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
@@ -1,0 +1,193 @@
+import { MouseEventHandler } from "react";
+// components
+import {
+  Box,
+  Button,
+  Flex,
+  Text,
+  useDisclosure,
+  Input,
+  ModalFooter,
+} from "@chakra-ui/react";
+import { Modal } from "components";
+// utils
+import { parseCustomHtml, useStore } from "utils";
+// types
+import { AnyObject, ReportStatus } from "types";
+
+export const AdminReview = ({
+  reviewVerbiage,
+  submitForm,
+  submitting,
+}: AdminReviewProps) => {
+  const { review } = reviewVerbiage;
+  const { adminInfo } = review;
+  const adminModal1 = useDisclosure();
+  const adminModal2 = useDisclosure();
+  const report = useStore().report;
+
+  return (
+    <Flex sx={sx.contentContainer} data-testid="ready-view">
+      <Box sx={sx.adminLeadTextBox}>
+        <Box sx={sx.infoTextBox}>
+          <Text sx={sx.infoHeading}>{adminInfo.header}</Text>
+          <Text>{parseCustomHtml(adminInfo.info)}</Text>
+        </Box>
+      </Box>
+      <Flex sx={sx.adminSubmitContainer}>
+        <Button
+          type="submit"
+          id="adminUnlock"
+          onClick={adminModal1.onOpen as MouseEventHandler}
+          sx={sx.submitButton && sx.adminUnlockBtn}
+          variant="outline"
+          disabled={report?.status !== ReportStatus.SUBMITTED ? true : false}
+        >
+          {adminInfo.unlockLink.text}
+        </Button>
+        <Button
+          type="submit"
+          id="adminApprove"
+          onClick={adminModal2.onOpen as MouseEventHandler}
+          sx={sx.submitButton && sx.adminApproveBtn}
+          disabled={report?.status !== ReportStatus.SUBMITTED ? true : false}
+        >
+          {adminInfo.submitLink.text}
+        </Button>
+      </Flex>
+      <Modal
+        onConfirmHandler={submitForm}
+        submitting={submitting}
+        modalDisclosure={{
+          isOpen: adminModal1.isOpen,
+          onClose: adminModal1.onClose,
+        }}
+        content={{
+          heading: adminInfo.modal.unlockModal.heading,
+          actionButtonText: adminInfo.modal.unlockModal.actionButtonText,
+          closeButtonText: adminInfo.modal.unlockModal.closeButtonText,
+        }}
+      >
+        <Text>{adminInfo.modal.unlockModal.body}</Text>
+      </Modal>
+      <Modal
+        onConfirmHandler={submitForm}
+        submitting={submitting}
+        modalDisclosure={{
+          isOpen: adminModal2.isOpen,
+          onClose: adminModal2.onClose,
+        }}
+        content={adminInfo.modal.approveModal}
+      >
+        <Text sx={sx.unlockModalBody}>{adminInfo.modal.approveModal.body}</Text>
+        <Text fontWeight="bold">Enter APPROVE to confirm.</Text>
+        <Input
+          id="approve"
+          name="approve"
+          type="password"
+          value={""}
+          onChange={() => {}}
+          className="field"
+        />
+        <ModalFooter sx={sx.modalFooter}>
+          <Button
+            type="submit"
+            variant="outline"
+            data-testid="modal-logout-button"
+            sx={sx.modalCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={true}
+            data-testid="modal-refresh-button"
+          >
+            Approve
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Flex>
+  );
+};
+
+interface AdminReviewProps {
+  submitForm: Function;
+  submitting?: boolean;
+  hasStarted?: boolean;
+  isPermittedToSubmit?: boolean;
+  reviewVerbiage: AnyObject;
+}
+
+const sx = {
+  contentContainer: {
+    flexDirection: "column",
+    width: "100%",
+    maxWidth: "reportPageWidth",
+  },
+  unlockModalBody: {
+    marginBottom: "1rem",
+  },
+  adminLeadTextBox: {
+    marginTop: "2rem",
+    ul: {
+      marginLeft: "2rem",
+    },
+  },
+  infoTextBox: {
+    marginTop: "2rem",
+    a: {
+      color: "palette.primary",
+      textDecoration: "underline",
+    },
+  },
+  infoHeading: {
+    fontWeight: "bold",
+    marginBottom: ".5rem",
+  },
+  adminApprove: {
+    display: "flex",
+  },
+  adminSubmitContainer: {
+    width: "100%",
+    justifyContent: "start",
+    marginTop: "2rem",
+  },
+  submitButton: {
+    minHeight: "3rem",
+    paddingRight: "1rem",
+  },
+  modalFooter: {
+    paddingStart: 0,
+    justifyContent: "start",
+  },
+  modalCancel: {
+    marginRight: "1rem",
+  },
+  adminUnlockBtn: {
+    marginRight: "1rem",
+    "&:disabled": {
+      opacity: 1,
+      background: "white",
+      color: "palette.gray_lighter",
+      borderColor: "palette.gray_lighter",
+    },
+    "&disabled:hover": {
+      opacity: 1,
+      background: "white",
+      color: "palette.gray_lighter",
+    },
+  },
+  adminApproveBtn: {
+    "&:disabled": {
+      opacity: 1,
+      background: "palette.gray_lighter",
+      color: "palette.gray",
+    },
+    "&disabled:hover": {
+      opacity: 1,
+      background: "white",
+      color: "palette.gray_lighter",
+    },
+  },
+};

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -33,7 +33,7 @@ export const ReviewSubmitPage = () => {
     useState<boolean>(false);
 
   // get user information
-  const { state, userIsEndUser } = useStore().user ?? {};
+  const { state, userIsEndUser, userIsAdmin } = useStore().user ?? {};
 
   // get report type, state, and id from context or storage
   const reportType =
@@ -112,12 +112,14 @@ export const ReviewSubmitPage = () => {
               isPermittedToSubmit={isPermittedToSubmit}
               reviewVerbiage={reviewVerbiage}
             />
-            <AdminReview
-              submitForm={submitForm}
-              submitting={submitting}
-              isPermittedToSubmit={isPermittedToSubmit}
-              reviewVerbiage={reviewVerbiage}
-            />
+            {userIsAdmin && (
+              <AdminReview
+                submitForm={submitForm}
+                submitting={submitting}
+                isPermittedToSubmit={isPermittedToSubmit}
+                reviewVerbiage={reviewVerbiage}
+              />
+            )}
           </div>
         )}
       </Flex>
@@ -325,7 +327,6 @@ export const SuccessMessage = ({
     submittedBy,
     stateName
   );
-
   return (
     <Flex sx={sx.contentContainer}>
       <Box sx={sx.leadTextBox}>

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -1,5 +1,6 @@
 import { MouseEventHandler, useContext, useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
+import { AdminReview } from "./AdminReview";
 // components
 import {
   Box,
@@ -9,8 +10,6 @@ import {
   Heading,
   Text,
   useDisclosure,
-  Input,
-  ModalFooter,
 } from "@chakra-ui/react";
 import { Alert, Modal, ReportContext, StatusTable } from "components";
 // types
@@ -34,7 +33,6 @@ export const ReviewSubmitPage = () => {
   const [isPermittedToSubmit, setIsPermittedToSubmit] =
     useState<boolean>(false);
 
-  // get user information
   const { state, userIsEndUser, userIsAdmin } = useStore().user ?? {};
 
   // get report type, state, and id from context or storage
@@ -50,7 +48,6 @@ export const ReviewSubmitPage = () => {
   };
 
   const reviewVerbiage = verbiage;
-
   const { alertBox } = reviewVerbiage;
 
   useEffect(() => {
@@ -164,6 +161,7 @@ const ReadyToSubmit = ({
   isPermittedToSubmit,
   reviewVerbiage,
 }: ReadyToSubmitProps) => {
+  const { userIsAdmin } = useStore().user ?? {};
   const { review } = reviewVerbiage;
   const { intro, modal, pageLink } = review;
   const pdfExport = true;
@@ -185,14 +183,16 @@ const ReadyToSubmit = ({
       </Box>
       <Flex sx={sx.submitContainer}>
         {pdfExport && <PrintButton reviewVerbiage={reviewVerbiage} />}
-        <Button
-          type="submit"
-          onClick={onOpen as MouseEventHandler}
-          isDisabled={!isPermittedToSubmit}
-          sx={sx.submitButton}
-        >
-          {pageLink.text}
-        </Button>
+        {!userIsAdmin && (
+          <Button
+            type="submit"
+            onClick={onOpen as MouseEventHandler}
+            isDisabled={!isPermittedToSubmit}
+            sx={sx.submitButton}
+          >
+            {pageLink.text}
+          </Button>
+        )}
       </Flex>
       <Modal
         onConfirmHandler={submitForm}
@@ -209,95 +209,6 @@ const ReadyToSubmit = ({
   );
 };
 
-const AdminReview = ({
-  reviewVerbiage,
-  submitForm,
-  submitting,
-}: AdminReviewProps) => {
-  const { review } = reviewVerbiage;
-  const { adminInfo } = review;
-  const adminModal1 = useDisclosure();
-  const adminModal2 = useDisclosure();
-
-  return (
-    <Flex sx={sx.contentContainer} data-testid="ready-view">
-      <Box sx={sx.adminLeadTextBox}>
-        <Box sx={sx.infoTextBox}>
-          <Text sx={sx.infoHeading}>{adminInfo.header}</Text>
-          <Text>{parseCustomHtml(adminInfo.info)}</Text>
-        </Box>
-      </Box>
-      <Flex sx={sx.adminSubmitContainer}>
-        <Button
-          type="submit"
-          id="adminUnlock"
-          onClick={adminModal1.onOpen as MouseEventHandler}
-          sx={sx.submitButton && sx.adminReviewButtons}
-          variant="outline"
-        >
-          {adminInfo.unlockLink.text}
-        </Button>
-        <Button
-          type="submit"
-          id="adminApprove"
-          onClick={adminModal2.onOpen as MouseEventHandler}
-          sx={sx.submitButton && sx.adminApprove}
-        >
-          {adminInfo.submitLink.text}
-        </Button>
-      </Flex>
-      <Modal
-        onConfirmHandler={submitForm}
-        submitting={submitting}
-        modalDisclosure={{
-          isOpen: adminModal1.isOpen,
-          onClose: adminModal1.onClose,
-        }}
-        content={{
-          heading: adminInfo.modal.unlockModal.heading,
-          actionButtonText: adminInfo.modal.unlockModal.actionButtonText,
-          closeButtonText: adminInfo.modal.unlockModal.closeButtonText,
-        }}
-      >
-        <Text>{adminInfo.modal.unlockModal.body}</Text>
-      </Modal>
-      <Modal
-        onConfirmHandler={submitForm}
-        submitting={submitting}
-        modalDisclosure={{
-          isOpen: adminModal2.isOpen,
-          onClose: adminModal2.onClose,
-        }}
-        content={adminInfo.modal.approveModal}
-      >
-        <Text sx={sx.unlockModalBody}>{adminInfo.modal.approveModal.body}</Text>
-        <Text fontWeight="bold">Enter APPROVE to confirm.</Text>
-        <Input
-          id="approve"
-          name="approve"
-          type="password"
-          value={""}
-          onChange={() => {}}
-          className="field"
-        />
-        <ModalFooter sx={sx.modalFooter}>
-          <Button
-            type="submit"
-            variant="outline"
-            data-testid="modal-logout-button"
-            sx={sx.modalCancel}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" data-testid="modal-refresh-button">
-            Approve
-          </Button>
-        </ModalFooter>
-      </Modal>
-    </Flex>
-  );
-};
-
 interface ReadyToSubmitProps {
   submitForm: Function;
   isOpen: boolean;
@@ -308,15 +219,6 @@ interface ReadyToSubmitProps {
   isPermittedToSubmit?: boolean;
   reviewVerbiage: AnyObject;
 }
-
-interface AdminReviewProps {
-  submitForm: Function;
-  submitting?: boolean;
-  hasStarted?: boolean;
-  isPermittedToSubmit?: boolean;
-  reviewVerbiage: AnyObject;
-}
-
 export const SuccessMessageGenerator = (
   reportType: string,
   name: string,
@@ -411,15 +313,6 @@ const sx = {
     fontSize: "4xl",
     fontWeight: "normal",
   },
-  unlockModalBody: {
-    marginBottom: "1rem",
-  },
-  adminLeadTextBox: {
-    marginTop: "2rem",
-    ul: {
-      marginLeft: "2rem",
-    },
-  },
   infoTextBox: {
     marginTop: "2rem",
     a: {
@@ -444,9 +337,6 @@ const sx = {
   additionalInfo: {
     color: "palette.gray",
   },
-  adminApprove: {
-    display: "flex",
-  },
   printButton: {
     minWidth: "6rem",
     height: "2rem",
@@ -470,11 +360,6 @@ const sx = {
     width: "100%",
     justifyContent: "space-between",
   },
-  adminSubmitContainer: {
-    width: "100%",
-    justifyContent: "start",
-    marginTop: "2rem",
-  },
   alert: {
     marginBottom: "2rem",
   },
@@ -489,15 +374,5 @@ const sx = {
         background: "palette.gray_lighter",
       },
     },
-  },
-  modalFooter: {
-    paddingStart: 0,
-    justifyContent: "start",
-  },
-  modalCancel: {
-    marginRight: "1rem",
-  },
-  adminReviewButtons: {
-    marginRight: "1rem",
   },
 };

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -9,6 +9,8 @@ import {
   Heading,
   Text,
   useDisclosure,
+  Input,
+  ModalFooter,
 } from "@chakra-ui/react";
 import { Alert, Modal, ReportContext, StatusTable } from "components";
 // types
@@ -239,7 +241,7 @@ const AdminReview = ({
           type="submit"
           id="adminApprove"
           onClick={adminModal2.onOpen as MouseEventHandler}
-          sx={sx.submitButton}
+          sx={sx.submitButton && sx.adminApprove}
         >
           {adminInfo.submitLink.text}
         </Button>
@@ -251,9 +253,12 @@ const AdminReview = ({
           isOpen: adminModal1.isOpen,
           onClose: adminModal1.onClose,
         }}
-        content={adminInfo.modal.unlockModal}
+        content={{
+          heading: adminInfo.modal.unlockModal.heading,
+          actionButtonText: adminInfo.modal.unlockModal.actionButtonText,
+          closeButtonText: adminInfo.modal.unlockModal.closeButtonText,
+        }}
       >
-        {" "}
         <Text>{adminInfo.modal.unlockModal.body}</Text>
       </Modal>
       <Modal
@@ -265,7 +270,29 @@ const AdminReview = ({
         }}
         content={adminInfo.modal.approveModal}
       >
-        <Text>{adminInfo.modal.approveModal.body}</Text>
+        <Text sx={sx.unlockModalBody}>{adminInfo.modal.approveModal.body}</Text>
+        <Text fontWeight="bold">Enter APPROVE to confirm.</Text>
+        <Input
+          id="approve"
+          name="approve"
+          type="password"
+          value={""}
+          onChange={() => {}}
+          className="field"
+        />
+        <ModalFooter sx={sx.modalFooter}>
+          <Button
+            type="submit"
+            variant="outline"
+            data-testid="modal-logout-button"
+            sx={sx.modalCancel}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" data-testid="modal-refresh-button">
+            Approve
+          </Button>
+        </ModalFooter>
       </Modal>
     </Flex>
   );
@@ -384,6 +411,9 @@ const sx = {
     fontSize: "4xl",
     fontWeight: "normal",
   },
+  unlockModalBody: {
+    marginBottom: "1rem",
+  },
   adminLeadTextBox: {
     marginTop: "2rem",
     ul: {
@@ -413,6 +443,9 @@ const sx = {
   },
   additionalInfo: {
     color: "palette.gray",
+  },
+  adminApprove: {
+    display: "flex",
   },
   printButton: {
     minWidth: "6rem",
@@ -456,6 +489,13 @@ const sx = {
         background: "palette.gray_lighter",
       },
     },
+  },
+  modalFooter: {
+    paddingStart: 0,
+    justifyContent: "start",
+  },
+  modalCancel: {
+    marginRight: "1rem",
   },
   adminReviewButtons: {
     marginRight: "1rem",

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -102,15 +102,23 @@ export const ReviewSubmitPage = () => {
             stateName={report.fieldData.stateName!}
           />
         ) : (
-          <ReadyToSubmit
-            submitForm={submitForm}
-            isOpen={isOpen}
-            onOpen={onOpen}
-            onClose={onClose}
-            submitting={submitting}
-            isPermittedToSubmit={isPermittedToSubmit}
-            reviewVerbiage={reviewVerbiage}
-          />
+          <div>
+            <ReadyToSubmit
+              submitForm={submitForm}
+              isOpen={isOpen}
+              onOpen={onOpen}
+              onClose={onClose}
+              submitting={submitting}
+              isPermittedToSubmit={isPermittedToSubmit}
+              reviewVerbiage={reviewVerbiage}
+            />
+            <AdminReview
+              submitForm={submitForm}
+              submitting={submitting}
+              isPermittedToSubmit={isPermittedToSubmit}
+              reviewVerbiage={reviewVerbiage}
+            />
+          </div>
         )}
       </Flex>
     </>
@@ -197,11 +205,83 @@ const ReadyToSubmit = ({
   );
 };
 
+const AdminReview = ({
+  reviewVerbiage,
+  submitForm,
+  submitting,
+}: AdminReviewProps) => {
+  const { review } = reviewVerbiage;
+  const { adminInfo } = review;
+  const adminModal1 = useDisclosure();
+  const adminModal2 = useDisclosure();
+
+  return (
+    <Flex sx={sx.contentContainer} data-testid="ready-view">
+      <Box sx={sx.adminLeadTextBox}>
+        <Box sx={sx.infoTextBox}>
+          <Text sx={sx.infoHeading}>{adminInfo.header}</Text>
+          <Text>{parseCustomHtml(adminInfo.info)}</Text>
+        </Box>
+      </Box>
+      <Flex sx={sx.adminSubmitContainer}>
+        <Button
+          type="submit"
+          id="adminUnlock"
+          onClick={adminModal1.onOpen as MouseEventHandler}
+          sx={sx.submitButton && sx.adminReviewButtons}
+          variant="outline"
+        >
+          {adminInfo.unlockLink.text}
+        </Button>
+        <Button
+          type="submit"
+          id="adminApprove"
+          onClick={adminModal2.onOpen as MouseEventHandler}
+          sx={sx.submitButton}
+        >
+          {adminInfo.submitLink.text}
+        </Button>
+      </Flex>
+      <Modal
+        onConfirmHandler={submitForm}
+        submitting={submitting}
+        modalDisclosure={{
+          isOpen: adminModal1.isOpen,
+          onClose: adminModal1.onClose,
+        }}
+        content={adminInfo.modal.unlockModal}
+      >
+        {" "}
+        <Text>{adminInfo.modal.unlockModal.body}</Text>
+      </Modal>
+      <Modal
+        onConfirmHandler={submitForm}
+        submitting={submitting}
+        modalDisclosure={{
+          isOpen: adminModal2.isOpen,
+          onClose: adminModal2.onClose,
+        }}
+        content={adminInfo.modal.approveModal}
+      >
+        <Text>{adminInfo.modal.approveModal.body}</Text>
+      </Modal>
+    </Flex>
+  );
+};
+
 interface ReadyToSubmitProps {
   submitForm: Function;
   isOpen: boolean;
   onOpen: Function;
   onClose: Function;
+  submitting?: boolean;
+  hasStarted?: boolean;
+  isPermittedToSubmit?: boolean;
+  reviewVerbiage: AnyObject;
+}
+
+interface AdminReviewProps {
+  submitForm: Function;
   submitting?: boolean;
   hasStarted?: boolean;
   isPermittedToSubmit?: boolean;
@@ -303,6 +383,12 @@ const sx = {
     fontSize: "4xl",
     fontWeight: "normal",
   },
+  adminLeadTextBox: {
+    marginTop: "2rem",
+    ul: {
+      marginLeft: "2rem",
+    },
+  },
   infoTextBox: {
     marginTop: "2rem",
     a: {
@@ -350,11 +436,17 @@ const sx = {
     width: "100%",
     justifyContent: "space-between",
   },
+  adminSubmitContainer: {
+    width: "100%",
+    justifyContent: "start",
+    marginTop: "2rem",
+  },
   alert: {
     marginBottom: "2rem",
   },
   submitButton: {
     minHeight: "3rem",
+    paddingRight: "1rem",
     "&:disabled": {
       opacity: 1,
       background: "palette.gray_lighter",
@@ -363,5 +455,8 @@ const sx = {
         background: "palette.gray_lighter",
       },
     },
+  },
+  adminReviewButtons: {
+    marginRight: "1rem",
   },
 };

--- a/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
@@ -17,6 +17,36 @@ export default {
         },
       ],
     },
+    adminInfo: {
+      header: "Admin Review",
+      info: [
+        {
+          type: "text",
+          as: "div",
+          content:
+            "<ul><li>To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state or territory contact and inform them. The status will change to “In revision.</li><br/><li>To approve a submission, review the submission and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR. <strong>You will not be able to unapprove or unlock it.</strong></li></ul>",
+        },
+      ],
+      modal: {
+        unlockModal: {
+          header: "You unlocked this Work Plan",
+          actionButtonText: "Return to dashboard",
+          body: "Email the state or territory contact and let them know it requires edits.",
+        },
+        approveModal: {
+          header: "Are you sure you want to approve this Work Plan?",
+          closeButtonText: "Cancel",
+          actionButtonText: "Approve",
+          body: "This action can’t be undone. Once the Work Plan is approved, the initiatives and benchmarks will be pulled into the Semi-Annual Report and this Work Plan can’t be unlocked or edited.",
+        },
+      },
+      unlockLink: {
+        text: "Unlock",
+      },
+      submitLink: {
+        text: "Approve",
+      },
+    },
     table: {
       headRow: ["Section", "Status", ""],
     },

--- a/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
@@ -29,14 +29,14 @@ export default {
       ],
       modal: {
         unlockModal: {
-          header: "You unlocked this Work Plan",
+          heading: "You unlocked this Work Plan",
           actionButtonText: "Return to dashboard",
           body: "Email the state or territory contact and let them know it requires edits.",
         },
         approveModal: {
-          header: "Are you sure you want to approve this Work Plan?",
-          closeButtonText: "Cancel",
-          actionButtonText: "Approve",
+          heading: "Are you sure you want to approve this Work Plan?",
+          closeButtonText: "",
+          actionButtonText: "",
           body: "This action can’t be undone. Once the Work Plan is approved, the initiatives and benchmarks will be pulled into the Semi-Annual Report and this Work Plan can’t be unlocked or edited.",
         },
       },

--- a/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/mfp/mfp-review-and-submit.ts
@@ -24,7 +24,7 @@ export default {
           type: "text",
           as: "div",
           content:
-            "<ul><li>To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state or territory contact and inform them. The status will change to “In revision.</li><br/><li>To approve a submission, review the submission and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR. <strong>You will not be able to unapprove or unlock it.</strong></li></ul>",
+            "<ul><li>To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state or territory contact and inform them. The status will change to “In revision”.</li><br/><li>To approve a submission, review the submission and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR. <strong>You will not be able to unapprove or unlock it.</strong></li></ul>",
         },
       ],
       modal: {


### PR DESCRIPTION
### Description
This is ONLY the UI portion of the following ticket. https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=5874&projectKey=CMDCT&view=detail&selectedIssue=CMDCT-2995&quickFilter=32496

Once a state user submits a report, the admin can go into that report and see the following admin view.

What this ticket covers:

1. Admin Review verbiage on the Review & Submit page ( admin login only )
2. Unlock and Approve buttons
3. Modal pop-ups for both buttons
### Related ticket(s)
MDCT-[CMDCT-2995](https://jiraent.cms.gov/browse/CMDCT-2995)

---
### How to test
1. Enter the app as a state user and fill out a report. 
2. Sign in as an admin user and select the state the form as filed in. 
3. In the Review and Submit section the admin view should show up. 
<!-- Step-by-step instructions on how to test, if necessary -->

<img width="1024" alt="MFP_WP_C CMS Admin" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/5a386885-95c7-485d-a5c2-66072fddd510">

The unlock and approve buttons trigger the modals but the modals aren't currently functional. Another ticket will be created to focus on the functionality since it's a larger lift.

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/65c24f29-0ecf-408c-ab70-450e74d5aac7




