### PR TITLE
MDCT-2877: SAR Dashboard (State User + Empty View)

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -247,18 +247,18 @@ export const DashboardPage = ({ reportType }: Props) => {
       </Link>
       {errorMessage && <ErrorAlert error={errorMessage} />}
       {/* Only show SAR alert banner if the corresponding Work Plan is not approved */}
-      {reportType === ReportType.SAR &&
-        workPlanStatus !== ReportStatus.APPROVED && (
-          <Alert
-            title={sarVerbiage.alertBanner.title}
-            showIcon={true}
-            icon={alertIcon}
-            status={AlertTypes.ERROR}
-            description={sarVerbiage.alertBanner.body}
-            sx={sx.alertBanner}
-          />
-        )}
       <Box sx={sx.leadTextBox}>
+        {reportType === ReportType.SAR &&
+          workPlanStatus !== ReportStatus.APPROVED && (
+            <Alert
+              title={sarVerbiage.alertBanner.title}
+              showIcon={true}
+              icon={alertIcon}
+              status={AlertTypes.ERROR}
+              description={sarVerbiage.alertBanner.body}
+              sx={sx.alertBanner}
+            />
+          )}
         <Heading as="h1" sx={sx.headerText}>
           {fullStateName} {intro.header}
         </Heading>
@@ -270,7 +270,6 @@ export const DashboardPage = ({ reportType }: Props) => {
                   .stateUserDashboard
           }
         />
-
         {parseCustomHtml(intro.body)}
       </Box>
       <Box sx={sx.bodyBox}>
@@ -442,8 +441,7 @@ const sx = {
     marginBottom: "2rem",
     borderInlineStartWidth: "7.5px",
     bgColor: "palette.error_lightest",
-    marginLeft: "5rem",
-    width: "65%",
+    width: "80%",
     fontSize: "18px",
     p: {
       fontSize: "16px",

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -84,6 +84,9 @@ export const DashboardPage = ({ reportType }: Props) => {
   const dashboardVerbiage = dashboardVerbiageMap[reportType]!;
   const { intro, body } = dashboardVerbiage;
 
+  // get Work Plan status
+  const workPlanStatus = workPlanToCopyFrom?.status;
+
   // get active state
   const adminSelectedState = localStorage.getItem("selectedState") || undefined;
   const activeState = userState || adminSelectedState;
@@ -243,16 +246,18 @@ export const DashboardPage = ({ reportType }: Props) => {
         Return home
       </Link>
       {errorMessage && <ErrorAlert error={errorMessage} />}
-      {reportType === ReportType.SAR && isAddSubmissionDisabled() && (
-        <Alert
-          title={sarVerbiage.alertBanner.title}
-          showIcon={true}
-          icon={alertIcon}
-          status={AlertTypes.ERROR}
-          description={sarVerbiage.alertBanner.body}
-          sx={sx.alertBanner}
-        />
-      )}
+      {/* Only show SAR alert banner if the corresponding Work Plan is not approved */}
+      {reportType === ReportType.SAR &&
+        workPlanStatus !== ReportStatus.APPROVED && (
+          <Alert
+            title={sarVerbiage.alertBanner.title}
+            showIcon={true}
+            icon={alertIcon}
+            status={AlertTypes.ERROR}
+            description={sarVerbiage.alertBanner.body}
+            sx={sx.alertBanner}
+          />
+        )}
       <Box sx={sx.leadTextBox}>
         <Heading as="h1" sx={sx.headerText}>
           {fullStateName} {intro.header}

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -244,15 +244,15 @@ export const DashboardPage = ({ reportType }: Props) => {
         <Heading as="h1" sx={sx.headerText}>
           {fullStateName} {intro.header}
         </Heading>
-        {reportType === "WP" && (
-          <InstructionsAccordion
-            verbiage={
-              userIsAdmin
-                ? accordion.WP.adminDashboard
-                : accordion.WP.stateUserDashboard
-            }
-          />
-        )}
+        <InstructionsAccordion
+          verbiage={
+            userIsAdmin
+              ? accordion[reportType as keyof typeof ReportType].adminDashboard
+              : accordion[reportType as keyof typeof ReportType]
+                  .stateUserDashboard
+          }
+        />
+
         {parseCustomHtml(intro.body)}
       </Box>
       <Box sx={sx.bodyBox}>
@@ -370,7 +370,7 @@ const sx = {
   leadTextBox: {
     width: "100%",
     maxWidth: "55.25rem",
-    margin: "2.5rem auto",
+    margin: "2.5rem auto 0rem",
     ".tablet &, .mobile &": {
       margin: "2.5rem 0 1rem",
     },

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -24,6 +24,7 @@ import {
   MobileDashboardTable,
   PageTemplate,
   ReportContext,
+  Alert,
 } from "components";
 // utils
 import {
@@ -33,6 +34,7 @@ import {
   ReportShape,
   ReportType,
   ReportStatus,
+  AlertTypes,
 } from "types";
 import { parseCustomHtml, useBreakpoint, useStore } from "utils";
 // verbiage
@@ -41,6 +43,7 @@ import sarVerbiage from "verbiage/pages/sar/sar-dashboard";
 import accordion from "verbiage/pages/accordion";
 // assets
 import arrowLeftIcon from "assets/icons/icon_arrow_left_blue.png";
+import alertIcon from "assets/icons/icon_alert_circle.png";
 
 export const DashboardPage = ({ reportType }: Props) => {
   const {
@@ -198,7 +201,7 @@ export const DashboardPage = ({ reportType }: Props) => {
       setReportId(undefined);
       setReleasing(false);
 
-      //useDiscourse to open modal
+      // useDisclosure to open modal
       confirmUnlockModalOnOpenHandler();
     }
   };
@@ -237,9 +240,19 @@ export const DashboardPage = ({ reportType }: Props) => {
     <PageTemplate type="report" sx={sx.layout}>
       <Link as={RouterLink} to="/" sx={sx.returnLink}>
         <Image src={arrowLeftIcon} alt="Arrow left" className="returnIcon" />
-        Return Home
+        Return home
       </Link>
       {errorMessage && <ErrorAlert error={errorMessage} />}
+      {reportType === ReportType.SAR && isAddSubmissionDisabled() && (
+        <Alert
+          title={sarVerbiage.alertBanner.title}
+          showIcon={true}
+          icon={alertIcon}
+          status={AlertTypes.ERROR}
+          description={sarVerbiage.alertBanner.body}
+          sx={sx.alertBanner}
+        />
+      )}
       <Box sx={sx.leadTextBox}>
         <Heading as="h1" sx={sx.headerText}>
           {fullStateName} {intro.header}
@@ -350,6 +363,7 @@ const sx = {
   returnLink: {
     display: "flex",
     width: "8.5rem",
+    paddingTop: "0.5rem",
     svg: {
       height: "1.375rem",
       width: "1.375rem",
@@ -417,6 +431,18 @@ const sx = {
     width: "100%",
     justifyContent: "center",
     padding: "10",
+  },
+  alertBanner: {
+    marginTop: "3.5rem",
+    marginBottom: "2rem",
+    borderInlineStartWidth: "7.5px",
+    bgColor: "palette.error_lightest",
+    marginLeft: "5rem",
+    width: "65%",
+    fontSize: "18px",
+    p: {
+      fontSize: "16px",
+    },
   },
 };
 

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -104,4 +104,109 @@ export default {
       text: "",
     },
   },
+  SAR: {
+    adminDashboard: {
+      buttonLabel: "Instructions",
+      intro: [
+        {
+          type: "text",
+          as: "header",
+          content: "<strong>State or Territory User Instructions<strong>",
+        },
+        {
+          type: "text",
+          as: "span",
+          content:
+            "<br>This reporting tool is to be used by grantees for reporting of MFP program data. The information provided in this report will allow CMS to monitor grantee progress and identify challenges and improvement opportunities. For additional guidance on completing this form, please see the associated ",
+        },
+        {
+          type: "externalLink",
+          content: "User Guide",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+            target: "_blank",
+            "aria-label": "User Guide (Link opens in new tab)",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: " and ",
+        },
+        {
+          type: "externalLink",
+          content: "Help File",
+          props: {
+            href: "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+            target: "_blank",
+            "aria-label": "Help File (Link opens in new tab)",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: ".<br>",
+        },
+        {
+          type: "text",
+          as: "span",
+          content: "<br><strong>Admin Instructions</strong>",
+        },
+      ],
+      list: [
+        "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission. The status will change to “In revision”.",
+        "Submission count is shown in the # column. Submissions started and submitted once have a count of 1. When a state resubmits a previous submission, the count increases by 1.",
+        "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”.",
+        "To approve a submission, review the submission, go to the Review & Submit page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the SAR and will be available for view-only reference.",
+      ],
+      text: "",
+    },
+    stateUserDashboard: {
+      buttonLabel: "Instructions",
+      intro: [
+        {
+          type: "text",
+          as: "span",
+          content:
+            "This reporting tool is to be used by MFP recipients for semi-annual reporting of MFP program data. The information provided in this report will allow CMS to monitor recipients’ progress and identify challenges and opportunities for improvement. For additional guidance on completing this form, see the associated ",
+        },
+        {
+          type: "externalLink",
+          content: "User Guide",
+          props: {
+            href: "https://www.google.com",
+            target: "_blank",
+            "aria-label": "User Guide",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: " and ",
+        },
+        {
+          type: "externalLink",
+          content: "Help File",
+          props: {
+            href: "https://www.google.com",
+            target: "_blank",
+            "aria-label": "Help File.",
+          },
+        },
+        {
+          type: "text",
+          as: "span",
+          content: ".",
+        },
+      ],
+      list: [],
+      text: "",
+    },
+    formIntro: {
+      buttonLabel: "Instructions",
+      intro: "",
+      list: [],
+      text: "",
+    },
+  },
 };

--- a/services/ui-src/src/verbiage/pages/sar/sar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-dashboard.ts
@@ -1,36 +1,7 @@
 export default {
   intro: {
     header: "MFP Semi-Annual Progress Report (SAR)",
-    body: [
-      {
-        type: "text",
-        content:
-          "This reporting tool is to be used by MFP recipients for semi-annual reporting of MFP program data. The information provided in this report will allow CMS to monitor recipients’ progress and identify challenges and opportunities for improvement. For additional guidance on completing this form, see the associated ",
-      },
-      {
-        type: "externalLink",
-        content: "User Guide",
-        props: {
-          href: "https://www.google.com",
-          target: "_blank",
-          "aria-label": "User Guide",
-        },
-      },
-      {
-        type: "text",
-        as: "span",
-        content: " and ",
-      },
-      {
-        type: "externalLink",
-        content: "Help File",
-        props: {
-          href: "https://www.google.com",
-          target: "_blank",
-          "aria-label": "Help File.",
-        },
-      },
-    ],
+    body: [],
   },
   body: {
     table: {
@@ -41,7 +12,7 @@ export default {
         "Target populations",
         "Due date",
         "Last edited",
-        "Edited By",
+        "Edited by",
         "Status",
         "",
       ],

--- a/services/ui-src/src/verbiage/pages/sar/sar-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-dashboard.ts
@@ -20,4 +20,9 @@ export default {
     empty: "Once you start a SAR submission, you can access it here.",
     callToAction: "Add new SAR submission",
   },
+  alertBanner: {
+    title:
+      "You must have an approved Work Plan not previously used in a Semi-Annual Progress Report (SAR) in order to add a new SAR",
+    body: "Enter your Work Plan by selecting <i>Return home</i> above.",
+  },
 };

--- a/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
@@ -1,12 +1,7 @@
 export default {
   intro: {
     header: "MFP Program Work Plan",
-    body: [
-      {
-        type: "text",
-        content: "",
-      },
-    ],
+    body: [],
   },
   body: {
     table: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Empty view of the SAR dashboard for a state user, including an alert banner that shows if a user doesn't have an ongoing Work Plan.

Follow-up items / not covered in this pull request:

- Once statusing is in place for the Work Plan, the alert banner will need to be updated to show if a Work Plan is submitted and approved by an admin
- Table contents themselves are covered in a separate ticket

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type MDCT-<ticket-number> for autolinking -->
MDCT-2877

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Navigate to the `/sar` page

You should see an alert banner ⏰ 

- Navigate to the `/wp` 
- Create a new Work Plan
- Navigate back to the `/sar` page

The alert should be gone! 🪄 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
