### PR TITLE
disable start wp button until wp is approved

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -213,7 +213,7 @@ export const DashboardPage = ({ reportType }: Props) => {
         return !workPlanToCopyFrom;
       case ReportType.WP:
         if (!lastDisplayedReport) return false;
-        return lastDisplayedReport.status !== ReportStatus.SUBMITTED;
+        return lastDisplayedReport.status !== ReportStatus.APPROVED;
       default:
         return true;
     }


### PR DESCRIPTION
### Description
User could create another workplan before the latest one got admin approval. This disables the button unless the status of the latest wp is 'approved' 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-424

---
### How to test
-Create a workplan and submit it
-See that the create button is disabled
-Login as admin, approve the workplam
-login as state user, see that button is enabled

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
