### PR TITLE
Add x-frame-options header

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -245,6 +245,7 @@ resources:
             headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
             headers['x-content-type-options'] = { value: 'nosniff' };
             headers['x-xss-protection'] = { value: '0' };
+            headers['x-frame-options'] = { value: 'DENY' };
             return response;
           }
         FunctionConfig:


### PR DESCRIPTION
### Description
This PR adds an additional HTTP header when serving the website, which instructs browsers not to serve our content within an iframe.

### Related ticket(s)
CMDCT-271

---
### How to test
We don't use iframes to serve this website, so this PR shouldn't change anything. A quick smoke test (as provided by Cypress) should be sufficient.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~

