### PR TITLE
fix number validation

### DIFF
--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -1,15 +1,14 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { number, ratio } from "./schemas";
+import { number, ratio, validNumber } from "./schemas";
 
 describe("Schemas", () => {
   const goodNumberTestCases = [
     "123",
     "123.00",
-    "123..00",
     "1,230",
     "1,2,30",
     "1230",
-    "123450123..,,,.123123123123",
+    "123450123,,,.123123123123",
     "N/A",
     "Data not available",
   ];
@@ -36,9 +35,24 @@ describe("Schemas", () => {
     "%@#$!ASDF",
   ];
 
+  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
+
+  const badValidNumberTestCases = ["N/A", "number", "foo"];
+
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
+    expectedReturn: boolean
+  ) => {
+    for (let testCase of testCases) {
+      let test = schemaToUse.isValidSync(testCase);
+      expect(test).toEqual(expectedReturn);
+    }
+  };
+
+  const testValidNumber = (
+    schemaToUse: MixedSchema,
+    testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
     for (let testCase of testCases) {
@@ -55,5 +69,10 @@ describe("Schemas", () => {
   test("Evaluate Number Schema using ratio scheme", () => {
     testNumberSchema(ratio(), goodRatioTestCases, true);
     testNumberSchema(ratio(), badRatioTestCases, false);
+  });
+
+  test("Test validNumber schema", () => {
+    testValidNumber(validNumber(), goodValidNumberTestCases, true);
+    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -1,7 +1,10 @@
 import { array, boolean, mixed, object, string } from "yup";
 import { validationErrors as error } from "verbiage/errors";
 import { Choice } from "types";
-import { checkStandardNumberInputAgainstRegexes } from "utils/other/checkInputValidity";
+import {
+  checkRatioInputAgainstRegexes,
+  checkStandardNumberInputAgainstRegexes,
+} from "utils/other/checkInputValidity";
 
 // TEXT - Helpers
 const isWhitespaceString = (value?: string) => value?.trim().length === 0;
@@ -19,12 +22,6 @@ export const textOptional = () => string().typeError(error.INVALID_GENERIC);
 
 // NUMBER - Helpers
 const validNAValues = ["N/A", "Data not available"];
-
-const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
-  return numberSchema().transform((_value) => {
-    return Number(value.replace(charsToReplace, ""));
-  });
-};
 
 // NUMBER - Number or Valid Strings
 export const numberSchema = () =>
@@ -60,6 +57,7 @@ const validNumberSchema = () =>
     },
   });
 
+// this is in case there are any fields that should only accept integers
 export const validNumber = () =>
   validNumberSchema()
     .required(error.REQUIRED_GENERIC)
@@ -98,33 +96,7 @@ export const ratio = () =>
     .test({
       message: error.INVALID_RATIO,
       test: (val) => {
-        const replaceCharsRegex = /[,.:]/g;
-        const ratio = val?.split(":");
-
-        // Double check and make sure that a ratio contains numbers on both sides
-        if (
-          !ratio ||
-          ratio.length != 2 ||
-          ratio[0].trim().length == 0 ||
-          ratio[1].trim().length == 0
-        ) {
-          return false;
-        }
-
-        // Check if the left side of the ratio is a valid number
-        const firstTest = valueCleaningNumberSchema(
-          ratio[0],
-          replaceCharsRegex
-        ).isValidSync(val);
-
-        // Check if the right side of the ratio is a valid number
-        const secondTest = valueCleaningNumberSchema(
-          ratio[1],
-          replaceCharsRegex
-        ).isValidSync(val);
-
-        // If both sides are valid numbers, return true!
-        return firstTest && secondTest;
+        return checkRatioInputAgainstRegexes(val).isValid;
       },
     });
 

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -1,13 +1,7 @@
-import {
-  array,
-  boolean,
-  mixed,
-  number as numberSchema,
-  object,
-  string,
-} from "yup";
+import { array, boolean, mixed, object, string } from "yup";
 import { validationErrors as error } from "verbiage/errors";
 import { Choice } from "types";
+import { checkStandardNumberInputAgainstRegexes } from "utils/other/checkInputValidity";
 
 // TEXT - Helpers
 const isWhitespaceString = (value?: string) => value?.trim().length === 0;
@@ -33,26 +27,65 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
 };
 
 // NUMBER - Number or Valid Strings
+export const numberSchema = () =>
+  string().test({
+    message: error.INVALID_NUMBER_OR_NA,
+    test: (value) => {
+      if (value) {
+        const isValidStringValue = validNAValues.includes(value);
+        const isValidNumberValue =
+          checkStandardNumberInputAgainstRegexes(value);
+        return isValidStringValue || isValidNumberValue;
+      } else return true;
+    },
+  });
+
 export const number = () =>
-  string()
+  numberSchema()
     .required(error.REQUIRED_GENERIC)
-    .test({
-      message: error.INVALID_NUMBER_OR_NA,
-      test: (value) => {
-        const validNumberRegex = /[0-9,.]/;
-        if (value) {
-          const isValidStringValue = validNAValues.includes(value);
-          const isValidNumberValue = validNumberRegex.test(value);
-          return isValidStringValue || isValidNumberValue;
-        } else return true;
-      },
-    })
     .test({
       test: (value) => !isWhitespaceString(value),
       message: error.REQUIRED_GENERIC,
     });
 
-export const numberOptional = () => number().notRequired();
+export const numberOptional = () => numberSchema().notRequired().nullable();
+
+const validNumberSchema = () =>
+  string().test({
+    message: error.INVALID_NUMBER,
+    test: (value) => {
+      return typeof value !== "undefined"
+        ? checkStandardNumberInputAgainstRegexes(value)
+        : false;
+    },
+  });
+
+export const validNumber = () =>
+  validNumberSchema()
+    .required(error.REQUIRED_GENERIC)
+    .test({
+      test: (value) => !isWhitespaceString(value),
+      message: error.REQUIRED_GENERIC,
+    });
+
+export const validNumberOptional = () =>
+  validNumberSchema().notRequired().nullable();
+
+// NUMBER NOT LESS THAN ONE
+export const numberNotLessThanOne = () =>
+  validNumber().test({
+    test: (value) => {
+      return parseFloat(value!) >= 1;
+    },
+    message: error.NUMBER_LESS_THAN_ONE,
+  });
+
+// NUMBER NOT LESS THAN ZERO
+export const numberNotLessThanZero = () =>
+  validNumber().test({
+    test: (value) => parseFloat(value!) >= 0,
+    message: error.NUMBER_LESS_THAN_ZERO,
+  });
 
 // Number - Ratio
 export const ratio = () =>

--- a/services/ui-src/src/verbiage/errors.ts
+++ b/services/ui-src/src/verbiage/errors.ts
@@ -15,6 +15,9 @@ export const validationErrors = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
+  NUMBER_LESS_THAN_ONE: "Response must be greater than or equal to one",
+  NUMBER_LESS_THAN_ZERO: "Response must be greater than or equal to zero",
+  INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };


### PR DESCRIPTION
### Description
Number validation was allowing lowercase letters and mixtures of numbers, decimals, and letters. This fix was taken from the fix made recently to MCR. The ratio validation was updated as well, since the function already existed in the `checkInputValidity` file.

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/e54af1cd-6ba1-4d8b-ac84-7765c6bd728d




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2371

---
### How to test
Create a workplan, create an initiative, edit it, go to Funding Sources, see that you can only enter numbers, `N/A`, and` Data not available`

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/711303ac-74a9-403f-a375-a5c037b793e1




### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
