### PR TITLE
set repeating quarters to 1 or 3 depending on the period

### DIFF
--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -16,14 +16,15 @@ import {
   ModalOverlayReportPageShape,
   OverlayModalPageShape,
   ReportJson,
+  ReportMetadataShape,
   ReportRoute,
   ReportType,
 } from "../types";
 import { getTemplate } from "../../handlers/formTemplates/populateTemplatesTable";
 import { createHash } from "crypto";
 import {
-  calculateCurrentQuarter,
   calculateCurrentYear,
+  calculatePeriod,
   incrementQuarterAndYear,
 } from "../time/time";
 
@@ -55,8 +56,13 @@ export const formTemplateForReportType = (reportType: ReportType) => {
   }
 };
 
-export const nextTwelveQuartersKeys = (fieldId: string) => {
-  let quarter = calculateCurrentQuarter();
+export const nextTwelveQuartersKeys = (
+  fieldId: string,
+  currentDate: number,
+  workPlan?: ReportMetadataShape
+) => {
+  let period = calculatePeriod(currentDate, workPlan);
+  let quarter = period === 1 ? 1 : 3;
   let year = calculateCurrentYear();
   const keys: (string[] | number[])[][] = [];
   for (let i = 0; i < 12; i++) {
@@ -69,9 +75,11 @@ export const nextTwelveQuartersKeys = (fieldId: string) => {
 export const nextTwelveQuarters = (
   formFields: FormField[],
   fieldIndex: number,
-  fieldToRepeat: FormField
+  fieldToRepeat: FormField,
+  currentDate: number,
+  workPlan?: ReportMetadataShape
 ) => {
-  var keys = nextTwelveQuartersKeys(fieldToRepeat.id);
+  var keys = nextTwelveQuartersKeys(fieldToRepeat.id, currentDate, workPlan);
   for (let key of keys) {
     const formField: FormField = {
       ...fieldToRepeat,


### PR DESCRIPTION
### Description
Quarters were being determined by the date, but it needed to be set by the period. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2372

---
### How to test
See that when you create a workplan, the first quarter you see in the repeating quarter fields right now is 'Q3' instead of 'Q4'.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
