### PR TITLE
Make WP and SAR dashboard instructions open by default

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -265,6 +265,7 @@ export const DashboardPage = ({ reportType }: Props) => {
               : accordion[reportType as keyof typeof ReportType]
                   .stateUserDashboard
           }
+          defaultIndex={0} // sets the accordion to open by default
         />
         {parseCustomHtml(intro.body)}
       </Box>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
See title

[chakra docs for accordion props](https://chakra-ui.com/docs/components/accordion/props) -> see `defaultIndex`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3038

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Login as a state user
Go to `/wp` and `/sar` in any order
Verify the instructions accordion on both pages is open by default

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---