### PR TITLE
CMDCT-159 AddEditReportModal (WP) tests

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -8,6 +8,7 @@ import {
 import { ReportContext } from "../reports/ReportProvider";
 import { AddEditReportModal } from "./AddEditReportModal";
 import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
 
 const mockCreateReport = jest.fn();
 const mockUpdateReport = jest.fn();
@@ -101,5 +102,13 @@ describe("Test AddEditReportModal functionality for Work Plan", () => {
     await expect(mockUpdateReport).toHaveBeenCalledTimes(1);
     await expect(mockFetchReportsByState).toHaveBeenCalledTimes(1);
     await expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Test AddEditReportModal accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(modalComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -1,0 +1,105 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ReportType } from "../../types";
+import {
+  RouterWrappedComponent,
+  mockWPFullReport,
+  mockWpReportContext,
+} from "../../utils/testing/setupJest";
+import { ReportContext } from "../reports/ReportProvider";
+import { AddEditReportModal } from "./AddEditReportModal";
+import userEvent from "@testing-library/user-event";
+
+const mockCreateReport = jest.fn();
+const mockUpdateReport = jest.fn();
+const mockFetchReportsByState = jest.fn();
+const mockCloseHandler = jest.fn();
+
+const mockedReportContext = {
+  ...mockWpReportContext,
+  createReport: mockCreateReport,
+  updateReport: mockUpdateReport,
+  fetchReportsByState: mockFetchReportsByState,
+  isReportPage: true,
+};
+
+const modalComponent = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="CA"
+        selectedReport={undefined}
+        reportType={ReportType.WP}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+const modalComponentWithSelectedReport = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockedReportContext}>
+      <AddEditReportModal
+        activeState="CA"
+        selectedReport={mockWPFullReport}
+        reportType={ReportType.WP}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
+describe("Test AddEditProgramModal", () => {
+  beforeEach(async () => {
+    await act(async () => {
+      await render(modalComponent);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("AddEditReportModal shows the contents", () => {
+    expect(screen.getByText("Start new")).toBeTruthy();
+  });
+
+  test("AddEditReportModal top close button can be clicked", () => {
+    fireEvent.click(screen.getByText("Close"));
+    expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Test AddEditReportModal functionality for Work Plan", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const fillForm = async () => {
+    const submitButton = screen.getByRole("button", { name: "Start new" });
+    await userEvent.click(submitButton);
+  };
+
+  test("Adding a new report", async () => {
+    await render(modalComponent);
+    const header = screen.getByRole("heading", { level: 1 });
+    expect(header.textContent).toEqual("Add new MFP Work Plan");
+    await fillForm();
+    await expect(mockCreateReport).toHaveBeenCalledTimes(1);
+    await expect(mockFetchReportsByState).toHaveBeenCalledTimes(1);
+    await expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("Editing an existing report", async () => {
+    await render(modalComponentWithSelectedReport);
+    await fillForm();
+    await expect(mockUpdateReport).toHaveBeenCalledTimes(1);
+    await expect(mockFetchReportsByState).toHaveBeenCalledTimes(1);
+    await expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This change adds tests for the AddEditReportModal for Work Plans. The test coverage is not at 100 percent yet as we need to add tests for SAR submissions. That will be in another PR :) 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
CMDCT-159

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. change directories to `/services/ui-src`
2. Run `yarn test`
3. Check that tests pass

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [X] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [X] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
