### PR TITLE
CMDCT-2229: Error when trying to add a duplicated "Other" target population

### DIFF
--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -18,6 +18,7 @@ import { MfpReportState, MfpUserState, entityTypes } from "../../types";
 
 const mockCloseHandler = jest.fn();
 const mockUpdateReport = jest.fn();
+const mockSetError = jest.fn();
 
 jest.mock("react-uuid", () => jest.fn(() => "mock-id-2"));
 jest.mock("utils/state/useStore");
@@ -71,6 +72,7 @@ const modalComponent = (
         verbiage={mockModalDrawerReportPageVerbiage}
         entityName={mockEntityName}
         form={mockModalForm}
+        setError={mockSetError}
         modalDisclosure={{
           isOpen: true,
           onClose: mockCloseHandler,
@@ -88,6 +90,7 @@ const modalComponentWithSelectedEntity = (
         selectedEntity={mockEntity}
         verbiage={mockModalDrawerReportPageVerbiage}
         form={mockModalForm}
+        setError={mockSetError}
         modalDisclosure={{
           isOpen: true,
           onClose: mockCloseHandler,
@@ -126,6 +129,15 @@ describe("Test AddEditEntityModal", () => {
   test("AddEditEntityModal close button closes modal", () => {
     fireEvent.click(screen.getByText("Close"));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("User cannot add duplicate 'Other' target populations", async () => {
+    const form = screen.queryByTestId("add-edit-entity-form");
+    const textField = form!.querySelector("input")!;
+    await userEvent.clear(textField);
+    await userEvent.type(textField, "mock input 1");
+    const submitButton = screen.getByRole("button", { name: "Save & close" });
+    expect(submitButton).toBeDisabled;
   });
 });
 

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -147,6 +147,7 @@ export const AddEditEntityModal = ({
         actionButtonText: submitting ? <Spinner size="md" /> : "Save & close",
         closeButtonText: "Cancel",
       }}
+      submitButtonDisabled={!!error}
     >
       {error && <ErrorAlert error={error} />}
       <Form

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -36,7 +36,7 @@ export const AddEditEntityModal = ({
   const [submitting, setSubmitting] = useState<boolean>(false);
 
   const onChange = (e: InputChangeEvent) => {
-    const input = e.target.value;
+    const input = e.target.value.trim();
     const existingOtherTargetPopulations =
       report?.fieldData.targetPopulations.filter(
         (object: AnyObject) => !object.isRequired

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -25,6 +25,8 @@ export const AddEditEntityModal = ({
   entityName,
   form,
   verbiage,
+  error,
+  setError,
   selectedEntity,
   modalDisclosure,
 }: Props) => {
@@ -32,7 +34,6 @@ export const AddEditEntityModal = ({
   const { updateReport } = useContext(ReportContext);
   const { full_name } = useStore().user ?? {};
   const [submitting, setSubmitting] = useState<boolean>(false);
-  const [error, setError] = useState<string>();
 
   const onChange = (e: InputChangeEvent) => {
     const input = e.target.value;
@@ -57,8 +58,6 @@ export const AddEditEntityModal = ({
 
   const writeEntity = async (enteredData: any) => {
     setSubmitting(true);
-    const submitButton = document.querySelector("[form=" + form.id + "]");
-    submitButton?.setAttribute("disabled", "true");
 
     const reportKeys = {
       reportType: report?.reportType,
@@ -171,6 +170,8 @@ interface Props {
   form: FormJson;
   verbiage: AnyObject;
   selectedEntity?: EntityShape;
+  error?: string;
+  setError: Function;
   modalDisclosure: {
     isOpen: boolean;
     onClose: any;

--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -24,6 +24,7 @@ export const Modal = ({
   submitting,
   formId,
   children,
+  submitButtonDisabled,
 }: Props) => {
   return (
     <ChakraModal
@@ -60,6 +61,7 @@ export const Modal = ({
                 form={formId}
                 type="submit"
                 data-testid="modal-submit-button"
+                disabled={submitButtonDisabled}
               >
                 {submitting ? <Spinner size="md" /> : content.actionButtonText}
               </Button>

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -56,6 +56,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
     undefined
   );
+  const [error, setError] = useState<string>();
 
   const { report } = useStore();
   const { updateReport } = useContext(ReportContext);
@@ -83,6 +84,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeAddEditEntityModal = () => {
     setSelectedEntity(undefined);
+    setError("");
     addEditEntityModalOnCloseHandler();
   };
 
@@ -227,6 +229,8 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           selectedEntity={selectedEntity}
           verbiage={verbiage}
           form={modalForm}
+          error={error}
+          setError={setError}
           modalDisclosure={{
             isOpen: addEditEntityModalIsOpen,
             onClose: closeAddEditEntityModal,

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -170,6 +170,7 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
             selectedEntity={selectedEntity}
             verbiage={verbiage}
             form={modalForm}
+            setError={() => {}}
             modalDisclosure={{
               isOpen: addEditEntityModalIsOpen,
               onClose: closeAddEditEntityModal,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Users should not be able to add multiple "Other" target populations with the same name. In this PR, we're disabling the `Save & close` button whenever a user attempts to add duplicated target populations and showing the following error:

![Screenshot 2023-11-21 at 11 53 54 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/af4230da-fdfd-426c-89ea-8c1fe2d58742)

**Note:** this was co-authored with @ailZhou and @gmrabian 🌟 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2229

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Navigate to `wp/transition-benchmarks`
- Add a new Target Population

Try to add another target population with the exact same name and you should see an error message pop up with the Save & close button disabled.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
