### PR TITLE
Address WP UI bugs

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -658,7 +658,10 @@
                   "type": "internalLink",
                   "content": "previous page",
                   "props": {
-                    "to": "/wp/state-and-territory-specific-initiatives/instructions"
+                    "to": "/wp/state-and-territory-specific-initiatives/instructions",
+                    "style": {
+                      "textDecoration": "underline"
+                    }
                   }
                 },
                 {

--- a/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
+++ b/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
@@ -31,6 +31,7 @@ interface Props {
 const sx = {
   root: {
     marginTop: "2rem",
+    color: "palette.base",
   },
   item: {
     marginBottom: "1.5rem",

--- a/services/ui-src/src/components/alerts/Alert.tsx
+++ b/services/ui-src/src/components/alerts/Alert.tsx
@@ -12,7 +12,7 @@ import {
 // utils
 import { AlertTypes } from "types";
 // assets
-import alertIcon from "assets/icons/icon_info_circle.png";
+import alertIcon from "assets/icons/icon_alert_circle.png";
 import { parseCustomHtml } from "utils";
 
 export const Alert = ({

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -94,7 +94,8 @@ const sx = {
     fontSize: "sm",
   },
   description: {
-    marginTop: "0.75rem",
+    marginTop: "0.25rem",
+    marginBottom: "1.25rem",
     fontSize: "sm",
   },
   grid: {
@@ -102,6 +103,7 @@ const sx = {
     gridTemplateRows: "1fr 1fr 1fr 1fr",
     gridAutoFlow: "column",
     gridGap: ".5rem",
+    marginBottom: "1.25rem",
   },
   gridSubtitle: {
     fontWeight: "bold",

--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -136,7 +136,7 @@ describe("Test AddEditEntityModal", () => {
     const textField = form!.querySelector("input")!;
     await userEvent.clear(textField);
     await userEvent.type(textField, "mock input 1");
-    const submitButton = screen.getByRole("button", { name: "Save & close" });
+    const submitButton = screen.getByRole("button", { name: "Save" });
     expect(submitButton).toBeDisabled;
   });
 });
@@ -157,7 +157,7 @@ describe("Test AddEditEntityModal functionality", () => {
     const textField = form.querySelector("[name='mock-modal-text-field']")!;
     await userEvent.clear(textField);
     await userEvent.type(textField, "mock input 2");
-    const submitButton = screen.getByRole("button", { name: "Save & close" });
+    const submitButton = screen.getByRole("button", { name: "Save" });
     await userEvent.click(submitButton);
   };
 
@@ -218,7 +218,7 @@ describe("Test AddEditEntityModal functionality", () => {
 
   test("Doesn't edit an existing entity if no update was made", async () => {
     render(modalComponentWithSelectedEntity);
-    const submitButton = screen.getByRole("button", { name: "Save & close" });
+    const submitButton = screen.getByRole("button", { name: "Save" });
     await userEvent.click(submitButton);
     expect(mockUpdateReport).toHaveBeenCalledTimes(0);
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -143,7 +143,7 @@ export const AddEditEntityModal = ({
         subheading: verbiage.addEditModalHint
           ? verbiage.addEditModalHint
           : undefined,
-        actionButtonText: submitting ? <Spinner size="md" /> : "Save & close",
+        actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}
       submitButtonDisabled={!!error}

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
@@ -170,7 +170,7 @@ describe("Test AddEditOverlayEntityModal functionality", () => {
     const textField = form.querySelector("[name='mock-modal-text-field']")!;
     await userEvent.clear(textField);
     await userEvent.type(textField, "mock input 2");
-    const submitButton = screen.getByRole("button", { name: "Save & close" });
+    const submitButton = screen.getByRole("button", { name: "Save" });
     await userEvent.click(submitButton);
   };
 

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -173,7 +173,7 @@ export const AddEditOverlayEntityModal = ({
         subheading: verbiage.addEditModalHint
           ? verbiage.addEditModalHint
           : undefined,
-        actionButtonText: submitting ? <Spinner size="md" /> : "Save & close",
+        actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}
     >

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -219,6 +219,8 @@ const sx = {
       marginBottom: "0.25rem",
     },
     th: {
+      fontWeight: "bold",
+      color: "palette.gray_medium",
       paddingLeft: "1rem",
       paddingRight: "0",
       borderBottom: "1px solid",

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -63,6 +63,7 @@ const sx = {
   },
   infoTextBox: {
     marginTop: "1.5rem",
+    color: "palette.gray",
     h3: {
       marginBottom: "-0.75rem",
     },

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -55,13 +55,14 @@ const sx = {
   subsectionHeading: {
     fontWeight: "normal",
     fontSize: "4xl",
+    marginTop: "0.5rem",
   },
   hintTextBox: {
     color: "#5B616B",
     paddingTop: "1.5rem",
   },
   infoTextBox: {
-    marginTop: "2rem",
+    marginTop: "1.5rem",
     h3: {
       marginBottom: "-0.75rem",
     },

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -167,12 +167,12 @@ const sx = {
   errorText: {
     color: "palette.error_dark",
     fontSize: "0.75rem",
-    marginBottom: "0.75rem",
+    marginBottom: "0.30rem",
   },
   entityName: {
     maxWidth: "18.75rem",
     ul: {
-      margin: "0.5rem auto",
+      margin: "0.25rem auto",
       listStyleType: "none",
       li: {
         wordWrap: "break-word",

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -152,6 +152,10 @@ const theme = extendTheme({
           border: "1px solid",
           borderColor: "palette.primary",
           textDecoration: "none",
+          "&:disabled, &:disabled:hover": {
+            color: "palette.gray",
+            borderColor: "palette.gray",
+          },
           _hover: {
             ...theme.components.Button.variants.transparent._hover,
             borderColor: "palette.primary_darker",

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -16,7 +16,7 @@ const theme = extendTheme({
   sizes: {
     appMax: "100vw",
     basicPageWidth: "46rem",
-    reportPageWidth: "40rem",
+    reportPageWidth: "46rem",
     // font sizes: https://design.cms.gov/utilities/font-size/
     xs: "0.75rem", // 12px
     sm: "0.875rem", // 14px

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -102,7 +102,7 @@ const theme = extendTheme({
       muted: "#e9ecf1",
       // custom
       gray_lightest_highlight: "#f8f8f8",
-      gray_medium: "#71767a",
+      gray_medium: "#7a767a",
       spreadsheet: "#1d6f42",
       spreadsheet_dark: "#174320",
     },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Per Kim's QA doc https://docs.google.com/spreadsheets/d/1HNW-ENP8JEQGvKIF9Urqn_lsIO9vveO7NGHHXEF3T2E/edit?pli=1#gid=279024116
Items addressed:

- WP All Initiatives Dashboard: Wrong icon is used in the alert. Should be the [alert circle icon](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2954887194/Graphic+Assets) (line 4)
- update header alignment in specific initiative dashboard (line 7)
- Close out disabled button should be gray (line 8)
- Previous page is missing the underline on initatives dashboard (line 3)
- update AddEditEntityModals to say Save instead of Save & close (line 5)
- update reportPage width to match basicPageWidth (line 7, also)
- update initiative entityRow margins (line 21)
- update theme color to match figma and add colors to the overModal page accordion (line 23)
- update margins in objective card questions (line 24)
- update add EntityModal button to say Save instead of Save & close" (line 40)
### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3088

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
