### PR TITLE
CMDCT-3044: Change "Edit" button text to "View" in a submitted WP

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -1432,6 +1432,7 @@
           }
         },
         "enterEntityDetailsButtonText": "Edit",
+        "readOnlyEntityDetailsButtonText": "View",
         "dashboardTitle": "Report progress for each initiative",
         "dashboardSubtitle": "Initiatives and Work Plan topics are auto-populated from your most recent approved Work Plan.",
         "tableHeader": "Initiative name <br/> Work Plan topic",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -60,6 +60,7 @@
         "pdfDashboardTitle": "Transition Benchmark Totals",
         "addEntityButtonText": "Add other target population",
         "editEntityButtonText": "Edit name",
+        "readOnlyEntityButtonText": "View name",
         "addEditModalAddTitle": "Add other target population",
         "addEditModalEditTitle": "Edit other target population",
         "deleteEntityButtonAltText": "Delete other target population",
@@ -68,6 +69,7 @@
         "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this population in the Work Plan. The population will remain in previously submitted Semi-Annual Reports if applicable.",
         "entityUnfinishedMessage": "Complete the remaining indicators for this access measure by entering details.",
         "enterEntityDetailsButtonText": "Edit",
+        "readOnlyEntityDetailsButtonText": "View",
         "reviewPdfHint": "To view Transition Benchmark Totals by target population and by quarter, click <i>Review PDF</i> and it will open a summary in a new tab.",
         "drawerTitle": "Report transition benchmarks for ",
         "drawerInfo": [
@@ -669,12 +671,14 @@
             "editEntityHint": "Select \"Edit\" to complete the details.",
 
             "editEntityButtonText": "Edit name/topic",
+            "readOnlyEntityButtonText": "View name/topic",
             "addEditModalAddTitle": "Add initiative",
             "addEditModalEditTitle": "Edit initiative",
             "deleteModalTitle": "Are you sure you want to delete this initiative?",
             "deleteModalConfirmButtonText": "Yes, delete initiative",
             "deleteModalWarning": "Are you sure you want to proceed? You will lose all information entered for this initiative in the Work Plan. The initiative will remain in previously submitted Semi-Annual Reports if applicable. <br/><br/>To close a completed initiative out, select “Cancel” and then the “Close out” button in the listing.",
             "enterEntityDetailsButtonText": "Edit",
+            "readOnlyEntityDetailsButtonText": "View",
             "dashboardTitle": "Initiative total count:",
             "countEntitiesInTitle": true,
             "tableHeader": "Initiative name <br/> Work Plan topic",
@@ -814,6 +818,7 @@
                   "exportSectionHeader": "exportSectionHeader"
                 },
                 "enterEntityDetailsButtonText": "Edit",
+                "readOnlyEntityDetailsButtonText": "View",
                 "editEntityHint": "Select \"Edit\" to complete initiative definition."
               },
               "form": {
@@ -913,6 +918,7 @@
                 "addEntityButtonText": "Add objective",
                 "editEntityHint": "Select \"Edit\" to complete initiative evaluation plan.",
                 "editEntityButtonText": "Edit objective",
+                "readOnlyEntityButtonText": "View objective",
                 "addEditModalAddTitle": "Add objective for ",
                 "addEditModalHint": "Objectives should be framed as SMART goals and have associated time-bound measures of success, including targets or milestones.",
                 "addEditModalEditTitle": "Edit objective for ",
@@ -920,6 +926,7 @@
                 "deleteModalConfirmButtonText": "Yes, delete objective",
                 "deleteModalWarning": "You will lose all information entered for this objective. Objective will not be deleted from archived Work Plans and Semi-Annual Reports, but it will not be available in future Work Plans and Semi-Annual Reports.",
                 "enterEntityDetailsButtonText": "Edit",
+                "readOnlyEntityDetailsButtonText": "View",
                 "dashboardTitle": "Objective total count",
                 "countEntitiesInTitle": true,
                 "deleteEntityButtonAltText": "",
@@ -1029,6 +1036,7 @@
                 "addEntityButtonText": "Add funding source",
                 "editEntityHint": "Select \"Edit\" to complete initiative funding information.",
                 "editEntityButtonText": "Edit funding source",
+                "readOnlyEntityButtonText": "View funding source",
                 "addEditModalAddTitle": "Add funding source and projected expenditures for ",
                 "addEditModalEditTitle": "Edit funding source and projected expenditures for ",
                 "deleteEntityButtonAltText": "Delete other target population",
@@ -1039,6 +1047,7 @@
                 "addEditModalHint": "Provide projected quarterly expenditures, by funding source, for this initiative. Actual quarterly expenditures will be reported in the recipient’s Semi-Annual Report (SAR).",
                 "dashboardTitle": "Funding Sources",
                 "enterEntityDetailsButtonText": "Edit",
+                "readOnlyEntityDetailsButtonText": "View",
                 "countEntitiesInTitle": true
               },
               "modalForm": {
@@ -1130,7 +1139,8 @@
                   "closeOutModalBodyText": "This initiative will be closed out and will no longer be editable. You will be able to continue to view this response. If you are not ready to close out an initiative, select <i>Cancel</i> and you’ll be able to save your draft data.<br><br>This action cannot be undone.<br><br>Are you sure you want to proceed?",
                   "closeOutModalConfirmButtonText": "Yes, close out initiative"
                 },
-                "enterEntityDetailsButtonText": "Edit"
+                "enterEntityDetailsButtonText": "Edit",
+                "readOnlyEntityDetailsButtonText": "View"
               },
               "form": {
                 "id": "sauxM9MnFZhIn5W44WY3BG",

--- a/services/app-api/utils/testing/mocks/mockForm.ts
+++ b/services/app-api/utils/testing/mocks/mockForm.ts
@@ -138,6 +138,7 @@ export const mockVerbiageIntro = {
     },
   ],
   editEntityButtonText: "Edit",
+  readOnlyEntityButtonText: "View",
   enterReportText: "Enter Details",
 };
 
@@ -169,6 +170,7 @@ export const mockModalDrawerReportPageVerbiage = {
   dashboardTitle: "Mock dashboard title",
   addEntityButtonText: "Mock add entity button text",
   editEntityButtonText: "Mock edit entity button text",
+  readOnlyEntityButtonText: "Mock read-only entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
   addEditModalEditTitle: "Mock add/edit entity modal edit title",
   addEditModalMessage: "Mock add/edit entity modal message",
@@ -178,6 +180,7 @@ export const mockModalDrawerReportPageVerbiage = {
   deleteModalWarning: "Mock delete modal warning",
   entityUnfinishedMessage: "Mock entity unfinished messsage",
   enterEntityDetailsButtonText: "Mock enter entity details button text",
+  readOnlyEntityDetailsButtonText: "Mock read-only entity details button text",
   editEntityDetailsButtonText: "Mock edit entity details button text",
   drawerTitle: "Mock drawer title",
   drawerNoFormMessage: "Mock no form fields here",

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -148,6 +148,7 @@ export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
   editEntityButtonText: string;
+  readOnlyEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;
   addEditModalMessage: string;
@@ -157,6 +158,7 @@ export interface ModalDrawerReportPageVerbiage
   deleteModalWarning: string;
   entityUnfinishedMessage: string;
   enterEntityDetailsButtonText: string;
+  readOnlyEntityDetailsButtonText: string;
   editEntityDetailsButtonText: string;
 }
 

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -8,6 +8,7 @@ import {
   EntityShape,
   ModalDrawerEntityTypes,
   ReportShape,
+  ReportStatus,
 } from "types";
 // utils
 import { useStore } from "utils";
@@ -112,7 +113,9 @@ export const EntityRow = ({
             variant="outline"
             disabled={entityStatus === "disabled"}
           >
-            {verbiage.enterEntityDetailsButtonText}
+            {report?.status === ReportStatus.SUBMITTED
+              ? "View"
+              : verbiage.enterEntityDetailsButtonText}
           </Button>
           {!isRequired && !isCopied && (
             <Button

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -100,7 +100,10 @@ export const EntityRow = ({
               variant="none"
               onClick={() => openAddEditEntityModal(entity)}
             >
-              {verbiage.editEntityButtonText}
+              {report?.status === ReportStatus.SUBMITTED ||
+              report?.status === ReportStatus.APPROVED
+                ? verbiage.readOnlyEntityButtonText
+                : verbiage.editEntityButtonText}
             </Button>
           )}
           <Button
@@ -113,8 +116,9 @@ export const EntityRow = ({
             variant="outline"
             disabled={entityStatus === "disabled"}
           >
-            {report?.status === ReportStatus.SUBMITTED
-              ? "View"
+            {report?.status === ReportStatus.SUBMITTED ||
+            report?.status === ReportStatus.APPROVED
+              ? verbiage.readOnlyEntityDetailsButtonText
               : verbiage.enterEntityDetailsButtonText}
           </Button>
           {!isRequired && !isCopied && (

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -152,6 +152,7 @@ export interface ModalDrawerReportPageVerbiage
   extends DrawerReportPageVerbiage {
   addEntityButtonText: string;
   editEntityButtonText: string;
+  readOnlyEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;
   deleteEntityButtonAltText: string;
@@ -160,6 +161,7 @@ export interface ModalDrawerReportPageVerbiage
   deleteModalWarning: string;
   entityUnfinishedMessage: string;
   enterEntityDetailsButtonText: string;
+  readOnlyEntityDetailsButtonText: string;
   reviewPdfHint: string;
   drawerTitle: string;
   pdfDashboardTitle?: string;
@@ -171,6 +173,7 @@ export interface OverlayModalPageVerbiage extends ReportPageVerbiage {
   editEntityHint?: string;
   addEditModalHint: string;
   editEntityButtonText: string;
+  readOnlyEntityButtonText: string;
   addEditModalAddTitle: string;
   addEditModalEditTitle: string;
   deleteEntityButtonAltText: string;
@@ -179,6 +182,7 @@ export interface OverlayModalPageVerbiage extends ReportPageVerbiage {
   deleteModalWarning: string;
   entityUnfinishedMessage: string;
   enterEntityDetailsButtonText: string;
+  readOnlyEntityDetailsButtonText: string;
   accordion: object;
   dashboardTitle: string;
   missingEntityMessage?: CustomHtmlElement[];

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -138,6 +138,7 @@ export const mockVerbiageIntro = {
     },
   ],
   editEntityButtonText: "Edit",
+  readOnlyEntityButtonText: "View",
   enterReportText: "Enter Details",
 };
 
@@ -181,6 +182,7 @@ export const mockModalDrawerReportPageVerbiage = {
   dashboardTitle: "Mock dashboard title",
   addEntityButtonText: "Mock add entity button text",
   editEntityButtonText: "Mock edit entity button text",
+  readOnlyEntityButtonText: "Mock read-only entity button text",
   addEditModalAddTitle: "Mock add/edit entity modal add title",
   addEditModalEditTitle: "Mock add/edit entity modal edit title",
   deleteEntityButtonAltText: "Mock delete entity button alt text",
@@ -189,6 +191,7 @@ export const mockModalDrawerReportPageVerbiage = {
   deleteModalWarning: "Mock delete modal warning",
   entityUnfinishedMessage: "Mock entity unfinished messsage",
   enterEntityDetailsButtonText: "Mock enter entity details button text",
+  readOnlyEntityDetailsButtonText: "Mock read-only entity details button text",
   drawerTitle: "Mock drawer title",
   reviewPdfHint: "Mock review PDF hint",
   drawerNoFormMessage: "Mock no form fields here",
@@ -211,6 +214,7 @@ export const mockOverlayModalPageVerbiage = {
   deleteModalWarning: "Mock delete modal warning",
   entityUnfinishedMessage: "Mock entity unfinished messsage",
   enterEntityDetailsButtonText: "Mock enter entity details button text",
+  readOnlyEntityDetailsButtonText: "Mock read-only entity details button text",
   drawerTitle: "Mock drawer title",
   countEntitiesInTitle: true,
 };
@@ -277,6 +281,7 @@ export const mockModalOverlayReportPageVerbiage = {
   addEntityButtonText: "Mock add entity button text",
   emptyDashboardText: "Mock empty dashboard text",
   editEntityButtonText: "Mock edit entity button text",
+  readOnlyEntityButtonText: "Mock read-only entity button text",
   deleteModalTitle: "Mock delete modal title",
   deleteModalConfirmButtonText: "Mock delete modal confirm button text",
   deleteModalWarning: "Mock delete modal warning",

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -63,6 +63,7 @@ export const mockFullReportJSON: ReportJson = {
           "Report projected number of transitions for each target population",
         addEntityButtonText: "Add other target population",
         editEntityButtonText: "Edit name",
+        readOnlyEntityButtonText: "View name",
         addEditModalAddTitle: "Add other target population",
         addEditModalEditTitle: "Edit other target population",
         deleteEntityButtonAltText: "Delete other target population",
@@ -74,6 +75,7 @@ export const mockFullReportJSON: ReportJson = {
         entityUnfinishedMessage:
           "Complete the remaining indicators for this access measure by entering details.",
         enterEntityDetailsButtonText: "Edit",
+        readOnlyEntityDetailsButtonText: "View",
         reviewPdfHint:
           "To view Transition Benchmark Totals by target population and by quarter, click <i>Review PDF</i> and it will open a summary in a new tab.",
         drawerTitle: "Report transition benchmarks for ",
@@ -683,6 +685,7 @@ export const mockFullReportJSON: ReportJson = {
             },
             addEntityButtonText: "Add Initiative",
             editEntityButtonText: "Edit name",
+            readOnlyEntityButtonText: "View name",
             addEditModalAddTitle: "Add initiative",
             addEditModalEditTitle: "Edit initiative",
             deleteModalTitle:
@@ -691,6 +694,7 @@ export const mockFullReportJSON: ReportJson = {
             deleteModalWarning:
               "Are you sure you want to proceed? You will lose all information entered for this initiative in the Work Plan. The initiative will remain in previously submitted Semi-Annual Reports if applicable. <br/><br/>To close a completed initiative out, select “Cancel” and then the “Close out” button in the listing.",
             enterEntityDetailsButtonText: "Edit",
+            readOnlyEntityDetailsButtonText: "View",
             dashboardTitle: "Initative total count",
             countEntitiesInTitle: true,
             tableHeader: "Initaitve name <br/> Work Plan topic",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If a WP has been submitted or approved, the Transition Benchmarks buttons should read "View" instead of "Edit", and the other Transition Benchmarks buttons should read "View name" instead of "Edit name".

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3044

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in and create a new WP
- Submit that WP
- Navigate to the `Transition Benchmark Projections` page

The buttons should now say "View":
![Screenshot 2023-11-27 at 2 55 14 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/ea07baeb-77e6-46b6-8b73-909dc2ccdbd8)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
