### PR TITLE
Cmdct 3019 - add period info for R, E, T pages except for page nine

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -158,7 +158,7 @@
       "path": "/sar/recruitment-enrollment-transitions",
       "children": [
         {
-          "name": "Number of people who signed an MFP informed consent form in the reporting period",
+          "name": "Number of people who signed an MFP informed consent form in the ",
           "path": "/sar/recruitment-enrollment-transitions/number-of-people-signed-informed-consent-form",
           "pageType": "standard",
           "verbiage": {
@@ -169,7 +169,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of people who signed an MFP informed consent form in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of people who signed an MFP informed consent form in the reporting period"
                 },
                 {
                   "type": "span",
@@ -229,7 +229,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of MFP transitions in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of MFP transitions in the reporting period"
                 },
                 {
                   "type": "span",
@@ -323,7 +323,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of MFP transitions from qualified institutions in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of MFP transitions from qualified institutions in the reporting period"
                 },
                 {
                   "type": "span",
@@ -516,7 +516,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of MFP transitions to qualified residences in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of MFP transitions to qualified residences in the reporting period"
                 },
                 {
                   "type": "span",
@@ -676,7 +676,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Total number of active MFP participants in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Total number of active MFP participants in the reporting period"
                 },
                 {
                   "type": "span",
@@ -737,7 +737,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of MFP participants completing the program in the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of MFP participants completing the program in the reporting period"
                 },
                 {
                   "type": "span",
@@ -798,7 +798,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of people re-enrolled in MFP during the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of people re-enrolled in MFP during the reporting period"
                 },
                 {
                   "type": "span",
@@ -859,7 +859,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of MFP participants disenrolled from the program during the {January 1 to June 30, 2023} reporting period"
+                  "content": "Number of MFP participants disenrolled from the program during the reporting period"
                 },
                 {
                   "type": "span",
@@ -1297,7 +1297,7 @@
               "info": [
                 {
                   "type": "h3",
-                  "content": "Number of HCBS participants (including MFP participants) admitted to a facility from the community, by length of stay and age group {July 1 to December 31} reporting period"
+                  "content": "Number of HCBS participants (including MFP participants) admitted to a facility from the community, by length of stay and age group reporting period"
                 },
                 {
                   "type": "span",

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -11,6 +11,7 @@ export const ReportPageIntro = ({
   accordion,
   initiativeName,
   reportPeriod,
+  reportYear,
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
@@ -25,7 +26,11 @@ export const ReportPageIntro = ({
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && <InstructionsAccordion verbiage={accordion} />}
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-      <ReportPeriod text={text} reportPeriod={reportPeriod} />
+      <ReportPeriod
+        text={text}
+        reportPeriod={reportPeriod}
+        reportYear={reportYear}
+      />
     </Box>
   );
 };
@@ -36,6 +41,7 @@ interface Props {
   initiativeName?: string;
   [key: string]: any;
   reportPeriod?: number;
+  reportYear?: number;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -2,8 +2,9 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
-import { displayLongformPeriod, parseCustomHtml } from "utils";
+import { parseCustomHtml } from "utils";
 import { AnyObject } from "types";
+import { ReportPeriod } from "./ReportPeriod";
 
 export const ReportPageIntro = ({
   text,
@@ -13,9 +14,6 @@ export const ReportPageIntro = ({
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
-  const retSection = section === "Recruitment, Enrollment, and Transitions";
-  const pageNine = subsection.includes("HCBS");
-  const currentPeriod = displayLongformPeriod(reportPeriod);
   return (
     <Box sx={sx.introBox} {...props}>
       <Heading as="h1" sx={sx.sectionHeading}>
@@ -27,16 +25,7 @@ export const ReportPageIntro = ({
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && <InstructionsAccordion verbiage={accordion} />}
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-      {retSection &&
-        (!pageNine ? (
-          <Heading as="h2" sx={sx.periodText}>
-            {currentPeriod}
-          </Heading>
-        ) : (
-          <Heading as="h2" sx={sx.periodText}>
-            This page needs a different calculation
-          </Heading>
-        ))}
+      <ReportPeriod text={text} reportPeriod={reportPeriod} />
     </Box>
   );
 };

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -2,7 +2,7 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
-import { parseCustomHtml } from "utils";
+import { calculatePeriod, convertDateUtcToEt, parseCustomHtml } from "utils";
 import { AnyObject } from "types";
 
 export const ReportPageIntro = ({
@@ -12,6 +12,9 @@ export const ReportPageIntro = ({
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
+  const currentDate = Date.now();
+  const date = new Date(convertDateUtcToEt(currentDate));
+  const currentPeriod = calculatePeriod(date);
   return (
     <Box sx={sx.introBox} {...props}>
       <Heading as="h1" sx={sx.sectionHeading}>
@@ -22,7 +25,14 @@ export const ReportPageIntro = ({
       </Heading>
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && <InstructionsAccordion verbiage={accordion} />}
-      {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
+      {info && (
+        <>
+          <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>
+          <Heading as="h2" sx={sx.periodText}>
+            {currentPeriod} reporting period
+          </Heading>
+        </>
+      )}
     </Box>
   );
 };
@@ -50,14 +60,10 @@ const sx = {
     color: "#5B616B",
     paddingTop: "1.5rem",
   },
-  spreadsheetWidgetBox: {
-    marginTop: "2rem",
-  },
   infoTextBox: {
     marginTop: "2rem",
-    h4: {
-      fontSize: "lg",
-      marginBottom: "0.75rem",
+    h3: {
+      marginBottom: "-0.75rem",
     },
     "p, span": {
       color: "palette.gray",
@@ -72,5 +78,9 @@ const sx = {
     b: {
       color: "palette.base",
     },
+  },
+  periodText: {
+    marginTop: "1.5rem",
+    fontSize: "2xl",
   },
 };

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -2,25 +2,20 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
-import {
-  calculateLongformPeriod,
-  convertDateUtcToEt,
-  parseCustomHtml,
-} from "utils";
-import { AnyObject, ReportType } from "types";
+import { displayLongformPeriod, parseCustomHtml } from "utils";
+import { AnyObject } from "types";
 
 export const ReportPageIntro = ({
   text,
   accordion,
   initiativeName,
-  reportType,
+  reportPeriod,
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
-  const currentDate = Date.now();
-  const isSAR = reportType === ReportType.SAR;
-  const date = new Date(convertDateUtcToEt(currentDate));
-  const currentPeriod = calculateLongformPeriod(date);
+  const retSection = section === "Recruitment, Enrollment, and Transitions";
+  const pageNine = subsection.includes("HCBS");
+  const currentPeriod = displayLongformPeriod(reportPeriod);
   return (
     <Box sx={sx.introBox} {...props}>
       <Heading as="h1" sx={sx.sectionHeading}>
@@ -32,11 +27,16 @@ export const ReportPageIntro = ({
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && <InstructionsAccordion verbiage={accordion} />}
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-      {info && isSAR && (
-        <Heading as="h2" sx={sx.periodText}>
-          {currentPeriod} reporting period
-        </Heading>
-      )}
+      {retSection &&
+        (!pageNine ? (
+          <Heading as="h2" sx={sx.periodText}>
+            {currentPeriod}
+          </Heading>
+        ) : (
+          <Heading as="h2" sx={sx.periodText}>
+            This page needs a different calculation
+          </Heading>
+        ))}
     </Box>
   );
 };
@@ -46,7 +46,7 @@ interface Props {
   accordion?: AnyObject;
   initiativeName?: string;
   [key: string]: any;
-  reportType?: string;
+  reportPeriod?: number;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -2,19 +2,25 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
-import { calculatePeriod, convertDateUtcToEt, parseCustomHtml } from "utils";
-import { AnyObject } from "types";
+import {
+  calculateLongformPeriod,
+  convertDateUtcToEt,
+  parseCustomHtml,
+} from "utils";
+import { AnyObject, ReportType } from "types";
 
 export const ReportPageIntro = ({
   text,
   accordion,
   initiativeName,
+  reportType,
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
   const currentDate = Date.now();
+  const isSAR = reportType === ReportType.SAR;
   const date = new Date(convertDateUtcToEt(currentDate));
-  const currentPeriod = calculatePeriod(date);
+  const currentPeriod = calculateLongformPeriod(date);
   return (
     <Box sx={sx.introBox} {...props}>
       <Heading as="h1" sx={sx.sectionHeading}>
@@ -25,13 +31,11 @@ export const ReportPageIntro = ({
       </Heading>
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && <InstructionsAccordion verbiage={accordion} />}
-      {info && (
-        <>
-          <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>
-          <Heading as="h2" sx={sx.periodText}>
-            {currentPeriod} reporting period
-          </Heading>
-        </>
+      {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
+      {info && isSAR && (
+        <Heading as="h2" sx={sx.periodText}>
+          {currentPeriod} reporting period
+        </Heading>
       )}
     </Box>
   );
@@ -42,6 +46,7 @@ interface Props {
   accordion?: AnyObject;
   initiativeName?: string;
   [key: string]: any;
+  reportType?: string;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportPeriod.tsx
+++ b/services/ui-src/src/components/reports/ReportPeriod.tsx
@@ -1,0 +1,39 @@
+// components
+import { Box, Heading } from "@chakra-ui/react";
+// utils
+import { displayLongformPeriod } from "utils";
+import { AnyObject } from "types";
+
+export const ReportPeriod = ({ text, reportPeriod }: Props) => {
+  const { section, subsection } = text;
+  const retSection = section === "Recruitment, Enrollment, and Transitions";
+  const pageNine = subsection.includes("HCBS");
+  const currentPeriod = displayLongformPeriod(reportPeriod);
+  return (
+    <Box>
+      {retSection &&
+        (!pageNine ? (
+          <Heading as="h2" sx={sx.periodText}>
+            {currentPeriod}
+          </Heading>
+        ) : (
+          <Heading as="h2" sx={sx.periodText}>
+            This page needs a different calculation
+          </Heading>
+        ))}
+    </Box>
+  );
+};
+
+interface Props {
+  text: AnyObject;
+  [key: string]: any;
+  reportPeriod?: number;
+}
+
+const sx = {
+  periodText: {
+    marginTop: "1.5rem",
+    fontSize: "2xl",
+  },
+};

--- a/services/ui-src/src/components/reports/ReportPeriod.tsx
+++ b/services/ui-src/src/components/reports/ReportPeriod.tsx
@@ -4,11 +4,11 @@ import { Box, Heading } from "@chakra-ui/react";
 import { displayLongformPeriod } from "utils";
 import { AnyObject } from "types";
 
-export const ReportPeriod = ({ text, reportPeriod }: Props) => {
+export const ReportPeriod = ({ text, reportPeriod, reportYear }: Props) => {
   const { section, subsection } = text;
   const retSection = section === "Recruitment, Enrollment, and Transitions";
   const pageNine = subsection.includes("HCBS");
-  const currentPeriod = displayLongformPeriod(reportPeriod);
+  const currentPeriod = displayLongformPeriod(reportPeriod, reportYear);
   return (
     <Box>
       {retSection &&
@@ -29,6 +29,7 @@ interface Props {
   text: AnyObject;
   [key: string]: any;
   reportPeriod?: number;
+  reportYear?: number;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -64,6 +64,7 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
         <ReportPageIntro
           text={route.verbiage.intro}
           reportPeriod={report?.reportPeriod}
+          reportYear={report?.reportYear}
         />
       )}
       <Form

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -59,7 +59,12 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
 
   return (
     <Box>
-      {route.verbiage?.intro && <ReportPageIntro text={route.verbiage.intro} />}
+      {route.verbiage?.intro && (
+        <ReportPageIntro
+          text={route.verbiage.intro}
+          reportType={report?.reportType}
+        />
+      )}
       <Form
         id={route.form.id}
         formJson={route.form}

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -14,6 +14,7 @@ import {
   AnyObject,
   isFieldElement,
   ReportStatus,
+  ReportShape,
 } from "types";
 // utils
 import { filterFormData, useFindRoute, useStore } from "utils";
@@ -62,7 +63,7 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
       {route.verbiage?.intro && (
         <ReportPageIntro
           text={route.verbiage.intro}
-          reportType={report?.reportType}
+          reportPeriod={report?.reportPeriod}
         />
       )}
       <Form
@@ -83,4 +84,5 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
 interface Props {
   route: StandardReportPageShape;
   validateOnRender?: boolean;
+  report?: ReportShape;
 }

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -163,3 +163,20 @@ export const calculateRemainingSeconds = (expiresAt?: any) => {
   if (!expiresAt) return 0;
   return moment(expiresAt).diff(moment()) / 1000;
 };
+
+/*
+ * Calculates the period given a due date.
+ * The periods are defined as follows:
+ *     Period 1 is from 01/01 to 06/30.
+ *     Period 2 is from 07/01 to 12/31.
+ */
+export const calculatePeriod = (currentDate: Date) => {
+  const date = new Date(currentDate);
+  const currentYear = new Date().getFullYear();
+  const period = Math.ceil((date.getMonth() + 1) / 6);
+  if (period == 1) {
+    return ` {January 1 to June 30 ${currentYear}}`;
+  } else {
+    return ` {July 1 to December 31 ${currentYear}}`;
+  }
+};

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -166,7 +166,7 @@ export const calculateRemainingSeconds = (expiresAt?: any) => {
 
 export const displayLongformPeriod = (period: number | undefined) => {
   const currentYear = new Date().getFullYear();
-  if (period == 1) {
+  if (period === 1) {
     return ` {January 1 to June 30 ${currentYear}} reporting period`;
   } else {
     return ` {July 1 to December 31 ${currentYear}} reporting period`;

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -164,19 +164,11 @@ export const calculateRemainingSeconds = (expiresAt?: any) => {
   return moment(expiresAt).diff(moment()) / 1000;
 };
 
-/*
- * Calculates the period given a due date.
- * The periods are defined as follows:
- *     Period 1 is from 01/01 to 06/30.
- *     Period 2 is from 07/01 to 12/31.
- */
-export const calculateLongformPeriod = (currentDate: Date) => {
-  const date = new Date(currentDate);
+export const displayLongformPeriod = (period: number | undefined) => {
   const currentYear = new Date().getFullYear();
-  const period = Math.ceil((date.getMonth() + 1) / 6);
   if (period == 1) {
-    return ` {January 1 to June 30 ${currentYear}}`;
+    return ` {January 1 to June 30 ${currentYear}} reporting period`;
   } else {
-    return ` {July 1 to December 31 ${currentYear}}`;
+    return ` {July 1 to December 31 ${currentYear}} reporting period`;
   }
 };

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -164,11 +164,13 @@ export const calculateRemainingSeconds = (expiresAt?: any) => {
   return moment(expiresAt).diff(moment()) / 1000;
 };
 
-export const displayLongformPeriod = (period: number | undefined) => {
-  const currentYear = new Date().getFullYear();
+export const displayLongformPeriod = (
+  period: number | undefined,
+  reportYear: number | undefined
+) => {
   if (period === 1) {
-    return ` {January 1 to June 30 ${currentYear}} reporting period`;
+    return ` {January 1 to June 30 ${reportYear}} reporting period`;
   } else {
-    return ` {July 1 to December 31 ${currentYear}} reporting period`;
+    return ` {July 1 to December 31 ${reportYear}} reporting period`;
   }
 };

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -170,7 +170,7 @@ export const calculateRemainingSeconds = (expiresAt?: any) => {
  *     Period 1 is from 01/01 to 06/30.
  *     Period 2 is from 07/01 to 12/31.
  */
-export const calculatePeriod = (currentDate: Date) => {
+export const calculateLongformPeriod = (currentDate: Date) => {
   const date = new Date(currentDate);
   const currentYear = new Date().getFullYear();
   const period = Math.ceil((date.getMonth() + 1) / 6);


### PR DESCRIPTION
### Description
Each page in the `Recruitment, Enrollment, and Transitions` section needs the reporting period displayed. The exception is page 9, so I've excluded it and that work is its own card. I put this section into its own component and then brought it into the `ReportPageIntro` component. 

Also, the design has been updated, here is a screenshot of the spec:
![Screenshot 2023-10-19 at 2 38 00 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/8aca1f01-0b8f-4bbb-93cb-39ec5666d7c4)




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3019

---
### How to test
See that the reporting period text only appears in the Recruitment, Enrollment, and Transitions section, and page 9 differs. Also see that this text doesn't appear on any other pages (this component is shared across the WP and SAR.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
