### PR TITLE
[CMDCT-2376] Make target populations only show if applicable

### DIFF
--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -17,6 +17,7 @@ import {
   formFieldFactory,
   hydrateFormFields,
   mapValidationTypesToSchema,
+  removeNotApplicablePopulations,
   sortFormErrors,
   updateFieldChoicesByID,
   useStore,
@@ -54,9 +55,11 @@ export const Form = ({
   const { report } = useStore();
 
   const updateRenderFields = (fields: (FormField | FormLayoutElement)[]) => {
-    const updatedTargetPopulationChoices = report?.fieldData?.targetPopulations;
+    const targetPopulations = report?.fieldData?.targetPopulations;
+    const filteredTargetPopulations =
+      removeNotApplicablePopulations(targetPopulations);
     const formatChoiceList = convertTargetPopulationsFromWPToSAREntity(
-      updatedTargetPopulationChoices
+      filteredTargetPopulations
     );
 
     const updateTargetPopulationChoiceList = updateFieldChoicesByID(

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -1,4 +1,4 @@
-import { resetClearProp } from "./forms";
+import { removeNotApplicablePopulations, resetClearProp } from "./forms";
 // types
 import { FormField } from "types";
 import {
@@ -6,6 +6,12 @@ import {
   mockFormField,
   mockNestedFormField,
   mockNumberField,
+  mockTargetPopButOtherApplicable,
+  mockTargetPopButOtherNotApplicable,
+  mockTargetPopByOtherNotDefined,
+  mockTargetPopReqButApplicable,
+  mockTargetPopReqButApplicableIsUndefined,
+  mockTargetPopReqButNotApplicable,
 } from "utils/testing/setupJest";
 
 describe("Test resetClearProp", () => {
@@ -34,5 +40,29 @@ describe("Test resetClearProp", () => {
     const fields: FormField[] = [mockDateField];
     resetClearProp(fields);
     expect(fields[0].props?.clear).toBe(false);
+  });
+});
+
+describe("Test removeNotApplicablePopulations", () => {
+  const exampleTargetPopulations = [
+    mockTargetPopReqButNotApplicable,
+    mockTargetPopReqButApplicable,
+    mockTargetPopReqButApplicableIsUndefined,
+    mockTargetPopButOtherApplicable,
+    mockTargetPopButOtherNotApplicable,
+    mockTargetPopByOtherNotDefined,
+  ];
+
+  it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration", async () => {
+    const filteredPopulations = removeNotApplicablePopulations(
+      exampleTargetPopulations
+    );
+    expect(filteredPopulations.length).toBe(4);
+    expect(filteredPopulations).toEqual([
+      mockTargetPopReqButApplicable,
+      mockTargetPopReqButApplicableIsUndefined,
+      mockTargetPopButOtherApplicable,
+      mockTargetPopByOtherNotDefined,
+    ]);
   });
 });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -333,7 +333,7 @@ export const injectFormWithTargetPopulations = (
 export const removeNotApplicablePopulations = (
   targetPopulations: AnyObject[]
 ) => {
-  const filteredPopulations = targetPopulations.filter((population) => {
+  const filteredPopulations = targetPopulations?.filter((population) => {
     const isApplicable =
       population?.transitionBenchmarks_applicableToMfpDemonstration?.[0]?.value;
     return isApplicable !== "No";

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -321,3 +321,22 @@ export const injectFormWithTargetPopulations = (
   form.fields = updatedFields;
   return form;
 };
+
+/**
+ * This function takes the target populations given from the form data and then filters out
+ * any population that a user has answered "No". It does this by looking for a child object
+ * called transitionBenchmarks_applicableToMfpDemonstration and seeing if it has a value of "No"
+ * @param {AnyObject[]} targetPopulations - targetPopulations that are in the formData
+ * @return {AnyObject[]} Target populations filtered to no long has No answers from
+ * transitionBenchmarks_applicableToMfpDemonstration
+ */
+export const removeNotApplicablePopulations = (
+  targetPopulations: AnyObject[]
+) => {
+  const filteredPopulations = targetPopulations.filter((population) => {
+    const isApplicable =
+      population?.transitionBenchmarks_applicableToMfpDemonstration?.[0]?.value;
+    return isApplicable !== "No";
+  });
+  return filteredPopulations;
+};

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -49,3 +49,67 @@ export const mockOtherTargetPopulationEntity = {
   isRequired: false,
   transitionBenchmarks_targetPopulationName: "New target population",
 };
+
+export const mockTargetPopReqButNotApplicable = {
+  id: "1",
+  transitionBenchmarks_targetPopulationName: "Required-No",
+  isRequired: true,
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "a",
+      value: "No",
+    },
+  ],
+  quarterlyProjections2023Q3: "",
+};
+
+export const mockTargetPopReqButApplicable = {
+  id: "2",
+  transitionBenchmarks_targetPopulationName: "Required-Yes",
+  isRequired: true,
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "b",
+      value: "Yes",
+    },
+  ],
+  quarterlyProjections2023Q3: "1",
+};
+
+export const mockTargetPopReqButApplicableIsUndefined = {
+  id: "3",
+  transitionBenchmarks_targetPopulationName: "Required-Undefined",
+  isRequired: true,
+};
+
+export const mockTargetPopButOtherApplicable = {
+  id: "4",
+  type: "targetPopulations",
+  transitionBenchmarks_targetPopulationName: "Other-Yes",
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "c",
+      value: "Yes",
+    },
+  ],
+  quarterlyProjections2023Q3: "4",
+};
+
+export const mockTargetPopButOtherNotApplicable = {
+  id: "5",
+  type: "targetPopulations",
+  transitionBenchmarks_targetPopulationName: "Other-No",
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "d",
+      value: "No",
+    },
+  ],
+  quarterlyProjections2023Q3: "",
+};
+
+export const mockTargetPopByOtherNotDefined = {
+  id: "6",
+  type: "targetPopulations",
+  transitionBenchmarks_targetPopulationName: "Other-Undefined",
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Target populations that were not applicable to the Work Plan were being shown in the Define Initiative screen. This makes it so that those populations will not show as choices under the Target Population question! Questions that are not yet answered will still currently show.

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/5b513ce6-24ed-4fce-8184-8c9067b91667

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2376

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a workplan
Go to the Transition Benchmarks page and update some target populations with Yes or No, or simply leave them be
Create a couple Other target populations
Go to the Iniatives screen and create an initiative
Enter the created initiative and then go to Define Initiative
See the Target populations you marked as no not show as choices.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
