### PR TITLE
PDF - Transition Benchmark Table - ( Includes Table Overflow )

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -370,6 +370,10 @@ const sx = {
     },
   },
   overflowStyles: {
+    "table:first-child tfoot th:last-child": {
+      background: "palette.secondary_lightest",
+      color: "black",
+    },
     "table:first-child tbody tr td:last-child": {
       background: "white",
       fontWeight: "normal",

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -194,6 +194,8 @@ const sx = {
       color: "palette.black",
       lineHeight: "normal",
       fontWeight: "bold",
+      width: "100px",
+      minWidth: "100px",
       ".tablet &, .mobile &": {
         border: "none",
       },

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -65,6 +65,24 @@ export const ExportedModalDrawerReportSection = ({
         quarterArray.push(entity[key]);
       }
     }
+
+    if (quarterArray.length === 0) {
+      let seedData = [
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+        "N/A",
+      ];
+      quarterArray.push(...seedData);
+    }
     return quarterArray;
   });
 
@@ -121,18 +139,31 @@ export const ExportedModalDrawerReportSection = ({
     {
       overflow === true ? tableHeadersArray.pop() : null;
     }
+
+    const overflowHeaderRows = tableHeadersArray.filter((arr: any[]) => {
+      return tableHeadersArray.indexOf(arr) <= 6 && arr;
+    });
+
+    const headerArray = overflow ? overflowHeaderRows : tableHeadersArray;
+
     const formatBodyRow = () => {
-      let bodyRows = [];
+      let bodyRows: any[] = [];
+
+      const overflowBodyRows = newQuarterValueArray.filter((arr: any[]) => {
+        return newQuarterValueArray.indexOf(arr) <= 5 && arr;
+      });
+
+      const valueArray = overflow ? overflowBodyRows : newQuarterValueArray;
 
       // get mainQuarterValueArray.length because arrays are all the same length
-      for (let item = 0; item < newQuarterValueArray[0].length; item++) {
+      for (let item = 0; item < valueArray[0].length; item++) {
         let row: string[] = [];
         // sum to be added up for each quarter row
         let sum = 0;
         row.push(quarterLabels[item]);
 
         // Add Not Answer if cell is empty string,
-        newQuarterValueArray.forEach((array: any[]) => {
+        valueArray.forEach((array: any[]) => {
           if (!array[item] && array[item] === "") {
             array[item] = "Not Answered";
           }
@@ -150,14 +181,21 @@ export const ExportedModalDrawerReportSection = ({
         }
         bodyRows.push(row);
       }
+
       return bodyRows;
     };
 
+    const updateFooterRow = overflow
+      ? generateFootRow().filter(
+          (arr: any) => generateFootRow().indexOf(arr) <= 5
+        )
+      : generateFootRow();
+
     const table = {
       caption: "Transition Benchmark Totals Table",
-      headRow: [...tableHeadersArray],
+      headRow: [...headerArray],
       bodyRows: [...formatBodyRow()],
-      footRow: [...generateFootRow()],
+      footRow: [...updateFooterRow],
     };
 
     return table;

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -85,7 +85,12 @@ export const ExportedModalDrawerReportSection = ({
     columnTotal.forEach((item: any) => {
       sum += convertToNum(item);
     });
-    return sum === 0 ? "-" : sum;
+
+    if (columnTotal.includes("N/A" || "Not Answered")) {
+      return `${sum}*`;
+    } else {
+      return sum === 0 ? "-" : sum;
+    }
   };
 
   /* layout of the table body rows  */
@@ -96,8 +101,7 @@ export const ExportedModalDrawerReportSection = ({
 
     // get quarterValueArray.length because arrays are all the same length
     for (let item = 0; item < quarterValueArray[0].length; item++) {
-      let row = [];
-
+      let row: string[] = [];
       // sum to be added up for each quarter row
       let sum = 0;
       row.push(quarterLabels[item]);
@@ -115,9 +119,19 @@ export const ExportedModalDrawerReportSection = ({
       });
 
       row.push(sum.toString());
+
+      // add asteriks to unfinished row totals
+      markUnfinishedRows(row);
       bodyRows.push(row);
     }
     return bodyRows;
+  };
+
+  const markUnfinishedRows = (row: string[]) => {
+    if (row.includes("N/A" || "Not Answered")) {
+      return (row[row.length - 1] = `${row[row.length - 1]}*`);
+    }
+    return;
   };
 
   const tableContent = {

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -1,14 +1,98 @@
 // components
 import { Box, Heading } from "@chakra-ui/react";
+import { Table } from "components";
 // utils
 import { useStore } from "utils";
 import { ModalDrawerReportPageShape } from "types";
+import { AnyObject } from "yup/lib/types";
 
 export const ExportedModalDrawerReportSection = ({
   section: { entityType, verbiage },
 }: Props) => {
   const { report } = useStore() ?? {};
   const entities = report?.fieldData?.[entityType];
+
+  const tableHeaders = entities.map((entity: AnyObject) =>
+    entity.transitionBenchmarks_targetPopulationName_short
+      ? entity.transitionBenchmarks_targetPopulationName_short
+      : entity.transitionBenchmarks_targetPopulationName
+  );
+  const quarterLabels = [
+    "2023 Q3",
+    "2023 Q4",
+    "2024 Q1",
+    "2025 Q4",
+    "2024 Q2",
+    "2024 Q3",
+    "2024 Q4",
+    "2025 Q1",
+    "2025 Q2",
+    "2025 Q3",
+    "2025 Q4",
+    "2026 Q1",
+    "2026 Q2",
+  ];
+
+  // create new arrays with only quarter values to populate the tbody
+  const extractQuarters = entities.map((element: any) => {
+    let arr = [];
+    for (const x in element) {
+      if (x.includes("quarterly")) {
+        arr.push(element[x]);
+      }
+    }
+    return arr;
+  });
+
+  // create array for tfoot section
+  const totalByPopSum = extractQuarters.map((element: any) => {
+    let sum = 0;
+
+    element.forEach((num: any) => {
+      let convertToNum = parseInt(num);
+      if (Number.isInteger(convertToNum)) {
+        sum += convertToNum;
+      }
+    });
+    return sum;
+  });
+
+  // add up bottom row sums
+  const finalPopSum = () => {
+    let sum = 0;
+    for (let i = 0; i < totalByPopSum.length; i++) {
+      let convertToNum = parseInt(totalByPopSum[i]);
+      if (Number.isInteger(convertToNum)) {
+        sum += convertToNum;
+      }
+    }
+    return sum;
+  };
+
+  const createBodyRows = () => {
+    let bodyRows = [];
+
+    for (let i = 0; i < extractQuarters[0].length; i++) {
+      let arr = [];
+      arr.push(quarterLabels[i]);
+      extractQuarters.forEach((array: any) => {
+        if (array[i] === "") {
+          array[i] = "Not Answered";
+        }
+        arr.push(array[i]);
+      });
+      arr.push("sum");
+      bodyRows.push(arr);
+    }
+    return bodyRows;
+  };
+
+  const tableContent = {
+    caption: "Transition Benchmark Totals Table",
+    headRow: ["Pop. by Quarter", ...tableHeaders, "Total by Quarter"],
+    bodyRows: [...createBodyRows()],
+    footRow: ["Total by Pop.", ...totalByPopSum, finalPopSum()],
+  };
 
   return (
     <Box
@@ -19,10 +103,9 @@ export const ExportedModalDrawerReportSection = ({
       <Heading as="h2" sx={sx.dashboardTitle} data-testid="headerCount">
         {verbiage.pdfDashboardTitle}
       </Heading>
-      <Box sx={sx.border}>
-        THIS IS WHERE THE TRANSITION BENCHMARK TOTALS WILL GO
-        <br />
-        {JSON.stringify(entities)}
+      <small>{"*astrisk denotes sum of incomplete fields"}</small>
+      <Box>
+        <Table sx={sx.table} content={tableContent}></Table>
       </Box>
     </Box>
   );
@@ -46,13 +129,61 @@ const sx = {
     marginTop: "0.5rem",
   },
   dashboardTitle: {
-    marginBottom: "1.25rem",
     fontSize: "md",
     fontWeight: "bold",
-    color: "palette.gray_medium",
+    color: "palette.gray_darkest",
   },
   // TODO: delete this
+  table: {
+    marginTop: "1.25rem",
+    borderLeft: "1px solid",
+    tableLayout: "fixed",
+    br: {
+      marginBottom: "0.25rem",
+    },
+    tr: {
+      background: "palette.gray_lightest",
+    },
+    thead: {
+      height: "100px",
+      borderTop: "1px solid",
+    },
+    "td,th": {
+      textAlign: "center",
+      wordWrap: "break-word",
+    },
+    "td:first-child": {
+      background: "palette.gray_lightest",
+      fontWeight: "bold",
+    },
+    th: {
+      borderBottom: "1px solid",
+      borderRight: "1px solid",
+      borderColor: "palette.black",
+      color: "palette.black",
+      lineHeight: "normal",
+      fontWeight: "bold",
+      ".tablet &, .mobile &": {
+        border: "none",
+      },
+    },
+    "tbody tr": {
+      background: "palette.white",
+    },
+    "tbody tr td:last-child, tfoot": {
+      background: "palette.secondary_lightest",
+    },
+    "tbody tr td": {
+      borderRight: "1px solid black",
+      borderBottom: "1px solid black",
+    },
+    "tfoot th:last-child": {
+      background: "palette.gray_medium",
+      color: "palette.white",
+    },
+  },
   border: {
-    border: "10px solid black",
+    border: "1px solid black",
+    marginTop: "1.25rem",
   },
 };

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -22,33 +22,16 @@ export const ExportedModalDrawerReportSection = ({
   const getTableHeaders = () => {
     let headers = [];
     const quarterHeader = "Pop. by Quarter";
-    const bodyHeader = entities.map((entity: AnyObject) =>
-      entity.transitionBenchmarks_targetPopulationName_short
-        ? entity.transitionBenchmarks_targetPopulationName_short
-        : truncateHeader(entity.transitionBenchmarks_targetPopulationName)
+    const bodyHeader = entities.map(
+      (entity: AnyObject) =>
+        entity.transitionBenchmarks_targetPopulationName_short ??
+        truncateHeader(entity.transitionBenchmarks_targetPopulationName)
     );
     const totalHeader = "Total by Quarter";
 
     headers.push(quarterHeader, ...bodyHeader, totalHeader);
     return headers;
   };
-
-  // list of quarters to be added to the table (left column)
-  const quarterLabels = [
-    "2023 Q3",
-    "2023 Q4",
-    "2024 Q1",
-    "2024 Q2",
-    "2024 Q3",
-    "2024 Q4",
-    "2025 Q1",
-    "2025 Q2",
-    "2025 Q3",
-    "2025 Q4",
-    "2026 Q1",
-    "2026 Q2",
-    "2026 Q3",
-  ];
 
   // utility to convert array strings to num for calculating totals
   const convertToNum = (item: any) => {
@@ -86,13 +69,31 @@ export const ExportedModalDrawerReportSection = ({
     return quarterArray;
   });
 
+  // list of quarters to be added to the table (left column)
+  const extractQuarterLabels = () => {
+    const newEntities = new Array(...entities);
+    let quarterLabelArray: any = [];
+    newEntities.map((entity: AnyObject) => {
+      for (const key in entity) {
+        // push key values into quarterArray that are quarters
+
+        if (key.includes("quarterly")) {
+          const id = key.replace("quarterlyProjections", "").split("Q");
+          quarterLabelArray.push(`${id[0]} Q${id[1]}`);
+        }
+      }
+    });
+    return quarterLabelArray;
+  };
+  const quarterLabels = [...extractQuarterLabels()];
+
   const generateFootRow = () => {
     // creates an array that totals up each each quarter column
     const columnTotal = quarterValueArray.map((column: string[]) => {
       let sum = 0;
       let isNACol = [];
       column.forEach((item: any) => {
-        if (item === "N/A") {
+        if (item === "N/A" || item === "Data not available") {
           isNACol.push(item);
         } else {
           sum += convertToNum(item)!;
@@ -365,7 +366,7 @@ const sx = {
       borderBottom: "1px solid black",
     },
     "tfoot th:last-child": {
-      background: "palette.gray_medium",
+      background: "palette.gray_dark",
       color: "palette.white",
     },
   },

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -76,15 +76,9 @@ export const ExportedModalDrawerReportSection = ({
     return sum;
   };
 
-  {
-    /* layout of the table body rows  */
-  }
-  {
-    /* sums up body rows */
-  }
-  {
-    /* updates empty cells to "Not Answered"  */
-  }
+  /* layout of the table body rows  */
+  /* sums up body rows */
+  /* updates empty cells to "Not Answered"  */
   const createBodyRows = () => {
     let bodyRows = [];
 

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -366,7 +366,7 @@ const sx = {
       borderBottom: "1px solid black",
     },
     "tfoot th:last-child": {
-      background: "palette.gray_dark",
+      background: "palette.gray_medium",
       color: "palette.white",
     },
   },

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -3,7 +3,7 @@ import { Box, Heading } from "@chakra-ui/react";
 import { Table } from "components";
 // utils
 import { useEffect, useState } from "react";
-import { useStore } from "utils";
+import { useStore, convertToThousandsSeparatedString } from "utils";
 import { ModalDrawerReportPageShape, AnyObject } from "types";
 import _ from "lodash";
 
@@ -114,19 +114,17 @@ export const ExportedModalDrawerReportSection = ({
       columnTotal.forEach((item: any) => {
         sum += convertToNum(item);
       });
-
       if (
         columnTotal.includes("N/A") ||
         columnTotal.includes("Not Answered") ||
         columnTotal.includes("-") ||
         columnTotal.includes("Data not available")
       ) {
-        return `${sum}*`;
+        return `${commaMasking(sum.toString())}*`;
       } else {
-        return sum === 0 ? "-" : sum;
+        return sum === 0 ? "-" : commaMasking(sum.toString());
       }
     };
-
     return ["Total by Pop.", ...columnTotal, footRowTotal()];
   };
 
@@ -142,6 +140,10 @@ export const ExportedModalDrawerReportSection = ({
       return (row[row.length - 1] = `${row[row.length - 1]}*`);
     }
     return;
+  };
+
+  const commaMasking = (item: string) => {
+    return convertToThousandsSeparatedString(item).maskedValue;
   };
 
   const generateMainTable = () => {
@@ -181,12 +183,12 @@ export const ExportedModalDrawerReportSection = ({
           }
 
           sum += convertToNum(array[item]);
-          row.push(array[item].toString());
+          row.push(commaMasking(array[item]));
           return sum;
         });
 
         {
-          overflow === false ? row.push(sum.toString()) : null;
+          overflow === false ? row.push(commaMasking(sum.toString())) : null;
         }
         {
           overflow === false ? markUnfinishedRows(row) : null;
@@ -199,7 +201,7 @@ export const ExportedModalDrawerReportSection = ({
 
     const updateFooterRow = overflow
       ? generateFootRow().filter(
-          (arr: any) => generateFootRow().indexOf(arr) <= 5
+          (arr: any) => generateFootRow().indexOf(arr) <= 6
         )
       : generateFootRow();
 
@@ -236,14 +238,14 @@ export const ExportedModalDrawerReportSection = ({
           if (!array[item] && array[item] === "") {
             array[item] = "Not Answered";
           }
-          row.push(array[item].toString());
+          row.push(commaMasking(array[item]));
         });
 
         quarterValueArray.forEach((array: any[]) => {
           sum += convertToNum(array[item]);
         });
 
-        row.push(sum.toString());
+        row.push(commaMasking(sum.toString()));
         // add asteriks to unfinished row totals
         markUnfinishedRows(row);
         bodyRows.push(row);

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -49,12 +49,18 @@ export const ExportedModalDrawerReportSection = ({
   // creates arrays of 'only' quarterly values
   const quarterValueArray = entities.map((entity: AnyObject) => {
     let quarterArray = [];
-    for (const key in entity) {
-      // push key values into quarterArray that are quarters
-      if (key.includes("quarterly")) {
-        quarterArray.push(entity[key]);
+    let overflowArray = [];
+    if (entities.indexOf(entity) <= 6) {
+      for (const key in entity) {
+        // push key values into quarterArray that are quarters
+        if (key.includes("quarterly")) {
+          quarterArray.push(entity[key]);
+        }
       }
+    } else {
+      overflowArray.push(entity);
     }
+
     return quarterArray;
   });
 
@@ -68,7 +74,7 @@ export const ExportedModalDrawerReportSection = ({
   });
 
   // adds up the footer row for the grey box total on bottom right of table
-  const footerRowTotal = () => {
+  const footRowTotal = () => {
     let sum = 0;
     columnTotal.forEach((item: any) => {
       sum += convertToNum(item);
@@ -85,12 +91,13 @@ export const ExportedModalDrawerReportSection = ({
     // get quarterValueArray.length because arrays are all the same length
     for (let item = 0; item < quarterValueArray[0].length; item++) {
       let row = [];
+
       // sum to be added up for each quarter row
       let sum = 0;
       row.push(quarterLabels[item]);
 
       // Add Not Answer if cell is empty string,
-      quarterValueArray.forEach((array: any) => {
+      quarterValueArray.forEach((array: any[]) => {
         if (array[item] === "") {
           array[item] = "Not Answered";
         }
@@ -114,7 +121,7 @@ export const ExportedModalDrawerReportSection = ({
     caption: "Transition Benchmark Totals Table",
     headRow: ["Pop. by Quarter", ...getTableHeaders, "Total by Quarter"],
     bodyRows: [...createBodyRows()],
-    footRow: ["Total by Pop.", ...columnTotal, footerRowTotal()],
+    footRow: ["Total by Pop.", ...columnTotal, footRowTotal()],
   };
 
   return (
@@ -126,9 +133,10 @@ export const ExportedModalDrawerReportSection = ({
       <Heading as="h2" sx={sx.dashboardTitle} data-testid="headerCount">
         {verbiage.pdfDashboardTitle}
       </Heading>
-      <small>{"*astrisk denotes sum of incomplete fields"}</small>
+      <small>{"*asterisk denotes sum of incomplete fields"}</small>
       <Box>
         <Table sx={sx.table} content={tableContent}></Table>
+        {}
       </Box>
     </Box>
   );

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -125,7 +125,11 @@ export const ExportedModalDrawerReportSection = ({
         return sum === 0 ? "-" : commaMasking(sum.toString());
       }
     };
-    return ["Total by Pop.", ...columnTotal, footRowTotal()];
+
+    const commaMaskColumTotal = columnTotal.map((item: string) =>
+      commaMasking(item)
+    );
+    return ["Total by Pop.", ...commaMaskColumTotal, footRowTotal()];
   };
 
   const markUnfinishedRows = (row: string[]) => {

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -91,7 +91,7 @@ export const ExportedModalDrawerReportSection = ({
     // creates an array that totals up each each quarter column
     const columnTotal = quarterValueArray.map((column: string[]) => {
       let sum = 0;
-      let isNACol = [];
+      let isNACol: any = [];
       column.forEach((item: any) => {
         if (item === "N/A" || item === "Data not available") {
           isNACol.push(item);
@@ -99,7 +99,6 @@ export const ExportedModalDrawerReportSection = ({
           sum += convertToNum(item)!;
         }
       });
-
       if (sum === 0 && isNACol.length !== 12) {
         return "-";
       } else if (isNACol.length === 12) {
@@ -116,7 +115,12 @@ export const ExportedModalDrawerReportSection = ({
         sum += convertToNum(item);
       });
 
-      if (columnTotal.includes("N/A" || "Not Answered")) {
+      if (
+        columnTotal.includes("N/A") ||
+        columnTotal.includes("Not Answered") ||
+        columnTotal.includes("-") ||
+        columnTotal.includes("Data not available")
+      ) {
         return `${sum}*`;
       } else {
         return sum === 0 ? "-" : sum;
@@ -127,7 +131,14 @@ export const ExportedModalDrawerReportSection = ({
   };
 
   const markUnfinishedRows = (row: string[]) => {
-    if (row.includes("N/A") || row.includes("Not Answered")) {
+    if (
+      row.includes("N/A") ||
+      row.includes(
+        "Not Answered" ||
+          row.includes("-") ||
+          row.includes("Data not available")
+      )
+    ) {
       return (row[row.length - 1] = `${row[row.length - 1]}*`);
     }
     return;

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -2,6 +2,7 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { Table } from "components";
 // utils
+import { useEffect, useState } from "react";
 import { useStore } from "utils";
 import { ModalDrawerReportPageShape, AnyObject } from "types";
 import _ from "lodash";
@@ -9,6 +10,7 @@ import _ from "lodash";
 export const ExportedModalDrawerReportSection = ({
   section: { entityType, verbiage },
 }: Props) => {
+  const [overflow, setOverflow] = useState(false);
   const { report } = useStore() ?? {};
   const entities = report?.fieldData?.[entityType];
 
@@ -17,18 +19,25 @@ export const ExportedModalDrawerReportSection = ({
   };
 
   // if Transition Benchmark Header title has an abbrev.just display that
-  const getTableHeaders = entities.map((entity: AnyObject) =>
-    entity.transitionBenchmarks_targetPopulationName_short
-      ? entity.transitionBenchmarks_targetPopulationName_short
-      : truncateHeader(entity.transitionBenchmarks_targetPopulationName)
-  );
+  const getTableHeaders = () => {
+    let headers = [];
+    const quarterHeader = "Pop. by Quarter";
+    const bodyHeader = entities.map((entity: AnyObject) =>
+      entity.transitionBenchmarks_targetPopulationName_short
+        ? entity.transitionBenchmarks_targetPopulationName_short
+        : truncateHeader(entity.transitionBenchmarks_targetPopulationName)
+    );
+    const totalHeader = "Total by Quarter";
+
+    headers.push(quarterHeader, ...bodyHeader, totalHeader);
+    return headers;
+  };
 
   // list of quarters to be added to the table (left column)
   const quarterLabels = [
     "2023 Q3",
     "2023 Q4",
     "2024 Q1",
-    "2025 Q4",
     "2024 Q2",
     "2024 Q3",
     "2024 Q4",
@@ -38,6 +47,7 @@ export const ExportedModalDrawerReportSection = ({
     "2025 Q4",
     "2026 Q1",
     "2026 Q2",
+    "2026 Q3",
   ];
 
   // utility to convert array strings to num for calculating totals
@@ -58,88 +68,173 @@ export const ExportedModalDrawerReportSection = ({
     return quarterArray;
   });
 
-  // creates an array that totals up each each quarter column
-  const columnTotal = quarterValueArray.map((column: string[]) => {
-    let sum = 0;
-    let isNACol = [];
-    column.forEach((item: any) => {
-      if (item === "N/A") {
-        isNACol.push(item);
+  const generateFootRow = () => {
+    // creates an array that totals up each each quarter column
+    const columnTotal = quarterValueArray.map((column: string[]) => {
+      let sum = 0;
+      let isNACol = [];
+      column.forEach((item: any) => {
+        if (item === "N/A") {
+          isNACol.push(item);
+        } else {
+          sum += convertToNum(item)!;
+        }
+      });
+
+      if (sum === 0 && isNACol.length !== 12) {
+        return "-";
+      } else if (isNACol.length === 12) {
+        return "N/A";
       } else {
-        sum += convertToNum(item)!;
+        return sum.toString();
       }
     });
 
-    if (sum === 0 && isNACol.length !== 12) {
-      return "-";
-    } else if (isNACol.length === 12) {
-      return "N/A";
-    } else {
-      return sum;
-    }
-  });
-
-  // adds up the footer row for the grey box total on bottom right of table
-  const footRowTotal = () => {
-    let sum = 0;
-    columnTotal.forEach((item: any) => {
-      sum += convertToNum(item);
-    });
-
-    if (columnTotal.includes("N/A" || "Not Answered")) {
-      return `${sum}*`;
-    } else {
-      return sum === 0 ? "-" : sum;
-    }
-  };
-
-  /* layout of the table body rows  */
-  /* sums up body rows */
-  /* updates empty cells to "Not Answered"  */
-  const createBodyRows = () => {
-    let bodyRows = [];
-
-    // get quarterValueArray.length because arrays are all the same length
-    for (let item = 0; item < quarterValueArray[0].length; item++) {
-      let row: string[] = [];
-      // sum to be added up for each quarter row
+    // adds up the footer row for the grey box total on bottom right of table
+    const footRowTotal = () => {
       let sum = 0;
-      row.push(quarterLabels[item]);
-
-      // Add Not Answer if cell is empty string,
-      quarterValueArray.forEach((array: any[]) => {
-        if (array[item] === "") {
-          array[item] = "Not Answered";
-        }
-
-        sum += convertToNum(array[item]);
-
-        row.push(array[item].toString());
-        return sum;
+      columnTotal.forEach((item: any) => {
+        sum += convertToNum(item);
       });
 
-      row.push(sum.toString());
+      if (columnTotal.includes("N/A" || "Not Answered")) {
+        return `${sum}*`;
+      } else {
+        return sum === 0 ? "-" : sum;
+      }
+    };
 
-      // add asteriks to unfinished row totals
-      markUnfinishedRows(row);
-      bodyRows.push(row);
-    }
-    return bodyRows;
+    return ["Total by Pop.", ...columnTotal, footRowTotal()];
   };
 
   const markUnfinishedRows = (row: string[]) => {
-    if (row.includes("N/A" || "Not Answered")) {
+    if (row.includes("N/A") || row.includes("Not Answered")) {
       return (row[row.length - 1] = `${row[row.length - 1]}*`);
     }
     return;
   };
 
-  const tableContent = {
-    caption: "Transition Benchmark Totals Table",
-    headRow: ["Pop. by Quarter", ...getTableHeaders, "Total by Quarter"],
-    bodyRows: [...createBodyRows()],
-    footRow: ["Total by Pop.", ...columnTotal, footRowTotal()],
+  const generateMainTable = () => {
+    // create new quarter value array
+    let newQuarterValueArray = new Array(...quarterValueArray);
+    let tableHeadersArray = new Array(...getTableHeaders());
+    {
+      overflow === true ? tableHeadersArray.pop() : null;
+    }
+    const formatBodyRow = () => {
+      let bodyRows = [];
+
+      // get mainQuarterValueArray.length because arrays are all the same length
+      for (let item = 0; item < newQuarterValueArray[0].length; item++) {
+        let row: string[] = [];
+        // sum to be added up for each quarter row
+        let sum = 0;
+        row.push(quarterLabels[item]);
+
+        // Add Not Answer if cell is empty string,
+        newQuarterValueArray.forEach((array: any[]) => {
+          if (!array[item] && array[item] === "") {
+            array[item] = "Not Answered";
+          }
+
+          sum += convertToNum(array[item]);
+          row.push(array[item].toString());
+          return sum;
+        });
+
+        {
+          overflow === false ? row.push(sum.toString()) : null;
+        }
+        {
+          overflow === false ? markUnfinishedRows(row) : null;
+        }
+        bodyRows.push(row);
+      }
+      return bodyRows;
+    };
+
+    const table = {
+      caption: "Transition Benchmark Totals Table",
+      headRow: [...tableHeadersArray],
+      bodyRows: [...formatBodyRow()],
+      footRow: [...generateFootRow()],
+    };
+
+    return table;
   };
+
+  const generateOverflowTable = () => {
+    // create new quarter value array
+    let newQuarterValueArray = new Array(...quarterValueArray);
+
+    let overflowQuarterValueArray = newQuarterValueArray.filter(
+      (arr: string[]) => newQuarterValueArray.indexOf(arr) > 5
+    );
+    let tableHeadersArray = new Array(...getTableHeaders());
+
+    const formatBodyRow = () => {
+      let bodyRows = [];
+
+      // get quarterValueArray.length because arrays are all the same length
+      for (let item = 0; item < overflowQuarterValueArray[0].length; item++) {
+        let row: string[] = [];
+        // sum to be added up for each quarter row
+        let sum = 0;
+        row.push(quarterLabels[item]);
+        // Add Not Answer if cell is empty string,
+        overflowQuarterValueArray.forEach((array: any[]) => {
+          if (!array[item] && array[item] === "") {
+            array[item] = "Not Answered";
+          }
+          row.push(array[item].toString());
+        });
+
+        quarterValueArray.forEach((array: any[]) => {
+          sum += convertToNum(array[item]);
+        });
+
+        row.push(sum.toString());
+        // add asteriks to unfinished row totals
+        markUnfinishedRows(row);
+        bodyRows.push(row);
+      }
+      return bodyRows;
+    };
+
+    const formatOverflowTableHeaders = () => {
+      let overflowTableHeadersArray: string[] = [];
+      overflowTableHeadersArray.push(tableHeadersArray[0]);
+      tableHeadersArray.find((arr: any) => {
+        if (tableHeadersArray.indexOf(arr) > 6) {
+          overflowTableHeadersArray.push(arr);
+        }
+      });
+      return overflowTableHeadersArray;
+    };
+
+    const formatFootRow = () => {
+      const newFootRowArray = new Array(...generateFootRow());
+      const mainFootRow = newFootRowArray.filter((item, index) => index >= 7);
+      return ["Total by Pop.", ...mainFootRow];
+    };
+
+    const overflowTable = {
+      caption: "Transition Benchmark Totals Table - Continued",
+      headRow: [...formatOverflowTableHeaders()],
+      bodyRows: [...formatBodyRow()],
+      footRow: [...formatFootRow()],
+    };
+
+    return overflowTable;
+  };
+
+  useEffect(() => {
+    if (quarterValueArray && quarterValueArray.length > 6) {
+      setOverflow(true);
+    } else {
+      setOverflow(false);
+    }
+  }, []);
 
   return (
     <Box
@@ -151,9 +246,11 @@ export const ExportedModalDrawerReportSection = ({
         {verbiage.pdfDashboardTitle}
       </Heading>
       <small>{"*asterisk denotes sum of incomplete fields"}</small>
-      <Box>
-        <Table sx={sx.table} content={tableContent}></Table>
-        {}
+      <Box sx={overflow ? sx.overflowStyles : {}}>
+        <Table sx={sx.table} content={generateMainTable()}></Table>
+        {overflow && (
+          <Table sx={sx.table} content={generateOverflowTable()}></Table>
+        )}
       </Box>
     </Box>
   );
@@ -186,6 +283,7 @@ const sx = {
     marginTop: "1.25rem",
     borderLeft: "1px solid",
     tableLayout: "fixed",
+    marginBottom: "2.25rem",
     br: {
       marginBottom: "0.25rem",
     },
@@ -231,6 +329,12 @@ const sx = {
     "tfoot th:last-child": {
       background: "palette.gray_medium",
       color: "palette.white",
+    },
+  },
+  overflowStyles: {
+    "table:first-child tbody tr td:last-child": {
+      background: "white",
+      fontWeight: "normal",
     },
   },
   border: {

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -54,18 +54,21 @@ export const AddEditReportModal = ({
         id: "2Vd02HAezQkxNu2ShmlQONHa",
         transitionBenchmarks_targetPopulationName:
           "Individuals with physical disabilities (PD)",
+        transitionBenchmarks_targetPopulationName_short: "PD",
         isRequired: true,
       },
       {
         id: "2Vd02IvLwE59ebYAjfiU7H66",
         transitionBenchmarks_targetPopulationName:
           "Individuals with intellectual and developmental disabilities (I/DD)",
+        transitionBenchmarks_targetPopulationName_short: "I/DD",
         isRequired: true,
       },
       {
         id: "2Vd02J1FHl3Ka1DbtU5FMSDh",
         transitionBenchmarks_targetPopulationName:
           "Individuals with mental health and substance use disorders (MH/SUD)",
+        transitionBenchmarks_targetPopulationName_short: "MH/SUD",
         isRequired: true,
       },
     ];

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -5,6 +5,7 @@ import {
   TableCaption,
   Tbody,
   Td,
+  Tfoot,
   Th,
   Thead,
   Tr,
@@ -67,6 +68,13 @@ export const Table = ({
             </Tr>
           ))}
       </Tbody>
+      <Tfoot>
+        {content.footRow?.map((headerCell: string, index: number) => (
+          <Th key={index} scope="col" sx={{ ...sx.tableHeader, ...sxOverride }}>
+            {sanitizeAndParseHtml(headerCell)}
+          </Th>
+        ))}
+      </Tfoot>
     </TableRoot>
   );
 };

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -60,7 +60,10 @@ export const Table = ({
               {row.map((cell: string, index: number) => (
                 <Td
                   key={cell + index}
-                  sx={border ? sx.tableCellBorder : sx.tableCell}
+                  sx={{
+                    tableCell: border ? sx.tableCellBorder : sx.tableCell,
+                    color: cell == "Not Answered" ? "palette.error_darker" : "",
+                  }}
                 >
                   {sanitizeAndParseHtml(cell)}
                 </Td>
@@ -126,4 +129,7 @@ const sx = {
     },
   },
   ".two-column &": {}, // TODO: add additional styling for two-column dynamic field tables if needed
+  notAnswered: {
+    color: "palette.error_darker",
+  },
 };

--- a/services/ui-src/src/types/other.ts
+++ b/services/ui-src/src/types/other.ts
@@ -56,6 +56,7 @@ export interface TableContentShape {
   caption?: string;
   headRow?: string[];
   bodyRows?: string[][];
+  footRow?: string[];
 }
 
 export interface CustomHtmlElement {


### PR DESCRIPTION
### Description
This is part one of completing the PDF target population table. 

This includes:
1. Header truncate {Other} target populations
2. Asterisks show on rows that have missing data
3. N/A displays in total column for cols that are all "N/A"
4. Totals for rows and columns
5. Display hyphens on the total row and total colums when a user doesn't have all values filled
6. When there are more than 2 Transition Benchmark Projections a overflow table is generated


<img width="382" alt="Screenshot 2023-12-06 at 2 18 54 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/c2182dae-6b94-4d6a-a7f5-443f0b642fcd">


Overflow
<img width="410" alt="Screenshot 2023-12-06 at 2 17 44 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/19ed8049-5441-44bd-bcf4-f943a2e4f890">




Work in progress:
7. Giving the overflow table cells a max width



### Related ticket(s)
CMDCT-](https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=5874&projectKey=CMDCT&view=detail&selectedIssue=CMDCT-3061)

---
### How to test
1. Fill out and Submit a WP 
4. Click the "Review and Submit" tab and go to "Review PDF"


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
