### PR TITLE
update getStatus for showing correct dashboard status

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -26,7 +26,7 @@ import {
   ReportContext,
   Alert,
 } from "components";
-// utils
+// types
 import {
   AnyObject,
   ReportMetadataShape,
@@ -36,6 +36,7 @@ import {
   ReportStatus,
   AlertTypes,
 } from "types";
+// utils
 import { parseCustomHtml, useBreakpoint, useStore } from "utils";
 // verbiage
 import wpVerbiage from "verbiage/pages/wp/wp-dashboard";

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -150,7 +150,7 @@ export const getStatus = (
       submissionCount >= 1 &&
       !status.includes("Submitted")
     ) {
-      return `In revision`;
+      return status;
     }
   }
   return status;


### PR DESCRIPTION
### Description
Bug addressing this ticket:

Testing notes: After I filled out a form as a state user and submitted it, I logged into the admin account to approve the WP. For some reason when I go through the approval process, it triggers the unlock functionality for the form and causes the form to go into "In revision". 
https://jiraent.cms.gov/browse/CMDCT-406

Solution: There was some old MCR logic that set the status to 'in revision' on the frontend if status isn't 'submitted'. That was removed so it's just passing in the status thats coming from the backend. 

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/e99b972f-74e9-46b0-89d5-7a0dc6a1fca7




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
1. In create.ts file, update this Item object with `status: 'Submitted" ` ( then rerun dev )
```// Create DyanmoDB record.
    const reportMetadataParams: DynamoWrite = {
      TableName: reportTable,
      Item: {
        ...validatedMetadata,
        state,
        id: reportId,
        fieldDataId,
        status: "Submitted",
        formTemplateId,
        createdAt: currentDate,
        lastAltered: currentDate,
        versionNumber: formTemplateVersion?.versionNumber,
        submissionName: createReportName(
          reportTypeExpanded,
          currentDate,
          state,
          reportYear,
          workPlanMetadata
        ),
        reportYear,
        reportPeriod,
        dueDate: calculateDueDate(reportYear, reportPeriod, reportType),
        associatedWorkPlan: workPlanMetadata?.id,
      },
    };```
2. Log in as a stateuser2 and create a report (status should be 'Submitted')
3. log out and sign in as an adminuser.
4. Go to review and submit and select Approve button from the Admin Review section
5. After approving report it should re-direct to the dashboard 
6. The report status should stay Approved 
