### PR TITLE
Add Autosave Check to I. Define Initiative 

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -91,6 +91,9 @@ export const EntityDetailsOverlay = ({
     //if spinner is active, that means the user has clicked the return button and if autosaveState is false, that means autosave had finished saving
     if (spinner && !autosaveState) {
       setSpinner(false);
+
+      //sometimes autosave runs a sec before submit, so we want to stop the spinner here
+      setSubmitting(false);
       if (closeEntityDetailsOverlay) {
         //call the function to return to the dashboard
         closeEntityDetailsOverlay();
@@ -155,8 +158,7 @@ export const EntityDetailsOverlay = ({
       if (shouldSave) await updateReport(reportKeys, dataToWrite);
     }
 
-    setSubmitting(false);
-    closeEntityDetailsOverlay!();
+    returnToDashboard!();
   };
 
   //used to get the exact form values to enable/disable close out button

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -149,7 +149,9 @@ export const getInitiativeDashboardStatus = (
       });
 
       //if any of the field data is empty, that means we're missing data and the status is automatically false
-      isFilled = !filterdFieldData.every((field: any) => field)
+      isFilled = !filterdFieldData.every(
+        (field: any) => field && field.length > 0
+      )
         ? false
         : isFilled;
     });
@@ -191,7 +193,7 @@ export const getCloseoutStatus = (form: FormJson, entity: EntityShape) => {
     }
 
     return isFilled?.every((field: any) => {
-      return typeof field === "object" ? field.length > 0 : field;
+      return field && field.length > 0;
     });
   }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I missed this condition during the initial autosave fix. Sometimes auto save run a millisecond earlier than the submit button and therefore the submit function doesn't think anything had changed.

This fix prevents the page from returning to the dashboard if autosave is running and the user clicked the save & return button

P.S. Sneaking in an addon to fix the status not checking empty arrays correctly.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2812

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP
2) Create a new WP
3) Enter WP and click **State and Territory-Specific Initiatives**
4) Add a new initiative and press Edit
5) Fill out Define Initiative and click Save & Return. The spinner in the button should run.
Before this update, save & return just immediately returns you to the dashboard

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
