### PR TITLE
start bringing over PDF components from MCR

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -1,0 +1,217 @@
+// components
+import { ExportedSectionHeading } from "components";
+import { Box } from "@chakra-ui/react";
+// types
+import {
+  EntityShape,
+  FormField,
+  FormLayoutElement,
+  ModalOverlayReportPageShape,
+  ReportType,
+} from "types";
+// utils
+import { useStore } from "utils";
+import { assertExhaustive } from "utils/other/typing";
+// verbiage
+import wpVerbiage from "verbiage/pages/wp/wp-export";
+import sarVerbiage from "verbiage/pages/sar/sar-export";
+
+const exportVerbiageMap: { [key in ReportType]: any } = {
+  WP: wpVerbiage,
+  SAR: sarVerbiage,
+};
+
+export const ExportedEntityDetailsOverlaySection = ({
+  section,
+  ...props
+}: ExportedEntityDetailsOverlaySectionProps) => {
+  const { report } = useStore() ?? {};
+  const entityType = section.entityType;
+
+  return (
+    <Box sx={sx.sectionHeading} {...props}>
+      <ExportedSectionHeading
+        heading={exportVerbiageMap[report?.reportType as ReportType]}
+        reportType={report?.reportType}
+        verbiage={{
+          ...section.verbiage,
+          intro: {
+            ...section.verbiage.intro,
+            info: undefined,
+            exportSectionHeader: undefined,
+            spreadsheet: "MLR Reporting",
+          },
+        }}
+      />
+      {renderEntityDetailTables(
+        report?.reportType as ReportType,
+        report?.fieldData[entityType] ?? [],
+        section
+      )}
+    </Box>
+  );
+};
+
+export interface ExportedEntityDetailsOverlaySectionProps {
+  section: ModalOverlayReportPageShape;
+}
+/**
+ * Split a list of form fields by the "sectionHeader" layout element type.
+ * This allows returning distinct tables for each section, rather than one large one.
+ *
+ * In the returned FormField sections, the first element is the section header.
+ *
+ * @param formFields List of form fields, possibly containing section headers
+ * @returns array of arrays containing form field elements representing a section
+ */
+export function getFormSections(
+  formFields: (FormField | FormLayoutElement)[]
+): (FormLayoutElement | FormField)[][] {
+  const formSections: (FormLayoutElement | FormField)[][] = [];
+
+  let currentSection: (FormField | FormLayoutElement)[] = [];
+  for (let field of formFields) {
+    if (field.type === "sectionHeader") {
+      if (currentSection.length > 0) {
+        formSections.push(currentSection);
+      }
+      currentSection = [field];
+    } else {
+      currentSection.push(field);
+    }
+  }
+  formSections.push(currentSection);
+
+  return formSections;
+}
+
+/**
+ *
+ * @param entities entities for entity type
+ * @param section form json for section
+ * @param formSections form fields broken down into sections
+ * @param report report field data
+ * @returns entity table and heading information for each section
+ */
+
+/**
+ * Render entity detail table(s) conditionally based on report type.
+ *
+ * @param reportType report type of report
+ * @param entities entities for entity type
+ * @param section form json section
+ * @param report report data
+ * @returns array of exported entity table components
+ */
+export function renderEntityDetailTables(
+  reportType: ReportType,
+  entities: EntityShape[],
+  section: ModalOverlayReportPageShape
+) {
+  switch (reportType) {
+    case ReportType.WP: {
+      const formSections = getFormSections(section.overlayForm?.fields ?? []);
+      return `${JSON.stringify(entities)}.....${JSON.stringify(
+        section
+      )}.....${JSON.stringify(formSections)}.....`;
+    }
+    case ReportType.SAR:
+      throw new Error(
+        `The entity detail table for report type '${reportType}' have not been implemented.`
+      );
+    default:
+      assertExhaustive(reportType);
+      throw new Error(
+        `The entity detail table for report type '${reportType}' have not been implemented.`
+      );
+  }
+}
+
+const sx = {
+  root: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+    marginBottom: "1rem",
+    width: "100%",
+    "tr, th": {
+      verticalAlign: "bottom",
+      lineHeight: "base",
+      borderBottom: "1px solid",
+      borderColor: "palette.gray_lighter",
+    },
+    thead: {
+      //this will prevent generating a new header whenever the table spills over in another page
+      display: "table-row-group",
+    },
+    td: {
+      p: {
+        lineHeight: "1.25rem",
+      },
+      padding: "0.75rem 0.5rem",
+      borderStyle: "none",
+      fontWeight: "normal",
+      color: "palette.base",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      ".mobile &": {
+        fontSize: "xs",
+      },
+      verticalAlign: "top",
+    },
+    th: {
+      maxWidth: "100%",
+      paddingBottom: "0.375rem",
+      fontWeight: "bold",
+      lineHeight: "lg",
+      color: "palette.gray_medium",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      "&:first-of-type": {
+        paddingLeft: 0,
+      },
+    },
+    ".desktop &": {
+      "&.two-column": {
+        "th:first-of-type": {
+          paddingLeft: "6rem",
+        },
+      },
+    },
+  },
+  tableIndex: {
+    color: "palette.gray_medium",
+    fontWeight: "bold",
+  },
+  statusIcon: {
+    paddingLeft: "1rem",
+    img: {
+      maxWidth: "fit-content",
+    },
+  },
+  emptyState: {
+    margin: "0 auto",
+    textAlign: "center",
+    paddingBottom: "5rem",
+  },
+  entityInformation: {
+    padding: "1rem 0 1rem 0",
+    fontWeight: "bold",
+  },
+  entityHeading: {
+    padding: "2rem 0 0.5rem 0",
+    color: "palette.gray_medium",
+    width: "100%",
+    p: {
+      color: "palette.base",
+      "&:first-of-type": {
+        marginTop: "1rem",
+      },
+    },
+  },
+  sectionHeading: {
+    padding: "1.5rem 0 0 0",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -1,0 +1,179 @@
+import { ReactElement } from "react";
+// components
+import { Table } from "components";
+// types, utils
+import {
+  EntityShape,
+  FieldChoice,
+  FormField,
+  ReportShape,
+  FormLayoutElement,
+  ReportType,
+  isFieldElement,
+} from "types";
+import { useStore } from "utils";
+// verbiage
+import verbiage from "verbiage/pages/wp/wp-export";
+
+import { ExportedEntityDetailsTableRow } from "./ExportedEntityDetailsTableRow";
+
+export const ExportedEntityDetailsTable = ({
+  fields,
+  entity,
+  ...props
+}: Props) => {
+  const { report } = useStore() ?? {};
+  const { tableHeaders } = verbiage;
+
+  const entityType = "program";
+
+  const threeColumnHeaderItems = [
+    tableHeaders.number,
+    tableHeaders.indicator,
+    tableHeaders.response,
+  ];
+
+  const reportType = report?.reportType as ReportType;
+  const hideHintText = reportType === ReportType.SAR;
+
+  return (
+    <Table
+      {...props}
+      sx={sx.root}
+      content={{
+        headRow: threeColumnHeaderItems,
+      }}
+    >
+      {renderFieldTableBody(
+        fields!,
+        "modalOverlay",
+        report,
+        !hideHintText,
+        entity.id,
+        entityType
+      )}
+    </Table>
+  );
+};
+
+export const renderFieldTableBody = (
+  formFields: (FormField | FormLayoutElement)[],
+  pageType: string,
+  report: ReportShape | undefined,
+  showHintText: boolean,
+  entityId: string,
+  entityType: string
+) => {
+  const tableRows: ReactElement[] = [];
+  // recursively renders field rows
+  const renderFieldRow = (formField: FormField | FormLayoutElement) => {
+    const validationType = isFieldElement(formField)
+      ? typeof formField.validation === "object"
+        ? formField.validation.type
+        : formField.validation
+      : "";
+
+    const optional =
+      validationType && validationType !== ""
+        ? validationType.includes("Optional")
+        : false;
+
+    tableRows.push(
+      <ExportedEntityDetailsTableRow
+        key={formField.id}
+        formField={formField}
+        pageType={pageType}
+        entityType={entityType}
+        showHintText={showHintText}
+        entityId={entityId}
+        optional={optional}
+      />
+    );
+
+    const entity = report?.fieldData[entityType].find(
+      (e: EntityShape) => e.id === entityId
+    );
+
+    // Handle rendering nested children
+    if (isFieldElement(formField) && formField.props?.choices) {
+      formField.props.choices.forEach((choice: FieldChoice) => {
+        // If choice has been selected
+        if (
+          entity &&
+          entity[formField.id] &&
+          Array.isArray(entity[formField.id]) &&
+          entity[formField.id].length > 0 &&
+          entity[formField.id][0].key?.endsWith(choice.id)
+        ) {
+          if (choice.children) {
+            choice.children.forEach((c) => renderFieldRow(c));
+          }
+        }
+      });
+    }
+  };
+  // map through form fields and call renderer
+  formFields?.forEach((field: FormField | FormLayoutElement) => {
+    renderFieldRow(field);
+  });
+  return tableRows;
+};
+
+export interface Props {
+  fields: FormField[];
+  entity: EntityShape;
+  showHintText?: boolean;
+}
+
+const sx = {
+  root: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+    marginBottom: "1rem",
+    "tr, th": {
+      verticalAlign: "top",
+      lineHeight: "base",
+      borderBottom: "1px solid",
+      borderColor: "palette.gray_lighter",
+    },
+    thead: {
+      //this will prevent generating a new header whenever the table spills over in another page
+      display: "table-row-group",
+    },
+    td: {
+      p: {
+        lineHeight: "1.25rem",
+      },
+      padding: "0.75rem 0.5rem",
+      borderStyle: "none",
+      fontWeight: "normal",
+      color: "palette.base",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      ".mobile &": {
+        fontSize: "xs",
+      },
+    },
+    th: {
+      paddingBottom: "0.375rem",
+      fontWeight: "bold",
+      lineHeight: "lg",
+      color: "palette.gray_medium",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      "&:first-of-type": {
+        paddingLeft: 0,
+      },
+    },
+    ".desktop &": {
+      "&.two-column": {
+        "th:first-of-type": {
+          paddingLeft: "6rem",
+        },
+      },
+    },
+  },
+};

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTableRow.tsx
@@ -1,0 +1,126 @@
+// components
+import { Box, Tr, Td, Text } from "@chakra-ui/react";
+// types
+import { FormField, FormLayoutElement, isFieldElement } from "types";
+// utils
+import {
+  parseFormFieldInfo,
+  parseCustomHtml,
+  renderOverlayEntityDataCell,
+  useStore,
+} from "utils";
+
+export const ExportedEntityDetailsTableRow = ({
+  formField,
+  entityType,
+  parentFieldCheckedChoiceIds,
+  showHintText = true,
+  entityId,
+  optional,
+}: Props) => {
+  const { report } = useStore() ?? {};
+  const reportData = report?.fieldData;
+  const isDynamicField = formField.type === "dynamic";
+  const formFieldInfo = parseFormFieldInfo(formField?.props!);
+
+  // guard against double-rendering "otherText" response
+  const isOtherTextEntry = formField.id.endsWith("-otherText");
+  if (isOtherTextEntry) return null;
+
+  return (
+    <Tr data-testid="exportRow">
+      {/* number column/cell */}
+      {!isDynamicField && (
+        <Td sx={sx.numberColumn}>
+          <Text sx={sx.fieldNumber} fontSize={"sm"}>
+            {formFieldInfo.number || "N/A"}
+          </Text>
+        </Td>
+      )}
+
+      {/* label column/cell */}
+      <Td sx={sx.labelColumn}>
+        {formFieldInfo.label || formFieldInfo.hint ? (
+          <>
+            {formFieldInfo.label && (
+              <Text sx={sx.fieldLabel} fontSize={"sm"}>
+                {!isDynamicField ? (
+                  optional ? (
+                    <Box>
+                      {formFieldInfo.label}
+                      <span className="optional-text"> (optional)</span>
+                    </Box>
+                  ) : (
+                    formFieldInfo.label
+                  )
+                ) : (
+                  formField?.props?.label
+                )}
+              </Text>
+            )}
+            {showHintText && formFieldInfo.hint && (
+              <Text sx={sx.fieldHint}>
+                {parseCustomHtml(formFieldInfo.hint)}
+              </Text>
+            )}
+          </>
+        ) : (
+          <Text>{"N/A"}</Text>
+        )}
+      </Td>
+
+      {/* data column/cell */}
+      <Td>
+        {reportData &&
+          isFieldElement(formField) &&
+          renderOverlayEntityDataCell(
+            formField,
+            reportData[entityType],
+            entityId,
+            parentFieldCheckedChoiceIds
+          )}
+      </Td>
+    </Tr>
+  );
+};
+
+export interface Props {
+  formField: FormField | FormLayoutElement;
+  pageType: string;
+  entityId: string;
+  entityType: string;
+  parentFieldCheckedChoiceIds?: string[];
+  showHintText?: boolean;
+  optional?: boolean;
+}
+
+const sx = {
+  numberColumn: {
+    width: "5.5rem",
+    paddingLeft: 0,
+  },
+  fieldNumber: {
+    fontWeight: "bold",
+  },
+  labelColumn: {
+    width: "14rem",
+    ".two-column &": {
+      ".desktop &": {
+        paddingLeft: "6rem",
+        width: "19.5rem",
+      },
+    },
+  },
+  fieldLabel: {
+    fontSize: "sm",
+    fontWeight: "bold",
+    ".optional-text": {
+      fontWeight: "lighter",
+    },
+  },
+  fieldHint: {
+    lineHeight: "lg",
+    fontSize: "sm",
+    color: "palette.gray_medium",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -1,0 +1,69 @@
+// components
+import { Box, Heading, Text } from "@chakra-ui/react";
+import { EntityStepCard } from "components";
+// utils
+import { getFormattedEntityData, useStore } from "utils";
+import { EntityShape, ModalDrawerReportPageShape } from "types";
+// verbiage
+import exportVerbiage from "verbiage/pages/wp/wp-export";
+
+export const ExportedModalDrawerReportSection = ({
+  section: { entityType, verbiage },
+}: Props) => {
+  const { report } = useStore() ?? {};
+  const { emptyEntityMessage } = exportVerbiage;
+  const entities = report?.fieldData?.[entityType];
+  const entityCount = entities?.length;
+
+  return (
+    <Box
+      mt="2rem"
+      data-testid="exportedModalDrawerReportSection"
+      sx={sx.container}
+    >
+      <Heading as="h3" sx={sx.dashboardTitle} data-testid="headerCount">
+        {`${verbiage.dashboardTitle} ${entityCount > 0 ? entityCount : ""}`}
+        {!entityCount && (
+          <Text as="span" sx={sx.notAnswered} data-testid="entityMessage">
+            {emptyEntityMessage[entityType as keyof typeof emptyEntityMessage]}
+          </Text>
+        )}
+      </Heading>
+      {entities?.map((entity: EntityShape, entityIndex: number) => (
+        <EntityStepCard
+          key={entity.id}
+          entity={entity}
+          entityIndex={entityIndex}
+          stepType={entityType}
+          verbiage={verbiage}
+          formattedEntityData={getFormattedEntityData(entityType, entity)}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export interface Props {
+  section: ModalDrawerReportPageShape;
+}
+
+const sx = {
+  container: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+  },
+  notAnswered: {
+    display: "block",
+    fontSize: "md",
+    fontWeight: "bold",
+    color: "palette.error_darker",
+    marginTop: "0.5rem",
+  },
+  dashboardTitle: {
+    marginBottom: "1.25rem",
+    fontSize: "md",
+    fontWeight: "bold",
+    color: "palette.gray_medium",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -1,0 +1,205 @@
+import { useStore, getEntityDetailsMLR } from "utils";
+// components
+import { EntityStatusIcon, Table } from "components";
+import { Box, Image, Td, Text, Tr } from "@chakra-ui/react";
+// types
+import { EntityShape, ModalOverlayReportPageShape, ReportType } from "types";
+import { assertExhaustive } from "utils/other/typing";
+// verbiage
+import wpVerbiage from "verbiage/pages/wp/wp-export";
+import sarVerbiage from "verbiage/pages/sar/sar-export";
+// assets
+import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
+import finishedIcon from "assets/icons/icon_check_circle.png";
+
+const exportVerbiageMap: { [key in ReportType]: any } = {
+  WP: wpVerbiage,
+  SAR: sarVerbiage,
+};
+
+export const ExportedModalOverlayReportSection = ({ section }: Props) => {
+  const { report } = useStore() ?? {};
+  const entityType = section.entityType;
+
+  const verbiage = exportVerbiageMap[report?.reportType as ReportType];
+
+  const { modalOverlayTableHeaders } = verbiage;
+
+  const headerLabels = Object.values(
+    modalOverlayTableHeaders as Record<string, string>
+  );
+
+  return (
+    <Box>
+      <Table
+        sx={sx.root}
+        content={{
+          headRow: headerLabels,
+        }}
+        data-testid="exportTable"
+      >
+        {report?.fieldData[entityType] &&
+          renderModalOverlayTableBody(
+            report?.reportType as ReportType,
+            report?.fieldData[entityType]
+          )}
+      </Table>
+      {(!report?.fieldData[entityType] ||
+        report?.fieldData[entityType].length === 0) && (
+        <Text sx={sx.emptyState}> No entities found.</Text>
+      )}
+    </Box>
+  );
+};
+
+export interface Props {
+  section: ModalOverlayReportPageShape;
+}
+
+export function renderStatusIcon(status: boolean) {
+  if (status) {
+    return <Image src={finishedIcon} alt="success icon" boxSize="xl" />;
+  }
+  return <Image src={unfinishedIcon} alt="warning icon" boxSize="xl" />;
+}
+
+export function renderModalOverlayTableBody(
+  reportType: ReportType,
+  entities: EntityShape[]
+) {
+  switch (reportType) {
+    case ReportType.WP:
+      return entities.map((entity, idx) => {
+        const { report_programName, reportingPeriod } =
+          getEntityDetailsMLR(entity);
+        return (
+          <Tr key={idx}>
+            <Td sx={sx.statusIcon}>
+              <EntityStatusIcon
+                entity={entity}
+                isPdf={true}
+                entityStatus={entity.status}
+              />
+            </Td>
+            <Td>
+              <Text sx={sx.tableIndex}>{idx + 1}</Text>
+            </Td>
+            <Td>
+              <Text sx={sx.entityList}>
+                {entity.report_planName ?? "Not entered"} <br />
+                {report_programName} <br />
+                {reportingPeriod}
+              </Text>
+            </Td>
+            <Td>
+              {/* <Text>
+                {entity.report_programType[0].value
+                  ? entity.report_programType[0].value
+                  : "Not entered"}
+              </Text> */}
+            </Td>
+            <Td>
+              <Text>
+                {entity["report_reportingPeriodDiscrepancyExplanation"]
+                  ? entity["report_reportingPeriodDiscrepancyExplanation"]
+                  : "N/A"}
+              </Text>
+            </Td>
+            <Td>
+              <Text>
+                {entity.report_miscellaneousNotes
+                  ? entity.report_miscellaneousNotes
+                  : "N/A"}
+              </Text>
+            </Td>
+          </Tr>
+        );
+      });
+    case ReportType.SAR:
+      throw new Error(
+        `The modal overlay table headers for report type '${reportType}' have not been implemented.`
+      );
+    default:
+      assertExhaustive(reportType);
+      throw new Error(
+        `The modal overlay table headers for report type '${reportType}' have not been implemented.`
+      );
+  }
+}
+
+const sx = {
+  root: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+    marginBottom: "1rem",
+    "tr, th": {
+      verticalAlign: "bottom",
+      lineHeight: "base",
+      borderBottom: "1px solid",
+      borderColor: "palette.gray_lighter",
+    },
+    "th:nth-of-type(3)": {
+      width: "15rem",
+    },
+    thead: {
+      //this will prevent generating a new header whenever the table spills over in another page
+      display: "table-row-group",
+    },
+    td: {
+      p: {
+        lineHeight: "1.25rem",
+      },
+      padding: "0.75rem 0.5rem",
+      borderStyle: "none",
+      fontWeight: "normal",
+      color: "palette.base",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      ".mobile &": {
+        fontSize: "xs",
+      },
+      verticalAlign: "middle",
+    },
+    th: {
+      maxWidth: "100%",
+      paddingBottom: "0.375rem",
+      fontWeight: "bold",
+      lineHeight: "lg",
+      color: "palette.gray_medium",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      "&:first-of-type": {
+        textAlign: "center",
+      },
+    },
+    ".desktop &": {
+      "&.two-column": {
+        "th:first-of-type": {
+          paddingLeft: "6rem",
+        },
+      },
+    },
+  },
+  entityList: {
+    wordBreak: "break-word",
+  },
+  tableIndex: {
+    color: "palette.gray_medium",
+    fontWeight: "bold",
+  },
+  statusIcon: {
+    paddingLeft: "1rem",
+    img: {
+      maxWidth: "fit-content",
+    },
+  },
+  emptyState: {
+    width: "100%",
+    margin: "0 auto",
+    textAlign: "center",
+    paddingBottom: "5rem",
+  },
+};

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -92,13 +92,6 @@ export function renderModalOverlayTableBody(
               </Text>
             </Td>
             <Td>
-              {/* <Text>
-                {entity.report_programType[0].value
-                  ? entity.report_programType[0].value
-                  : "Not entered"}
-              </Text> */}
-            </Td>
-            <Td>
               <Text>
                 {entity["report_reportingPeriodDiscrepancyExplanation"]
                   ? entity["report_reportingPeriodDiscrepancyExplanation"]

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -1,0 +1,204 @@
+import { ReactElement } from "react";
+// components
+import { Table } from "components";
+// types, utils
+import { useStore } from "utils";
+import {
+  Choice,
+  EntityShape,
+  FieldChoice,
+  FormField,
+  StandardReportPageShape,
+  DrawerReportPageShape,
+  ReportShape,
+  FormLayoutElement,
+  isFieldElement,
+  ReportType,
+} from "types";
+// verbiage
+import verbiage from "verbiage/pages/wp/wp-export";
+
+export const ExportedReportFieldTable = ({ section }: Props) => {
+  const { report } = useStore() ?? {};
+  const { tableHeaders } = verbiage;
+
+  const pageType = section.pageType;
+  const formFields =
+    pageType === "drawer" ? section.drawerForm?.fields : section.form?.fields;
+  const entityType = section.entityType;
+
+  const formHasOnlyDynamicFields = formFields?.every(
+    (field: FormField | FormLayoutElement) => field.type === "dynamic"
+  );
+  const twoColumnHeaderItems = [tableHeaders.indicator, tableHeaders.response];
+  const threeColumnHeaderItems = [
+    tableHeaders.number,
+    tableHeaders.indicator,
+    tableHeaders.response,
+  ];
+  const headRowItems = formHasOnlyDynamicFields
+    ? twoColumnHeaderItems
+    : threeColumnHeaderItems;
+
+  const reportType = report?.reportType as ReportType;
+  const hideHintText = reportType === ReportType.SAR;
+
+  return (
+    <Table
+      sx={sx.root}
+      className={formHasOnlyDynamicFields ? "two-column" : ""}
+      content={{
+        headRow: headRowItems,
+      }}
+      data-testid="exportTable"
+    >
+      {renderFieldTableBody(
+        formFields!,
+        pageType!,
+        report,
+        !hideHintText,
+        entityType
+      )}
+    </Table>
+  );
+};
+
+export const renderFieldTableBody = (
+  formFields: (FormField | FormLayoutElement)[],
+  pageType: string,
+  report: ReportShape | undefined,
+  showHintText: boolean,
+  entityType?: string
+) => {
+  const tableRows: ReactElement[] = [];
+  // recursively renders field rows
+  const renderFieldRow = (
+    formField: FormField | FormLayoutElement,
+    parentFieldCheckedChoiceIds?: string[]
+  ) => {
+    tableRows.push(
+      <tr>
+        key={JSON.stringify(formField.id)}
+        ------------------------------------ formField=
+        {JSON.stringify(formField)}
+        ------------------------------------ pageType={JSON.stringify(pageType)}
+        ------------------------------------ entityType=
+        {JSON.stringify(entityType)}
+        ------------------------------------ parentFieldCheckedChoiceIds=
+        {JSON.stringify(parentFieldCheckedChoiceIds)}
+        ------------------------------------ showHintText=
+        {JSON.stringify(showHintText)}
+      </tr>
+    );
+    // for drawer pages, render nested child field if any entity has a checked parent choice
+    if (pageType === "drawer") {
+      const entityData = report?.fieldData[entityType!];
+      formField?.props?.choices?.forEach((choice: FieldChoice) => {
+        // filter to only entities where this choice is checked
+        const entitiesWithCheckedChoice = entityData?.filter(
+          (entity: EntityShape) =>
+            Object.keys(entity)?.find((fieldDataKey: string) => {
+              const fieldDataValue = entity[fieldDataKey];
+              return (
+                Array.isArray(fieldDataValue) &&
+                fieldDataValue.find((selectedChoice: Choice) =>
+                  selectedChoice.key?.endsWith(choice.id)
+                )
+              );
+            })
+        );
+        // get all checked parent field choices
+        const parentFieldCheckedChoiceIds = entitiesWithCheckedChoice?.map(
+          (entity: EntityShape) => entity.id
+        );
+        // if choice is checked in any entity, and the choice has children to display, render them
+        if (entitiesWithCheckedChoice?.length > 0 && choice?.children) {
+          choice.children?.forEach((childField: FormField) =>
+            renderFieldRow(childField, parentFieldCheckedChoiceIds)
+          );
+        }
+      });
+    } else {
+      // for standard pages, render nested child field if parent choice is checked
+      const nestedChildren = formField?.props?.choices?.filter(
+        (choice: FieldChoice) => {
+          const selected = report?.fieldData[formField.id];
+          const entryExists = selected?.find((selectedChoice: Choice) =>
+            selectedChoice.key.endsWith(choice.id)
+          );
+          return entryExists && choice?.children;
+        }
+      );
+      nestedChildren?.forEach((choice: FieldChoice) =>
+        choice.children?.forEach((childField: FormField) =>
+          renderFieldRow(childField)
+        )
+      );
+    }
+  };
+  // map through form fields and call renderer
+  formFields?.map((field: FormField | FormLayoutElement) => {
+    if (isFieldElement(field)) {
+      renderFieldRow(field);
+    }
+  });
+  return tableRows;
+};
+
+export interface Props {
+  section: StandardReportPageShape | DrawerReportPageShape;
+  showHintText?: boolean;
+}
+
+const sx = {
+  root: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+    marginBottom: "1rem",
+    "tr, th": {
+      verticalAlign: "top",
+      lineHeight: "base",
+      borderBottom: "1px solid",
+      borderColor: "palette.gray_lighter",
+    },
+    thead: {
+      //this will prevent generating a new header whenever the table spills over in another page
+      display: "table-row-group",
+    },
+    td: {
+      p: {
+        lineHeight: "1.25rem",
+      },
+      padding: "0.75rem 0.5rem",
+      borderStyle: "none",
+      fontWeight: "normal",
+      color: "palette.base",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      ".mobile &": {
+        fontSize: "xs",
+      },
+    },
+    th: {
+      paddingBottom: "0.375rem",
+      fontWeight: "bold",
+      lineHeight: "lg",
+      color: "palette.gray_medium",
+      ".shrink &": {
+        padding: "0.375rem 0rem",
+      },
+      "&:first-of-type": {
+        paddingLeft: 0,
+      },
+    },
+    ".desktop &": {
+      "&.two-column": {
+        "th:first-of-type": {
+          paddingLeft: "6rem",
+        },
+      },
+    },
+  },
+};

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -78,6 +78,7 @@ export const renderFieldTableBody = (
   ) => {
     tableRows.push(
       <tr>
+        {/* just displaying data for now */}
         key={JSON.stringify(formField.id)}
         ------------------------------------ formField=
         {JSON.stringify(formField)}

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -1,0 +1,105 @@
+// components
+import { Table } from "components";
+// utils
+import { ReportShape, ReportType } from "types";
+import { convertDateUtcToEt, useStore } from "utils";
+import { assertExhaustive } from "utils/other/typing";
+
+export const ExportedReportMetadataTable = ({
+  reportType,
+  verbiage,
+}: Props) => {
+  const { report } = useStore() ?? {};
+  return (
+    <Table
+      data-testid="exportedReportMetadataTable"
+      sx={sx.metadataTable}
+      content={{
+        headRow: headerRowLabels(reportType, verbiage),
+        bodyRows: bodyRowContent(reportType, report),
+      }}
+    />
+  );
+};
+
+export const headerRowLabels = (
+  reportType: ReportType,
+  verbiage: any
+): string[] => {
+  switch (reportType) {
+    case ReportType.WP:
+      return [
+        verbiage.metadataTableHeaders.dueDate,
+        verbiage.metadataTableHeaders.lastEdited,
+        verbiage.metadataTableHeaders.editedBy,
+        verbiage.metadataTableHeaders.status,
+      ];
+    case ReportType.SAR:
+      return [
+        verbiage.metadataTableHeaders.submissionName,
+        verbiage.metadataTableHeaders.lastEdited,
+        verbiage.metadataTableHeaders.editedBy,
+        verbiage.metadataTableHeaders.status,
+      ];
+    default:
+      assertExhaustive(reportType);
+      throw new Error(
+        `The metadata table headers for report type '${reportType}' have not been implemented.`
+      );
+  }
+};
+
+export const bodyRowContent = (
+  reportType: ReportType,
+  report?: ReportShape
+): string[][] => {
+  if (!report) {
+    return [[]];
+  }
+  switch (reportType) {
+    case ReportType.WP:
+      return [
+        [
+          convertDateUtcToEt(report.dueDate),
+          convertDateUtcToEt(report.lastAltered),
+          report.lastAlteredBy,
+          report.status,
+        ],
+      ];
+    case ReportType.SAR:
+      return [
+        [
+          report?.submissionName ?? "",
+          convertDateUtcToEt(report?.lastAltered),
+          report?.lastAlteredBy,
+          report?.status,
+        ],
+      ];
+    default:
+      assertExhaustive(reportType);
+      throw new Error(
+        `The metadata table body for report type '${reportType}' has not been implemented.`
+      );
+  }
+};
+
+export interface Props {
+  reportType: ReportType;
+  verbiage: any;
+}
+
+const sx = {
+  metadataTable: {
+    margin: "3rem 0",
+    maxWidth: "reportPageWidth",
+    td: {
+      paddingTop: "0rem",
+      verticalAlign: "middle",
+    },
+    th: {
+      border: "none",
+      fontWeight: "bold",
+      color: "palette.gray_medium",
+    },
+  },
+};

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -1,11 +1,5 @@
 // components
 import { Box } from "@chakra-ui/react";
-/*
- * ExportedModalDrawerReportSection,
- * ExportedReportFieldTable,
- * ExportedEntityDetailsOverlaySection,
- * ExportedModalOverlayReportSection,
- */
 import {
   ExportedModalDrawerReportSection,
   ExportedReportFieldTable,
@@ -14,7 +8,7 @@ import {
 } from "components";
 // types
 import {
-  // DrawerReportPageShape,
+  DrawerReportPageShape,
   ModalDrawerReportPageShape,
   ModalOverlayReportPageShape,
   PageTypes,
@@ -35,9 +29,9 @@ export const ExportedReportWrapper = ({ section }: Props) => {
     case PageTypes.DRAWER:
       return (
         <Box data-testid="exportedDrawerReportSection" mt="2rem">
-          {/* <ExportedReportFieldTable
+          <ExportedReportFieldTable
             section={section as DrawerReportPageShape}
-          /> */}
+          />
         </Box>
       );
     case PageTypes.MODAL_DRAWER:

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -10,6 +10,7 @@ import {
   ExportedModalDrawerReportSection,
   ExportedReportFieldTable,
   ExportedEntityDetailsOverlaySection,
+  ExportedModalOverlayReportSection,
 } from "components";
 // types
 import {
@@ -48,9 +49,9 @@ export const ExportedReportWrapper = ({ section }: Props) => {
     case PageTypes.MODAL_OVERLAY:
       return (
         <>
-          {/* <ExportedModalOverlayReportSection
+          <ExportedModalOverlayReportSection
             section={section as ModalOverlayReportPageShape}
-          /> */}
+          />
           <ExportedEntityDetailsOverlaySection
             section={section as ModalOverlayReportPageShape}
           />

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -1,0 +1,66 @@
+// components
+import { Box } from "@chakra-ui/react";
+/*
+ * ExportedModalDrawerReportSection,
+ * ExportedReportFieldTable,
+ * ExportedEntityDetailsOverlaySection,
+ * ExportedModalOverlayReportSection,
+ */
+import {
+  ExportedModalDrawerReportSection,
+  ExportedReportFieldTable,
+  ExportedEntityDetailsOverlaySection,
+} from "components";
+// types
+import {
+  // DrawerReportPageShape,
+  ModalDrawerReportPageShape,
+  ModalOverlayReportPageShape,
+  PageTypes,
+  ReportRouteWithForm,
+  StandardReportPageShape,
+} from "types";
+
+export const ExportedReportWrapper = ({ section }: Props) => {
+  switch (section.pageType) {
+    case PageTypes.STANDARD:
+      return (
+        <Box data-testid="exportedStandardReportSection" mt="2rem">
+          <ExportedReportFieldTable
+            section={section as StandardReportPageShape}
+          />
+        </Box>
+      );
+    case PageTypes.DRAWER:
+      return (
+        <Box data-testid="exportedDrawerReportSection" mt="2rem">
+          {/* <ExportedReportFieldTable
+            section={section as DrawerReportPageShape}
+          /> */}
+        </Box>
+      );
+    case PageTypes.MODAL_DRAWER:
+      return (
+        <ExportedModalDrawerReportSection
+          section={section as ModalDrawerReportPageShape}
+        />
+      );
+    case PageTypes.MODAL_OVERLAY:
+      return (
+        <>
+          {/* <ExportedModalOverlayReportSection
+            section={section as ModalOverlayReportPageShape}
+          /> */}
+          <ExportedEntityDetailsOverlaySection
+            section={section as ModalOverlayReportPageShape}
+          />
+        </>
+      );
+    default:
+      return <></>;
+  }
+};
+
+export interface Props {
+  section: ReportRouteWithForm;
+}

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -1,0 +1,72 @@
+// components
+import { Box, Heading } from "@chakra-ui/react";
+import { SpreadsheetWidget } from "components";
+// types
+import { ReportPageVerbiage } from "types";
+// utils
+import { parseCustomHtml } from "utils";
+
+export const ExportedSectionHeading = ({
+  heading,
+  reportType,
+  verbiage,
+}: Props) => {
+  const sectionHeading = verbiage?.intro?.exportSectionHeader
+    ? verbiage?.intro?.exportSectionHeader
+    : verbiage?.intro?.subsection || heading;
+  const sectionInfo = verbiage?.intro?.exportSectionHeader
+    ? null
+    : verbiage?.intro?.info;
+  const sectionSpreadsheet = verbiage?.intro?.spreadsheet;
+
+  return (
+    <Box data-testid="exportedSectionHeading" sx={sx.container}>
+      <Heading as="h2" sx={sx.heading}>
+        {sectionHeading}
+      </Heading>
+      {sectionInfo && <Box sx={sx.info}>{parseCustomHtml(sectionInfo)}</Box>}
+      {sectionSpreadsheet && (
+        <Box sx={sx.spreadsheet}>
+          <SpreadsheetWidget
+            description={sectionSpreadsheet}
+            alt=""
+            reportType={reportType}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export interface Props {
+  heading: string;
+  reportType?: string;
+  verbiage?: ReportPageVerbiage;
+}
+
+const sx = {
+  container: {
+    "@media print": {
+      pageBreakInside: "avoid",
+    },
+  },
+  heading: {
+    margin: "1.5rem 0",
+    fontSize: "xl",
+    fontWeight: "bold",
+  },
+  info: {
+    p: {
+      margin: "1.5rem 0",
+    },
+    h3: {
+      fontSize: "lg",
+    },
+  },
+  spreadsheet: {
+    margin: "1.5rem 0",
+    "@media print": {
+      pageBreakAfter: "avoid",
+    },
+  },
+};

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -38,6 +38,7 @@ export { ExportedReportFieldTable } from "./export/ExportedReportFieldTable";
 export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDetailsOverlaySection";
 export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
 export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
+export { ExportedModalOverlayReportSection } from "./export/ExportedModalOverlayReportSection";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -29,6 +29,11 @@ export { EntityStepCardBottomSection } from "./cards/EntityCardBottomSection";
 // drawers
 export { Drawer } from "./drawers/Drawer";
 export { ReportDrawer } from "./drawers/ReportDrawer";
+// export
+export { ExportedReportMetadataTable } from "./export/ExportedReportMetadataTable";
+export { ExportedSectionHeading } from "./export/ExportedSectionHeading";
+export { ExportedReportWrapper } from "./export/ExportedReportWrapper";
+
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -32,8 +32,12 @@ export { ReportDrawer } from "./drawers/ReportDrawer";
 // export
 export { ExportedReportMetadataTable } from "./export/ExportedReportMetadataTable";
 export { ExportedSectionHeading } from "./export/ExportedSectionHeading";
+export { ExportedModalDrawerReportSection } from "./export/ExportedModalDrawerReportSection";
 export { ExportedReportWrapper } from "./export/ExportedReportWrapper";
-
+export { ExportedReportFieldTable } from "./export/ExportedReportFieldTable";
+export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDetailsOverlaySection";
+export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
+export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -1,10 +1,201 @@
+import { Helmet } from "react-helmet";
 // utils
 import { useStore } from "utils";
-import { ReportType } from "types";
+import { assertExhaustive } from "utils/other/typing";
+// components
+import { Box, Center, Heading, Text, Tr, Td, Spinner } from "@chakra-ui/react";
+import {
+  ExportedReportMetadataTable,
+  ExportedSectionHeading,
+  ExportedReportWrapper,
+  Table,
+} from "components";
+// types
+import {
+  PageTypes,
+  ReportRoute,
+  ReportRouteWithForm,
+  ReportShape,
+  ReportType,
+} from "types";
+// verbiage
+import wpVerbiage from "verbiage/pages/wp/wp-export";
+import sarVerbiage from "verbiage/pages/sar/sar-export";
+
 export const ExportedReportPage = () => {
   const { report } = useStore() ?? {};
+  const routesToRender = report?.formTemplate.routes.filter(
+    (route: ReportRoute) => route
+  );
   const reportType = (report?.reportType ||
     localStorage.getItem("selectedReportType")) as ReportType;
 
-  return <div>Hi! This will be a PDF for {reportType}</div>;
+  const exportVerbiageMap: { [key in ReportType]: any } = {
+    WP: wpVerbiage,
+    SAR: sarVerbiage,
+  };
+  const exportVerbiage = exportVerbiageMap[reportType];
+  const { metadata, reportPage, tableHeaders } = exportVerbiage;
+  return (
+    <Box sx={sx.container}>
+      {(report && routesToRender && (
+        <Box sx={sx.innerContainer}>
+          {/* pdf metadata */}
+          <Helmet>
+            <title>{reportTitle(reportType, reportPage, report)}</title>
+            <meta name="author" content={metadata.author} />
+            <meta name="subject" content={metadata.subject} />
+            <meta name="language" content={metadata.language} />
+          </Helmet>
+          {/* report heading */}
+          <Heading as="h1" sx={sx.heading}>
+            {reportTitle(reportType, reportPage, report)}
+          </Heading>
+          {/* report metadata tables */}
+          <ExportedReportMetadataTable
+            reportType={reportType}
+            verbiage={reportPage}
+          />
+          {/* combined data table */}
+          {reportType === ReportType.WP && (
+            <Table
+              sx={sx.combinedDataTable}
+              className="short"
+              content={{
+                headRow: [tableHeaders.indicator, tableHeaders.response],
+              }}
+            >
+              <Tr>
+                <Td>
+                  <Text className="combined-data-title">
+                    {reportPage.combinedDataTable.title}
+                  </Text>
+                  <Text>{reportPage.combinedDataTable.subtitle}</Text>
+                </Td>
+                {/* <Td>{report.combinedData ? "Selected" : "Not Selected"}</Td> */}
+              </Tr>
+            </Table>
+          )}
+          {/* report sections */}
+          {renderReportSections(report.formTemplate.routes, report.reportType)}
+        </Box>
+      )) || (
+        <Center>
+          <Spinner size="lg" />
+        </Center>
+      )}
+    </Box>
+  );
+};
+
+export const reportTitle = (
+  reportType: ReportType,
+  reportPage: any,
+  report: ReportShape
+): string => {
+  switch (reportType) {
+    case ReportType.WP:
+      return `${report.fieldData.stateName} ${reportPage.heading} ${report.reportYear} - Period ${report.reportPeriod}`;
+    case ReportType.SAR:
+      return `THIS IS A SARRRRRRRR`;
+    default:
+      assertExhaustive(reportType);
+      throw new Error(
+        `The title for report type ${reportType} has not been implemented.`
+      );
+  }
+};
+
+export const renderReportSections = (
+  reportRoutes: ReportRoute[],
+  reportType: string
+) => {
+  // recursively render sections
+  const renderSection = (section: ReportRoute) => {
+    const childSections = section?.children;
+    return (
+      <Box key={section.path}>
+        {/* if section has children, recurse */}
+        {childSections?.map((child: ReportRoute) => renderSection(child))}
+        {/* if section does not have children and has content to render, render it */}
+        {!childSections && (
+          <Box>
+            <ExportedSectionHeading
+              heading={section.verbiage?.intro?.subsection || section.name}
+              reportType={reportType}
+              verbiage={section.verbiage || undefined}
+            />
+            <ExportedReportWrapper section={section as ReportRouteWithForm} />
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  return reportRoutes.map(
+    (section: ReportRoute) =>
+      section?.pageType !== PageTypes.REVIEW_SUBMIT && (
+        <Box key={section.path} mt="5rem">
+          {/*  render top-level section headings */}
+          {/* <Heading as="h2" sx={sx.sectionHeading}>
+            {`Section ${section.name}`}
+          </Heading> */}
+          {renderSection(section)}
+        </Box>
+      )
+  );
+};
+
+export const sx = {
+  container: {
+    width: "100%",
+    maxWidth: "55.25rem",
+    margin: "0 auto",
+  },
+  innerContainer: {
+    width: "100%",
+    maxWidth: "40rem",
+    margin: "0 auto 0 0",
+    "@media print": {
+      margin: "5rem 0",
+    },
+  },
+  heading: {
+    fontWeight: "300",
+    lineHeight: "lineHeights.heading",
+    fontSize: "4xl",
+  },
+  combinedDataTable: {
+    marginBottom: "1rem",
+    ".combined-data-title": {
+      display: "inline-block",
+      marginBottom: "0.5rem",
+      fontSize: "md",
+      fontWeight: "bold",
+    },
+    "th, td": {
+      verticalAlign: "top",
+      lineHeight: "base",
+      borderBottom: "1px solid",
+      borderColor: "palette.gray_lighter",
+      paddingLeft: "0.5rem",
+    },
+    tr: {
+      "th, td": {
+        "&:first-of-type": {
+          ".desktop &": {
+            paddingLeft: "6rem",
+          },
+        },
+        "&:nth-last-of-type(2)": {
+          width: "19.5rem",
+        },
+      },
+    },
+  },
+  sectionHeading: {
+    fontWeight: "bold",
+    fontSize: "2xl",
+    marginBottom: "2xl",
+  },
 };

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -32,3 +32,4 @@ export * from "./other/scrollToTop";
 export * from "./other/time";
 export * from "./other/useBreakpoint";
 export * from "./other/parsing";
+export * from "./other/export";

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -1,0 +1,302 @@
+import { Box, Link, Text } from "@chakra-ui/react";
+// types
+import { AnyObject, Choice, EntityShape, FieldChoice, FormField } from "types";
+// utils
+import { eligibilityGroup, maskResponseData } from "utils";
+// verbiage
+import verbiage from "verbiage/pages/wp/wp-export";
+
+// checks for type of data cell to be render and calls the appropriate renderer
+export const renderDataCell = (
+  formField: FormField,
+  allResponseData: AnyObject,
+  pageType: string,
+  entityType?: string,
+  parentFieldCheckedChoiceIds?: string[]
+) => {
+  // render drawer data cell (list entities & per-entity responses)
+  if (pageType === "drawer") {
+    const entityResponseData = allResponseData[entityType!];
+    return renderDrawerDataCell(
+      formField,
+      entityResponseData,
+      pageType,
+      parentFieldCheckedChoiceIds
+    );
+  }
+  // render dynamic field data cell (list dynamic field entities)
+  if (formField.type === "dynamic") {
+    const fieldResponseData = allResponseData[formField.id];
+    return renderDynamicDataCell(fieldResponseData);
+  }
+  // render standard data cell (just field response data)
+  const fieldResponseData = allResponseData[formField.id];
+  return renderResponseData(
+    formField,
+    fieldResponseData,
+    allResponseData,
+    pageType
+  );
+};
+
+export const renderOverlayEntityDataCell = (
+  formField: FormField,
+  entityResponseData: EntityShape[],
+  entityId: string,
+  parentFieldCheckedChoiceIds?: string[]
+) => {
+  const entity = entityResponseData.find((ent) => ent.id === entityId);
+
+  if (!entity || !entity[formField.id]) {
+    const validationType =
+      typeof formField.validation === "object"
+        ? formField.validation.type
+        : formField.validation;
+
+    if (validationType.includes("Optional")) {
+      return <Text>{verbiage.missingEntry.noResponse}, optional</Text>;
+    } else {
+      return (
+        <Text sx={sx.noResponse}>
+          {verbiage.missingEntry.noResponse}; required
+        </Text>
+      );
+    }
+  }
+
+  const notApplicable =
+    parentFieldCheckedChoiceIds &&
+    !parentFieldCheckedChoiceIds?.includes(entity.id);
+  return (
+    <Box>
+      <Text>
+        {renderResponseData(
+          formField,
+          entity[formField.id],
+          entityResponseData,
+          "modalOverlay",
+          notApplicable
+        )}
+      </Text>
+    </Box>
+  );
+};
+
+export const renderDrawerDataCell = (
+  formField: FormField,
+  entityResponseData: AnyObject | undefined,
+  pageType: string,
+  parentFieldCheckedChoiceIds?: string[]
+) =>
+  entityResponseData?.map((entity: EntityShape, index: number) => {
+    const notApplicable =
+      parentFieldCheckedChoiceIds &&
+      !parentFieldCheckedChoiceIds?.includes(entity.id);
+    const fieldResponseData = entity[formField.id];
+    return (
+      <Box key={entity.id + formField.id} sx={sx.entityBox}>
+        <ul>
+          <li>
+            <Text sx={sx.entityName}>{entity.name}</Text>
+          </li>
+          <li className="entityResponse">
+            {renderResponseData(
+              formField,
+              fieldResponseData,
+              entityResponseData,
+              pageType,
+              notApplicable,
+              index
+            )}
+          </li>
+        </ul>
+      </Box>
+    );
+  }) ?? <Text sx={sx.noResponse}>{verbiage.missingEntry.noResponse}</Text>;
+
+export const renderDynamicDataCell = (fieldResponseData: AnyObject) =>
+  fieldResponseData?.map((entity: EntityShape) => (
+    <Text key={entity.id} sx={sx.dynamicItem}>
+      {entity.name}
+    </Text>
+  )) ?? <Text sx={sx.noResponse}>{verbiage.missingEntry.noResponse}</Text>;
+
+export const renderResponseData = (
+  formField: FormField,
+  fieldResponseData: any,
+  widerResponseData: AnyObject,
+  pageType: string,
+  notApplicable?: boolean,
+  entityIndex?: number
+) => {
+  const isChoiceListField = ["checkbox", "radio"].includes(formField.type);
+  // check for and handle no response
+  const hasResponse: boolean = isChoiceListField
+    ? fieldResponseData?.length
+    : fieldResponseData;
+  const missingEntryVerbiage = notApplicable
+    ? verbiage.missingEntry.notApplicable
+    : verbiage.missingEntry.noResponse;
+  const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
+  if (!hasResponse)
+    return <Text sx={missingEntryStyle}>{missingEntryVerbiage}</Text>;
+  // chandle choice list fields (checkbox, radio)
+  if (isChoiceListField) {
+    return renderChoiceListFieldResponse(
+      formField,
+      fieldResponseData,
+      widerResponseData,
+      pageType,
+      entityIndex!
+    );
+  }
+  // check for and handle link fields (email, url)
+  const { isLink, isEmail } = checkLinkTypes(formField);
+  if (isLink) return renderLinkFieldResponse(fieldResponseData, isEmail);
+  // handle all other field types
+  return renderDefaultFieldResponse(formField, fieldResponseData);
+};
+
+export const renderChoiceListFieldResponse = (
+  formField: FormField,
+  fieldResponseData: AnyObject,
+  widerResponseData: AnyObject,
+  pageType: string,
+  entityIndex: number
+) => {
+  // filter potential choices to just those that are selected
+  const potentialFieldChoices = formField.props?.choices;
+  const selectedChoices = potentialFieldChoices.filter(
+    (potentialChoice: FieldChoice) => {
+      return fieldResponseData?.find((element: Choice) =>
+        element.key.includes(potentialChoice.id)
+      );
+    }
+  );
+  const choicesToDisplay = selectedChoices?.map((choice: FieldChoice) => {
+    // get related "otherText" value, if present (always only a single child element here)
+    const firstChildId = choice?.children?.[0]?.id!;
+    const shouldDisplayRelatedOtherTextEntry =
+      choice.children?.[0]?.id.endsWith("-otherText");
+    const relatedOtherTextEntry =
+      pageType === "drawer"
+        ? widerResponseData[entityIndex]?.[firstChildId]
+        : widerResponseData?.[firstChildId];
+    return (
+      <Text key={choice.id} sx={sx.fieldChoice}>
+        {choice.label}
+        {shouldDisplayRelatedOtherTextEntry && " – " + relatedOtherTextEntry}
+      </Text>
+    );
+  });
+  return choicesToDisplay;
+};
+
+export const renderLinkFieldResponse = (
+  fieldResponseData: AnyObject,
+  isEmail: boolean
+) => (
+  <Link href={(isEmail ? "mailto:" : "") + fieldResponseData} target="_blank">
+    {fieldResponseData}
+  </Link>
+);
+
+export const renderDefaultFieldResponse = (
+  formField: FormField,
+  fieldResponseData: AnyObject
+) => {
+  // check and handle fields that need a mask applied
+  const fieldMask = formField.props?.mask;
+  if (fieldMask)
+    return <Text>{maskResponseData(fieldResponseData, fieldMask)}</Text>;
+  // render all other fields
+  return <Text>{fieldResponseData}</Text>;
+};
+
+// check for and handle link fields (email, url)
+export const checkLinkTypes = (formField: FormField) => {
+  const emailTypes = ["email", "emailOptional"];
+  const urlTypes = ["url", "urlOptional"];
+  const linkTypes = [...emailTypes, ...urlTypes];
+  const fieldValidationType =
+    typeof formField?.validation === "string"
+      ? formField.validation
+      : formField.validation?.type;
+  return {
+    isLink: linkTypes.includes(fieldValidationType ?? ""),
+    isEmail: emailTypes.includes(fieldValidationType ?? ""),
+  };
+};
+
+// parse field info from field props
+export const parseFormFieldInfo = (formFieldProps?: AnyObject) => {
+  if (
+    formFieldProps === undefined ||
+    Object.values(formFieldProps).every((x) => typeof x === "undefined")
+  )
+    return {};
+  const labelArray = formFieldProps?.label?.split(" ");
+  return {
+    number: labelArray?.[0].match(/[-.0-9]+/) ? labelArray?.[0] : "N/A",
+    label: labelArray?.[0].match(/[-.0-9]+/)
+      ? labelArray?.slice(1)?.join(" ")
+      : labelArray?.join(" "),
+    hint: formFieldProps?.hint,
+    indicator: formFieldProps?.indicator,
+  };
+};
+
+export const getEntityDetailsMLR = (entity: EntityShape) => {
+  const { report_programName, report_planName } = entity;
+
+  const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
+  const mlrEligibilityGroup = eligibilityGroup(entity);
+
+  return {
+    report_planName,
+    report_programName,
+    reportingPeriod,
+    mlrEligibilityGroup,
+  };
+};
+
+// style object for rendered elements
+const sx = {
+  fieldChoice: {
+    marginBottom: "1rem",
+  },
+  dynamicItem: {
+    marginBottom: "1rem",
+  },
+  entityBox: {
+    verticalAlign: "top",
+    marginBottom: "1rem",
+    ul: {
+      listStyle: "none",
+      ".entityResponse": {
+        paddingBottom: "0.5rem",
+        p: {
+          lineHeight: "1.25rem",
+          fontSize: "sm",
+        },
+      },
+      p: {
+        lineHeight: "1.25rem",
+        marginBottom: "0.5rem",
+      },
+    },
+    "&:last-of-type": {
+      marginBottom: 0,
+    },
+  },
+  entityName: {
+    marginBottom: "1rem",
+    fontWeight: "bold",
+  },
+  noResponse: {
+    color: "palette.error_darker",
+  },
+  notApplicable: {
+    color: "palette.gray_medium",
+  },
+};

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -2,7 +2,7 @@ import { Box, Link, Text } from "@chakra-ui/react";
 // types
 import { AnyObject, Choice, EntityShape, FieldChoice, FormField } from "types";
 // utils
-import { eligibilityGroup, maskResponseData } from "utils";
+import { maskResponseData } from "utils";
 // verbiage
 import verbiage from "verbiage/pages/wp/wp-export";
 
@@ -250,13 +250,13 @@ export const getEntityDetailsMLR = (entity: EntityShape) => {
   const { report_programName, report_planName } = entity;
 
   const reportingPeriod = `${entity.report_reportingPeriodStartDate} to ${entity.report_reportingPeriodEndDate}`;
-  const mlrEligibilityGroup = eligibilityGroup(entity);
+  // const mlrEligibilityGroup = eligibilityGroup(entity);
 
   return {
     report_planName,
     report_programName,
     reportingPeriod,
-    mlrEligibilityGroup,
+    // mlrEligibilityGroup,
   };
 };
 

--- a/services/ui-src/src/verbiage/pages/wp/wp-export.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-export.ts
@@ -13,7 +13,7 @@ export default {
     language: "English",
   },
   reportPage: {
-    heading: "Managed Care Program Annual Report (WP) for ",
+    heading: "MFP Program Work Plan for ",
     metadataTableHeaders: {
       dueDate: "Due date",
       lastEdited: "Last edited",

--- a/services/ui-src/src/verbiage/pages/wp/wp-export.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-export.ts
@@ -31,6 +31,15 @@ export default {
     indicator: "Indicator",
     response: "Response",
   },
+  modalOverlayTableHeaders: {
+    status: "{Status}",
+    index: "{#}",
+    submissionInformation:
+      "{I., J. & L., N. & O., M. <br/> MCO, PIHP, or PAHP name <br /> Program name <br/> Eligibility group & description <br/> MLR reporting period dates}",
+    programType: "{K. Program type}",
+    discrepancyExplanation: "{P. Reporting period discrepancy explanation}",
+    notes: "{Q. Misc notes (optional)}",
+  },
   emptyEntityMessage: {
     accessMeasures: "0  - No access measures entered",
     sanctions: "0 - No sanctions entered",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The second step in creating the WP PDF - porting over PDF components from MCR. 

There is probably a component or two that I won't end up needing, but I'm bringing them over now, and will delete later if I don't need them, or can't repurpose them.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-218

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
You can create a workplan and then click Review PDF to be taken to the PDF export - there are a few things showing up, and hopefully no breaking errors.
You can fill out a WP and click Review PDF to see the export, which should have a little bit more info and components to see, and also no breaking errors.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
