### PR TITLE
show Other input on the initiatives dashboard

### DIFF
--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -62,7 +62,15 @@ export const EntityRow = ({
     programInfo = (entityInfo as string[]).flatMap((info) => {
       //if the data is in an array, like a radio button values, get each as text
       if (typeof entity?.[info] === "object") {
-        return (entity[info] as any[]).map((arr) => arr.value);
+        return (entity[info] as any[]).map((arr) => {
+          if (
+            entity?.initiative_wp_otherTopic &&
+            arr.value === "Other, specify"
+          ) {
+            return entity.initiative_wp_otherTopic;
+          }
+          return arr.value;
+        });
       }
       return entity[info];
     });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Fixed a bug where if "Other" was chosen for the Initiative Workplan Topic, the custom input wouldn't show - it would display "Other, specify" instead.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3039

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
create a work plan, 
go to Initiatives dashboard, 
create an initiative, 
choose "Other" as the topic, 
type in a custom topic, 
save and see that it displays beneath the Initiative name on the dashboard

![Screenshot 2023-11-27 at 12 32 16 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/5b9ef0ed-aaf7-409d-9bf0-f33f76255e2e)



### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
