### PR TITLE
Make the print button work on transition benchmark page

### DIFF
--- a/services/ui-src/src/components/export/PrintButton.test.tsx
+++ b/services/ui-src/src/components/export/PrintButton.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+// components
+import { PrintButton } from "./PrintButton";
+// types
+import { ReportStatus } from "types";
+// utils
+import { useStore } from "utils";
+import { mockUseStore, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockWPApprovedFullReport,
+  mockWPFullReport,
+} from "utils/testing/mockReport";
+
+jest.mock("utils/state/useStore");
+
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+
+const wpSubmittedContext = {
+  report: {
+    ...mockWPFullReport,
+    status: ReportStatus.SUBMITTED,
+  },
+};
+
+const mockSubmittedReportStore = {
+  ...mockUseStore,
+  ...wpSubmittedContext,
+};
+
+const mockApprovedReportStore = {
+  ...mockUseStore,
+  report: {
+    ...mockWPApprovedFullReport,
+  },
+};
+
+const PrintButtonComponent = () => {
+  return (
+    <RouterWrappedComponent>
+      <PrintButton />
+    </RouterWrappedComponent>
+  );
+};
+
+describe("PrintButton", () => {
+  test("check text when not submitted", () => {
+    mockedUseStore.mockReturnValue(mockUseStore);
+    render(PrintButtonComponent());
+    expect(screen.getByText("Review PDF")).toBeVisible();
+  });
+
+  test("check text when submitted", () => {
+    mockedUseStore.mockReturnValue(mockSubmittedReportStore);
+    render(PrintButtonComponent());
+    expect(screen.getByText("Download PDF")).toBeVisible();
+  });
+
+  test("check text when approved", () => {
+    mockedUseStore.mockReturnValue(mockApprovedReportStore);
+    render(PrintButtonComponent());
+    expect(screen.getByText("Download PDF")).toBeVisible();
+  });
+});
+
+describe("Test PrintButton accessibility", () => {
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockUseStore);
+  });
+
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(PrintButtonComponent());
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/export/PrintButton.tsx
+++ b/services/ui-src/src/components/export/PrintButton.tsx
@@ -1,0 +1,63 @@
+import { Link as RouterLink } from "react-router-dom";
+// components
+import { Button, Image } from "@chakra-ui/react";
+// assets
+import iconSearch from "assets/icons/icon_search_blue.png";
+import iconPDF from "assets/icons/icon_pdf_white.png";
+// types
+import { AnyObject } from "types";
+// utils
+import { useStore } from "utils";
+
+export const PrintButton = ({ sxOverride }: Props) => {
+  const report = useStore().report;
+  const reportType = report?.reportType === "WP" ? "wp" : "sar";
+
+  const isNonEditable =
+    report?.status === "Submitted" || report?.status === "Approved";
+  const styling = !isNonEditable ? sx.printButton : sx.downloadButton;
+  return (
+    <Button
+      as={RouterLink}
+      to={`/${reportType}/export`}
+      target="_blank"
+      sx={{ ...styling, ...sxOverride }}
+      leftIcon={
+        !isNonEditable ? (
+          <Image src={iconSearch} alt="Search Icon" height="1rem" />
+        ) : (
+          <Image src={iconPDF} alt="PDF Icon" height="1rem" />
+        )
+      }
+      variant={!isNonEditable ? "outline" : "primary"}
+    >
+      {!isNonEditable ? "Review PDF" : "Download PDF"}
+    </Button>
+  );
+};
+
+export interface Props {
+  sxOverride?: AnyObject;
+}
+
+const sx = {
+  printButton: {
+    minWidth: "6rem",
+    height: "2.375rem",
+    fontSize: "md",
+    fontWeight: "700",
+    border: "1px solid",
+  },
+  downloadButton: {
+    minWidth: "6rem",
+    height: "2.375rem",
+    fontSize: "md",
+    fontWeight: "700",
+    color: "white !important",
+    textDecoration: "none !important",
+    "&:hover, &:focus": {
+      backgroundColor: "palette.primary",
+      color: "white",
+    },
+  },
+};

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -39,6 +39,7 @@ export { ExportedEntityDetailsOverlaySection } from "./export/ExportedEntityDeta
 export { ExportedEntityDetailsTable } from "./export/ExportedEntityDetailsTable";
 export { ExportedEntityDetailsTableRow } from "./export/ExportedEntityDetailsTableRow";
 export { ExportedModalOverlayReportSection } from "./export/ExportedModalOverlayReportSection";
+export { PrintButton } from "./export/PrintButton";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -1,5 +1,4 @@
 import { MouseEventHandler, useContext, useEffect, useState } from "react";
-import { Link as RouterLink } from "react-router-dom";
 import { AdminReview } from "./AdminReview";
 // components
 import {
@@ -11,7 +10,13 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Alert, Modal, ReportContext, StatusTable } from "components";
+import {
+  Alert,
+  Modal,
+  PrintButton,
+  ReportContext,
+  StatusTable,
+} from "components";
 // types
 import { AlertTypes, AnyObject, ReportStatus } from "types";
 // utils
@@ -20,8 +25,6 @@ import { parseCustomHtml, useStore, utcDateToReadableDate } from "utils";
 import verbiage from "verbiage/pages/mfp/mfp-review-and-submit";
 // assets
 import checkIcon from "assets/icons/icon_check_circle.png";
-import iconSearchDefault from "assets/icons/icon_search_blue.png";
-import iconSearchSubmitted from "assets/icons/icon_search_white.png";
 
 export const ReviewSubmitPage = () => {
   const { fetchReport, submitReport } = useContext(ReportContext);
@@ -126,32 +129,6 @@ export const ReviewSubmitPage = () => {
   );
 };
 
-const PrintButton = ({ reviewVerbiage }: { reviewVerbiage: AnyObject }) => {
-  const { print } = reviewVerbiage;
-  const report = useStore().report;
-  const reportType = report?.reportType === "WP" ? "wp" : "sar";
-
-  const isSubmitted = report?.status === "Submitted";
-  return (
-    <Button
-      as={RouterLink}
-      to={`/${reportType}/export`}
-      target="_blank"
-      sx={!isSubmitted ? sx.printButton : sx.downloadButton}
-      leftIcon={
-        !isSubmitted ? (
-          <Image src={iconSearchDefault} alt="Search Icon" height=".9rem" />
-        ) : (
-          <Image src={iconSearchSubmitted} alt="Search Icon" height=".9rem" />
-        )
-      }
-      variant={!isSubmitted ? "outline" : "primary"}
-    >
-      {print.printButtonText}
-    </Button>
-  );
-};
-
 const ReadyToSubmit = ({
   submitForm,
   isOpen,
@@ -164,7 +141,6 @@ const ReadyToSubmit = ({
   const { userIsAdmin } = useStore().user ?? {};
   const { review } = reviewVerbiage;
   const { intro, modal, pageLink } = review;
-  const pdfExport = true;
 
   return (
     <Flex sx={sx.contentContainer} data-testid="ready-view">
@@ -182,7 +158,7 @@ const ReadyToSubmit = ({
         </Box>
       </Box>
       <Flex sx={sx.submitContainer}>
-        {pdfExport && <PrintButton reviewVerbiage={reviewVerbiage} />}
+        <PrintButton />
         {!userIsAdmin && (
           <Button
             type="submit"
@@ -276,7 +252,7 @@ export const SuccessMessage = ({
       </Box>
 
       <Box sx={sx.infoTextBox}>
-        <PrintButton reviewVerbiage={reviewVerbiage} />
+        <PrintButton />
       </Box>
     </Flex>
   );
@@ -336,25 +312,6 @@ const sx = {
   },
   additionalInfo: {
     color: "palette.gray",
-  },
-  printButton: {
-    minWidth: "6rem",
-    height: "2rem",
-    fontSize: "md",
-    fontWeight: "700",
-    border: "1px solid",
-  },
-  downloadButton: {
-    minWidth: "6rem",
-    height: "2rem",
-    fontSize: "md",
-    fontWeight: "700",
-    color: "white !important",
-    textDecoration: "none !important",
-    "&:hover, &:focus": {
-      backgroundColor: "palette.primary",
-      color: "white",
-    },
   },
   submitContainer: {
     width: "100%",

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -12,6 +12,7 @@ import {
   AddEditEntityModal,
   DeleteEntityModal,
   EntityRow,
+  PrintButton,
   ReportContext,
   ReportDrawer,
   ReportPageFooter,
@@ -20,7 +21,6 @@ import {
 } from "components";
 // assets
 import addIcon from "assets/icons/icon_add.png";
-import searchIcon from "assets/icons/icon_search_blue.png";
 // types
 import {
   AnyObject,
@@ -212,15 +212,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           <Text sx={sx.reviewPdfHint}>
             {parseCustomHtml(verbiage.reviewPdfHint)}
           </Text>
-          <Button
-            sx={sx.reviewPdfButton}
-            variant="outline"
-            leftIcon={
-              <Image sx={sx.buttonIcons} src={searchIcon} alt="Review" />
-            }
-          >
-            Review PDF
-          </Button>
+          <PrintButton sxOverride={sx.reviewPdfButton} />
         </Box>
         {/* MODALS */}
         <AddEditEntityModal


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Made the PrintButton more reusable and added tests
Fixed PrintButton styling to match Figma

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3102

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Navigate to Transition Benchmarks and verify the "Review PDF" button opens a new tab with the export page
- Navigate to Review and Submit and verify the same
- In `PrintButton.tsx` set `isNonEditable` to true on line 16
- Verify on both pages that it now shows "Download PDF" with a different icon and styling (check against [Figma](https://www.figma.com/file/oOJMUZerbafZefLQQ33GwI/MFP_Playground?type=design&node-id=0-1&mode=design&t=Xj0CT1IGrqDUI8I2-0))

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---