### PR TITLE
WP Copy: Evaluation Plan and Funding Source Card Alerts

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -858,15 +858,15 @@
                     "props": {
                       "label": "Does the initiative have a projected end date?",
                       "hint": "Select 'No' if the initiative will be ongoing without a set end point.",
-                      "choices" : [
+                      "choices": [
                         {
                           "id": "WNsSaAHeDvRD2Pjkz6DcOE",
                           "label": "Yes",
                           "children": [
-                            { 
+                            {
                               "id": "defineInitiative_projectedEndDate_value",
                               "type": "date",
-                              "validation": { 
+                              "validation": {
                                 "type": "endDate",
                                 "dependentFieldName": "defineInitiative_projectedStartDate",
                                 "nested": true,
@@ -956,7 +956,7 @@
                 "dashboardTitle": "Objective total count",
                 "countEntitiesInTitle": true,
                 "deleteEntityButtonAltText": "",
-                "entityUnfinishedMessage": "",
+                "entityUnfinishedMessage": "Add the quantitative targets for the next 2 quarters by editing the objective.",
                 "drawerTitle": ""
               },
               "modalForm": {
@@ -1074,6 +1074,7 @@
                 "dashboardTitle": "Funding Sources",
                 "enterEntityDetailsButtonText": "Edit",
                 "readOnlyEntityDetailsButtonText": "View",
+                "entityUnfinishedMessage": "Add the Projected quarterly expenditures for the next 2 quarters by editing funding source.",
                 "countEntitiesInTitle": true
               },
               "modalForm": {

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -1,5 +1,6 @@
 // components
 import { Heading, Text, Grid, GridItem, Flex } from "@chakra-ui/react";
+import { notAnsweredText } from "../../constants";
 // utils
 import { AnyObject, OverlayModalStepTypes } from "types";
 
@@ -36,7 +37,15 @@ export const EntityStepCardTopSection = ({
                     <GridItem key={quarter.id}>
                       <Flex sx={sx.gridItems}>
                         <Text sx={sx.gridSubtitle}>{quarter.id}:</Text>
-                        <Text sx={sx.subtext}>{quarter.value}</Text>
+                        <Text
+                          sx={
+                            quarter.value === notAnsweredText
+                              ? sx.error
+                              : sx.subtext
+                          }
+                        >
+                          {quarter.value}
+                        </Text>
                       </Flex>
                     </GridItem>
                   );
@@ -68,7 +77,15 @@ export const EntityStepCardTopSection = ({
                     <GridItem key={quarter.id}>
                       <Flex sx={sx.gridItems}>
                         <Text sx={sx.gridSubtitle}>{quarter.id}:</Text>
-                        <Text sx={sx.subtext}>{quarter.value}</Text>
+                        <Text
+                          sx={
+                            quarter.value === notAnsweredText
+                              ? sx.error
+                              : sx.subtext
+                          }
+                        >
+                          {quarter.value}
+                        </Text>
                       </Flex>
                     </GridItem>
                   );
@@ -116,6 +133,10 @@ const sx = {
   subtext: {
     marginTop: "0.25rem",
     fontSize: "sm",
+  },
+  error: {
+    fontSize: "sm",
+    color: "palette.error_dark",
   },
   gridItems: {
     alignItems: "end",

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -13,8 +13,7 @@ import completedIcon from "assets/icons/icon_check_circle.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import editIcon from "assets/icons/icon_edit.png";
 import unfinishedIcon from "assets/icons/icon_error_circle.png";
-import { notAnsweredText } from "../../constants";
-import { calculateNextQuarter } from "utils";
+import { fillEmptyQuarters } from "utils";
 
 export const EntityStepCard = ({
   entity,
@@ -41,26 +40,20 @@ export const EntityStepCard = ({
       entityCompleted = formattedEntityData?.objectiveName;
       if (entityCompleted && formattedEntityData?.includesTargets === "Yes") {
         entityCompleted = formattedEntityData?.quarters.length === 12;
-        const quarters = formattedEntityData?.quarters;
-        for (var i: number = quarters.length; i < 12; i++) {
-          quarters.push({
-            id: calculateNextQuarter(quarters[i - 1].id),
-            value: notAnsweredText,
-          });
-        }
+        if (formattedEntityData?.quarters)
+          formattedEntityData.quarters = fillEmptyQuarters(
+            formattedEntityData?.quarters
+          );
       }
       break;
     case OverlayModalStepTypes.FUNDING_SOURCES:
       entityCompleted =
         formattedEntityData?.fundingSource &&
         formattedEntityData?.quarters.length === 12;
-      const quarters = formattedEntityData?.quarters;
-      for (var i: number = quarters.length; i < 12; i++) {
-        quarters.push({
-          id: calculateNextQuarter(quarters[i - 1].id),
-          value: notAnsweredText,
-        });
-      }
+      if (formattedEntityData?.quarters)
+        formattedEntityData.quarters = fillEmptyQuarters(
+          formattedEntityData?.quarters
+        );
       break;
     default:
       break;

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -245,6 +245,7 @@ const sx = {
     color: "palette.error_dark",
   },
   editButton: {
+    marginY: "1rem",
     fontWeight: "normal",
     borderColor: "palette.gray_light",
   },

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -131,6 +131,7 @@ export const OverlayModalPage = ({
                 entityIndex={entityIndex}
                 stepType={stepType}
                 verbiage={verbiage}
+                printVersion={false}
                 formattedEntityData={getFormattedEntityData(stepType, entity)}
                 openAddEditEntityModal={openAddEditEntityModal}
                 openDeleteEntityModal={openDeleteEntityModal}

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -9,6 +9,7 @@ export const dropdownDefaultOptionText = "- Select an option -";
 
 export const closeText = "Close";
 export const saveAndCloseText = "Save & close";
+export const notAnsweredText = "Not Answered";
 
 // STATES
 export enum States {

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -1,4 +1,9 @@
-import { removeNotApplicablePopulations, resetClearProp } from "./forms";
+import { notAnsweredText } from "../../constants";
+import {
+  fillEmptyQuarters,
+  removeNotApplicablePopulations,
+  resetClearProp,
+} from "./forms";
 // types
 import { FormField } from "types";
 import {
@@ -13,6 +18,7 @@ import {
   mockTargetPopReqButApplicableIsUndefined,
   mockTargetPopReqButNotApplicable,
 } from "utils/testing/setupJest";
+import { AnyObject } from "yup/lib/types";
 
 describe("Test resetClearProp", () => {
   it("should reset clear for choicelist fields and its nested children", async () => {
@@ -64,5 +70,18 @@ describe("Test removeNotApplicablePopulations", () => {
       mockTargetPopButOtherApplicable,
       mockTargetPopByOtherNotDefined,
     ]);
+  });
+});
+
+describe("Test fillEmptyQuarters", () => {
+  it("should has 12 quarters and 2 values as not answered", () => {
+    let mockQuarters = [];
+    for (var i = 0; i < 10; i++) mockQuarters.push({ id: `2021 Q1`, value: i });
+
+    const newQuarters: AnyObject[] = fillEmptyQuarters(mockQuarters);
+    expect(newQuarters).toHaveLength(12);
+    expect(
+      newQuarters.filter((quarter) => quarter.value === notAnsweredText)
+    ).toHaveLength(2);
   });
 });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -22,6 +22,8 @@ import { DateField } from "components/fields/DateField";
 import { DropdownField } from "components/fields/DropdownField";
 import { NumberField } from "components/fields/NumberField";
 import { SectionHeader } from "components/forms/FormLayoutElements";
+import { calculateNextQuarter } from "utils";
+import { notAnsweredText } from "../../constants";
 
 // return created elements from provided fields
 export const formFieldFactory = (
@@ -339,4 +341,15 @@ export const removeNotApplicablePopulations = (
     return isApplicable !== "No";
   });
   return filteredPopulations;
+};
+
+//This function is used to fill out the missing quarters in cards for evaluation plan and funding sources after a copy over
+export const fillEmptyQuarters = (quarters: AnyObject[]) => {
+  for (var i: number = quarters.length; i < 12; i++) {
+    quarters.push({
+      id: calculateNextQuarter(quarters[i - 1].id),
+      value: notAnsweredText,
+    });
+  }
+  return quarters;
 };

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -1,4 +1,5 @@
 import {
+  calculateNextQuarter,
   calculateRemainingSeconds,
   calculateTimeByType,
   checkDateRangeStatus,
@@ -116,5 +117,19 @@ describe("Test calculateTimeLeft", () => {
   it("something else", () => {
     const expirationTime = "2050-11-18T12:53:11-05:00";
     expect(calculateRemainingSeconds(expirationTime)).toBeGreaterThan(0);
+  });
+});
+
+describe("Test calculateNextQuarter", () => {
+  it("returns same year and next period", () => {
+    const previousQuarter = "2027 Q1";
+    expect(calculateNextQuarter(previousQuarter)).toBe("2027 Q2");
+  });
+  it("returns next year and next period", () => {
+    const previousQuarter = "2027 Q2";
+    expect(calculateNextQuarter(previousQuarter)).toBe("2028 Q1");
+  });
+  it("returns empty string when nothing is passed in", () => {
+    expect(calculateNextQuarter("")).toBe("");
   });
 });

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -159,3 +159,18 @@ export const displayLongformPeriod = (
     return ` July 1 to December 31 ${reportYear} reporting period`;
   }
 };
+
+export const calculateNextQuarter = (previousQuarter: string) => {
+  if (previousQuarter) {
+    const formattedQuarter = previousQuarter.split(" ");
+    const year = parseInt(formattedQuarter[0]);
+    const period = parseInt(
+      formattedQuarter[1][formattedQuarter[1].length - 1]
+    );
+
+    const nextPeriod = period === 2 ? 1 : 2;
+    const nextYear = period === 2 ? year + 1 : year;
+    return `${nextYear} Q${nextPeriod}`;
+  }
+  return "";
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When copying over evaluation plan and funding source in the initiatives, there needs to be two need alert messages and changes to the cards. It should display something similar to the screenshot below.

![Screenshot 2023-12-01 at 11 51 36 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/ee800e22-486b-447c-b86c-9640c99931fa)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-2823

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Because this only shows up after you copy over an already filled out WP, please follow the instructions in this PR: https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/247
1) Once you have created a copy over WP, just verified that in that WP, any Evaluation Plan and Funding Source with quarters card look similar to the image above.

Evaluation Plan Alert Message : _Add the quantitative targets for the next 2 quarters by editing the objective._
Funding Source Alert Message: _Add the Projected quarterly expenditures for the next 2 quarters by editing funding source._

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
