### PR TITLE
CMDCT-2980: Sort WP & SAR Reports from Newest to Oldest on the Submissions Dashboard

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -216,7 +216,7 @@ describe("Test WP Admin Report Dashboard View (with reports, desktop view, mobil
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[1];
+      const unlockButton = screen.getAllByText("Unlock")[0];
       expect(unlockButton).toBeVisible();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
@@ -255,7 +255,7 @@ describe("Test WP Admin Report Dashboard View (with reports, desktop view, mobil
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[1];
+      const unlockButton = screen.getAllByText("Unlock")[0];
       expect(unlockButton).toBeVisible();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -110,7 +110,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   useEffect(() => {
     let newReportsToDisplay = reportsByState;
     // sort by creation date (newest to oldest)
-    newReportsToDisplay?.sort((a, b) => b.createdAt - a.createdAt);
+    newReportsToDisplay?.reverse();
     if (!userIsAdmin) {
       newReportsToDisplay = reportsByState?.filter(
         (report: ReportMetadataShape) => !report?.archived

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -109,6 +109,8 @@ export const DashboardPage = ({ reportType }: Props) => {
 
   useEffect(() => {
     let newReportsToDisplay = reportsByState;
+    // sort by creation date (newest to oldest)
+    newReportsToDisplay?.sort((a, b) => b.createdAt - a.createdAt);
     if (!userIsAdmin) {
       newReportsToDisplay = reportsByState?.filter(
         (report: ReportMetadataShape) => !report?.archived


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
See title.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2980

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Navigate to `DashboardPage.tsx`
- Comment out Line #325 [see here](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/997d1e5e420df86108a8a690ee028edb754f3f82/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx#L325)
- Log in as a state user
- Create multiple Work Plans

To really visualize this, I'd recommend: 
- Creating a WP
- Filling a few fields so it's set to `In progress`
- Creating a new one

The newest one (with `Not started` status) should be at the top of the submissions dashboard.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
