### PR TITLE
make sidebar show when user tries to return to all initiatives

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -27,12 +27,17 @@ export const ReportPageWrapper = () => {
   const { pathname } = useLocation();
   const [sidebarHidden, setSidebarHidden] = useState<boolean>(false);
 
+  const showSidebar = () => {
+    if (sidebarHidden) setSidebarHidden(false);
+  };
+
   // these should be built off the form template, which comes from the report.
   const renderPageSection = (route: ReportRoute) => {
     switch (route.pageType) {
       case PageTypes.DRAWER:
         return <DrawerReportPage route={route as DrawerReportPageShape} />;
       case PageTypes.MODAL_DRAWER:
+        showSidebar();
         return (
           <ModalDrawerReportPage route={route as ModalDrawerReportPageShape} />
         );
@@ -46,6 +51,7 @@ export const ReportPageWrapper = () => {
       case PageTypes.REVIEW_SUBMIT:
         return <ReviewSubmitPage />;
       default:
+        showSidebar();
         return <StandardReportPage route={route as StandardReportPageShape} />;
     }
   };


### PR DESCRIPTION
### Description
bug: sidebar would disappear if a user tries to `return to all initiatives` without clicking one of the buttons provided:
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/be02dd38-602d-4866-a39a-4b51d1f4d70c



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2364

---
### How to test
Go to initiatives section, add initiative, enter it, and see that if you use your trackpad to go back, you'll land on the description page w/ the sidebar showing.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
