### PR TITLE
[CMDCT-159] Add DateField tests

### DIFF
--- a/services/ui-src/src/components/fields/DateField.test.tsx
+++ b/services/ui-src/src/components/fields/DateField.test.tsx
@@ -1,11 +1,16 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 //components
 import { useFormContext } from "react-hook-form";
-import { DateField } from "components";
+import { DateField, ReportContext } from "components";
 import { useStore } from "utils";
-import { mockStateUserStore } from "utils/testing/setupJest";
+import {
+  mockStateUserStore,
+  mockWpReportContext,
+} from "utils/testing/setupJest";
+import { ReportStatus } from "../../types";
+import { mockStateUser } from "../../utils/testing/mockUsers";
 
 const mockTrigger = jest.fn();
 const mockRhfMethods = {
@@ -55,6 +60,173 @@ describe("Test DateField basic functionality", () => {
     await userEvent.type(dateFieldInput, "07/14/2022");
     await userEvent.tab();
     expect(dateFieldInput.value).toEqual("07/14/2022");
+  });
+});
+
+describe("Test DateField hydration functionality", () => {
+  const mockFormFieldValue = "7/1/2022";
+  const mockHydrationValue = "1/1/2022";
+
+  const dateFieldComponentWithHydrationValue = (
+    <DateField
+      name="testDateFieldWithHydrationValue"
+      label="test-date-field-with-hydration-value"
+      hydrate={mockHydrationValue}
+    />
+  );
+
+  const clearPropGivenAndTrueDateField = (
+    <DateField
+      name="testDateFieldWithHydrationValue"
+      label="test-date-field-with-hydration-value"
+      hydrate={mockHydrationValue}
+      clear
+    />
+  );
+
+  const clearPropGivenAndFalseDateField = (
+    <DateField
+      name="testDateFieldWithHydrationValue"
+      label="test-date-field-with-hydration-value"
+      hydrate={mockHydrationValue}
+      clear={false}
+    />
+  );
+
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockStateUserStore);
+  });
+
+  test("If only formFieldValue exists, displayValue is set to it", () => {
+    mockedUseStore.mockReturnValue(mockStateUserStore);
+    mockGetValues(mockFormFieldValue);
+    const result = render(dateFieldComponent);
+    const dateFieldInput: HTMLInputElement = result.container.querySelector(
+      "[name='testDateField']"
+    )!;
+    expect(dateFieldInput).toBeVisible();
+    expect(dateFieldInput.value).toEqual(mockFormFieldValue);
+  });
+
+  test("If only hydrationValue exists, displayValue is set to it", () => {
+    mockGetValues(undefined);
+    const result = render(dateFieldComponentWithHydrationValue);
+    const dateFieldInput: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateFieldInput.value;
+    expect(displayValue).toEqual(mockHydrationValue);
+  });
+
+  test("If both formFieldValue and hydrationValue exist, displayValue is set to formFieldValue", () => {
+    mockGetValues(mockFormFieldValue);
+    const result = render(dateFieldComponentWithHydrationValue);
+    const dateFieldInput: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateFieldInput.value;
+    expect(displayValue).toEqual(mockFormFieldValue);
+  });
+
+  test("should set value to default if given clear prop and clear is set to true", () => {
+    mockGetValues(undefined);
+
+    const result = render(clearPropGivenAndTrueDateField);
+    const dateField: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateField.value;
+    expect(displayValue).toEqual("");
+  });
+
+  test("should set value to hydrationvalue if given clear prop and clear is set to false", () => {
+    mockGetValues(undefined);
+    const result = render(clearPropGivenAndFalseDateField);
+    const dateField: HTMLInputElement = result.container.querySelector(
+      "[name='testDateFieldWithHydrationValue']"
+    )!;
+    const displayValue = dateField.value;
+    expect(displayValue).toEqual(mockHydrationValue);
+  });
+});
+
+describe("Test DateField autosave functionality", () => {
+  const dateFieldAutosavingComponent = (
+    <ReportContext.Provider value={mockWpReportContext}>
+      <DateField name="testDateField" label="test-date-field" autosave={true} />
+    </ReportContext.Provider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Autosaves entered date when state user, autosave true, and field is valid", async () => {
+    mockedUseStore.mockReturnValue(mockStateUserStore);
+    mockTrigger.mockReturnValue(true);
+    mockGetValues(undefined);
+    render(dateFieldAutosavingComponent);
+    const dateField = screen.getByRole("textbox", { name: "test-date-field" });
+    expect(dateField).toBeVisible();
+    await userEvent.type(dateField, "07/14/2022");
+    await userEvent.tab();
+    expect(mockWpReportContext.updateReport).toHaveBeenCalledTimes(1);
+    expect(mockWpReportContext.updateReport).toHaveBeenCalledWith(
+      {
+        reportType: undefined,
+        state: mockStateUser.user?.state,
+        id: undefined,
+      },
+      {
+        metadata: {
+          status: ReportStatus.IN_PROGRESS,
+          lastAlteredBy: mockStateUser.user?.full_name,
+        },
+        fieldData: { testDateField: "07/14/2022" },
+      }
+    );
+  });
+
+  test("Does not autosave if autosave is false", async () => {
+    mockedUseStore.mockReturnValue(mockStateUser);
+    mockGetValues(undefined);
+    render(dateFieldComponent);
+    const dateField = screen.getByRole("textbox", { name: "test-date-field" });
+    expect(dateField).toBeVisible();
+    await userEvent.type(dateField, "07/14/2022");
+    await userEvent.tab();
+    expect(mockWpReportContext.updateReport).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("Datefield handles triggering validation", () => {
+  const dateFieldComponentWithValidateOnRender = (
+    <DateField name="testDateField" label="test-date-field" validateOnRender />
+  );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Blanking field triggers form validation", async () => {
+    mockedUseStore.mockReturnValue(mockStateUser);
+    mockGetValues(undefined);
+    const result = render(dateFieldComponent);
+    expect(mockTrigger).not.toHaveBeenCalled();
+    const dateFieldInput = result.getByRole("textbox", {
+      name: "test-date-field",
+    });
+    await userEvent.click(dateFieldInput);
+    await userEvent.clear(dateFieldInput);
+    await userEvent.tab();
+    expect(mockTrigger).toHaveBeenCalled();
+  });
+
+  test("Component with validateOnRender passed should validate on initial render", async () => {
+    mockedUseStore.mockReturnValue(mockStateUser);
+    mockGetValues(undefined);
+    render(dateFieldComponentWithValidateOnRender);
+    expect(mockTrigger).toHaveBeenCalled();
   });
 });
 

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -22,6 +22,7 @@ export const DateField = ({
   sxOverride,
   nested,
   autosave,
+  validateOnRender,
   styleAsOptional,
   ...props
 }: Props) => {
@@ -36,6 +37,16 @@ export const DateField = ({
 
   // get form context and register form field
   const form = useFormContext();
+
+  const fieldIsRegistered = name in form.getValues();
+
+  useEffect(() => {
+    if (!fieldIsRegistered && !validateOnRender) {
+      form.register(name);
+    } else if (validateOnRender) {
+      form.trigger(name);
+    }
+  }, []);
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate || defaultValue;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This change adds DateFields test to increase line coverage to 100% (though Branch Coverage is not 100)


| File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       |
|--------|--------|--------|--------|--------|-------|
|  DateField.tsx               |     100 |    83.33 |     100 |     100 | 46,117-130  |


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-159

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. cd `/services/ui-src/`
2. run `yarn test --coverage`
3. verify that coverage for DateField class is 100
4. cd `../..` back to mfp root
5. run `./dev local'`
6. create a WP. Validate DateField components render correctly on dashboard

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [X] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [N/A] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
