### PR TITLE
[PenTest] - Remove renderHTML from places it dont belong

### DIFF
--- a/services/ui-src/src/components/modals/DeleteEntityModal.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.tsx
@@ -5,7 +5,7 @@ import { Modal, ReportContext } from "components";
 
 // types
 import { AnyObject, EntityShape, ReportStatus } from "types";
-import { renderHtml, useStore } from "utils";
+import { useStore } from "utils";
 
 export const DeleteEntityModal = ({
   entityType,
@@ -98,7 +98,7 @@ export const DeleteEntityModal = ({
         closeButtonText: "Cancel",
       }}
     >
-      <Text>{renderHtml(verbiage.deleteModalWarning)}</Text>
+      <Text>{verbiage.deleteModalWarning}</Text>
     </Modal>
   );
 };

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -106,7 +106,7 @@ export const EntityRow = ({
             sx={!isRequired ? sx.editOtherEntityButton : sx.editEntityButton}
             onClick={() => openOverlayOrDrawer(entity)}
             variant="outline"
-            // disabled={entityStatus === "disabled"}
+            disabled={entityStatus === "disabled"}
           >
             {verbiage.enterEntityDetailsButtonText}
           </Button>

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -10,7 +10,7 @@ import {
   ReportShape,
 } from "types";
 // utils
-import { renderHtml, useStore } from "utils";
+import { useStore } from "utils";
 // assets
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import {
@@ -80,7 +80,7 @@ export const EntityRow = ({
               {!isRequired &&
                 entityType === ModalDrawerEntityTypes.TARGET_POPULATIONS &&
                 `Other: `}
-              {renderHtml(field)}
+              {field}
             </li>
           ))}
         </ul>
@@ -106,7 +106,7 @@ export const EntityRow = ({
             sx={!isRequired ? sx.editOtherEntityButton : sx.editEntityButton}
             onClick={() => openOverlayOrDrawer(entity)}
             variant="outline"
-            disabled={entityStatus === "disabled"}
+            // disabled={entityStatus === "disabled"}
           >
             {verbiage.enterEntityDetailsButtonText}
           </Button>

--- a/services/ui-src/src/utils/other/renderHtml.ts
+++ b/services/ui-src/src/utils/other/renderHtml.ts
@@ -1,7 +1,0 @@
-import React from "react";
-
-// render '<' special character
-export const renderHtml = (rawHTML: string) =>
-  React.createElement("span", {
-    dangerouslySetInnerHTML: { __html: rawHTML },
-  });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
renderHTML was being called in entityRows and allowing for user entered data to be shown. Whoops! Was an accidental copy from MCR's exportedEntityRow and has now been removed.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a Workplan
Create a transition benchmark or initiative and pass into the textbox `<iframe src=javascript:alert(document.domain)>`
See that no alert pops up!

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
