### PR TITLE
Cmdct 419 bug

### DIFF
--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 // assets
 import closeIcon from "assets/icons/icon_close.png";
+import { renderHtml } from "utils";
 
 export const Modal = ({
   modalDisclosure,
@@ -40,7 +41,7 @@ export const Modal = ({
           </Heading>
         </ModalHeader>
         {content.subheading && (
-          <Box sx={sx.modalSubheader}>{content.subheading}</Box>
+          <Box sx={sx.modalSubheader}>{renderHtml(content.subheading)}</Box>
         )}
         <Flex sx={sx.modalCloseContainer}>
           <Button

--- a/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
+++ b/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
@@ -7,7 +7,7 @@
     "edit": "Continue MFP Work Plan",
     "add": "Add new MFP Work Plan",
     "subheading": "Start a new Work Plan for the reporting period. Once you complete this Work Plan and CMS approves it, you’ll be able to continue updating it by selecting Continue from previous period or completely reset your MFP program information and start from a blank form. You will be able to view all Work Plans from previous periods. ",
-    "subheadingEdit": "Update your Work Plan for the next period, starting from the information in your last approved Work Plan by selecting Continue from previous period. Use Reset Work Plan only when you want to completely reset your MFP program information and start from a blank form. You will still be able to view the Work Plans from all previous periods."
+    "subheadingEdit": "Update your Work Plan for the next period, starting from the information in your last approved Work Plan by selecting <i>Continue from previous period</i>. Use <i>Reset Work Plan</i> only when you want to completely reset your MFP program information and start from a blank form. You will still be able to view the Work Plans from all previous periods."
   },
   "fields": [
     {

--- a/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
+++ b/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
@@ -6,7 +6,7 @@
   "heading": {
     "edit": "Continue MFP Work Plan",
     "add": "Add new MFP Work Plan",
-    "subheading": "Start a new Work Plan for the reporting period. Once you complete this Work Plan and CMS approves it, you’ll be able to continue updating it by selecting Continue from previous period or completely reset your MFP program information and start from a blank form. You will be able to view all Work Plans from previous periods. ",
+    "subheading": "Start a new Work Plan for the reporting period. Once you complete this Work Plan and CMS approves it, you’ll be able to continue updating it by selecting <i>Continue from previous period</i> or completely reset your MFP program information and start from a blank form. You will be able to view all Work Plans from previous periods.",
     "subheadingEdit": "Update your Work Plan for the next period, starting from the information in your last approved Work Plan by selecting <i>Continue from previous period</i>. Use <i>Reset Work Plan</i> only when you want to completely reset your MFP program information and start from a blank form. You will still be able to view the Work Plans from all previous periods."
   },
   "fields": [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Addressed a lack of italics in the Create or Copy modal in the WorkPlan


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-419

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
in the Create modal, "Continue from previous period" should be italicized
in the Continue from Previous modal, "Continue from previous period" and "Reset Work Plan" should be italicized

link to figma
https://www.figma.com/file/oOJMUZerbafZefLQQ33GwI/MFP_Playground?type=design&node-id=4150%3A110854&mode=design&t=jcBVta11shAii8J9-1

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
