### PR TITLE
Disallow negative numbers; cleanup unused schemas

### DIFF
--- a/services/app-api/utils/validation/completionSchemaMap.ts
+++ b/services/app-api/utils/validation/completionSchemaMap.ts
@@ -5,8 +5,6 @@ export const completionSchemaMap: any = {
   textOptional: schema.textOptional(),
   number: schema.number(),
   numberOptional: schema.numberOptional(),
-  numberNotLessThanOne: schema.numberNotLessThanOne(),
-  numberNotLessThanZero: schema.numberNotLessThanZero(),
   ratio: schema.ratio(),
   email: schema.email(),
   emailOptional: schema.emailOptional(),
@@ -22,6 +20,4 @@ export const completionSchemaMap: any = {
   radioOptional: schema.radioOptional(),
   dynamic: schema.dynamic(),
   dynamicOptional: schema.dynamicOptional(),
-  validNumber: schema.validNumber(),
-  validNumberOptional: schema.validNumberOptional(),
 };

--- a/services/app-api/utils/validation/completionSchemas.test.ts
+++ b/services/app-api/utils/validation/completionSchemas.test.ts
@@ -1,11 +1,5 @@
 import { MixedSchema } from "yup/lib/mixed";
-import {
-  number,
-  ratio,
-  validNumber,
-  numberNotLessThanOne,
-  numberNotLessThanZero,
-} from "./completionSchemas";
+import { number, ratio } from "./completionSchemas";
 
 describe("Schemas", () => {
   const goodNumberTestCases = [
@@ -19,29 +13,7 @@ describe("Schemas", () => {
     "N/A",
     "Data not available",
   ];
-  const badNumberTestCases = ["abc", "N", "", "!@#!@%"];
-
-  const zeroTest = ["0", "0.0"];
-
-  const goodPositiveNumberTestCases = [
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-  ];
-
-  const negativeNumberTestCases = [
-    "-123",
-    "-123.00",
-    "-123..00",
-    "-1,230",
-    "-1,2,30",
-    "-1230",
-    "-123450123..,,,.123123123123",
-  ];
+  const badNumberTestCases = ["abc", "N", "", "!@#!@%", "-1"];
 
   const goodRatioTestCases = [
     "1:1",
@@ -65,24 +37,9 @@ describe("Schemas", () => {
     "%@#$!ASDF",
   ];
 
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
-    expectedReturn: boolean
-  ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
-  };
-
-  const testValidNumber = (
-    schemaToUse: MixedSchema,
-    testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
     for (let testCase of testCases) {
@@ -96,45 +53,8 @@ describe("Schemas", () => {
     testNumberSchema(number(), badNumberTestCases, false);
   });
 
-  // testing numberNotLessThanOne scheme
-  test("Evaluate Number Schema using numberNotLessThanOne scheme", () => {
-    testNumberSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
-    testNumberSchema(numberNotLessThanOne(), badNumberTestCases, false);
-  });
-
-  test("Test zero values using numberNotLessThanOne scheme", () => {
-    testNumberSchema(numberNotLessThanOne(), zeroTest, false);
-  });
-
-  test("Test negative values using numberNotLessThanOne scheme", () => {
-    testNumberSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
-  });
-
-  // testing numberNotLessThanZero scheme
-  test("Evaluate Number Schema using numberNotLessThanZero scheme", () => {
-    testNumberSchema(
-      numberNotLessThanZero(),
-      goodPositiveNumberTestCases,
-      true
-    );
-    testNumberSchema(numberNotLessThanZero(), badNumberTestCases, false);
-  });
-
-  test("Test zero values using numberNotLessThanZero scheme", () => {
-    testNumberSchema(numberNotLessThanZero(), zeroTest, true);
-  });
-
-  test("Test negative values using numberNotLessThanZero scheme", () => {
-    testNumberSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
-  });
-
   test("Evaluate Number Schema using ratio scheme", () => {
     testNumberSchema(ratio(), goodRatioTestCases, true);
     testNumberSchema(ratio(), badRatioTestCases, false);
-  });
-
-  test("Test validNumber schema", () => {
-    testValidNumber(validNumber(), goodValidNumberTestCases, true);
-    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -17,7 +17,6 @@ export const error = {
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
   NUMBER_LESS_THAN_ZERO: "Response must be greater than or equal to zero",
-  NUMBER_LESS_THAN_ONE: "Response must be greater than or equal to one",
   INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
@@ -60,39 +59,13 @@ const numberSchema = () =>
     .test({
       test: (value) => !isWhitespaceString(value),
       message: error.REQUIRED_GENERIC,
-    });
-
-// NUMBER NOT LESS THAN ONE
-export const numberNotLessThanOne = () =>
-  string()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
     })
     .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
-    })
-    .test({
-      test: (value) => parseInt(value!) >= 1,
-      message: error.NUMBER_LESS_THAN_ONE,
-    });
-
-// NUMBER NOT LESS THAN ZERO
-export const numberNotLessThanZero = () =>
-  string()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    })
-    .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
-    })
-    .test({
-      test: (value) => parseFloat(value!) >= 0,
+      test: (value) => {
+        if (validNumberRegex.test(value!)) {
+          return parseFloat(value!) >= 0;
+        } else return true;
+      },
       message: error.NUMBER_LESS_THAN_ZERO,
     });
 
@@ -104,27 +77,6 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
 
 export const number = () => numberSchema().required();
 export const numberOptional = () => numberSchema().notRequired().nullable();
-
-const validNumberSchema = () =>
-  string().test({
-    message: error.INVALID_NUMBER,
-    test: (value) => {
-      return typeof value !== "undefined"
-        ? validNumberRegex.test(value)
-        : false;
-    },
-  });
-
-export const validNumber = () =>
-  validNumberSchema()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    });
-
-export const validNumberOptional = () =>
-  validNumberSchema().notRequired().nullable();
 
 // Number - Ratio
 export const ratio = () =>

--- a/services/app-api/utils/validation/schemaMap.test.ts
+++ b/services/app-api/utils/validation/schemaMap.test.ts
@@ -6,9 +6,6 @@ import {
   date,
   isEndDateAfterStartDate,
   nested,
-  validNumber,
-  numberNotLessThanOne,
-  numberNotLessThanZero,
 } from "./schemaMap";
 
 describe("Schemas", () => {
@@ -24,29 +21,7 @@ describe("Schemas", () => {
     "N/A",
     "Data not available",
   ];
-  const badNumberTestCases = ["abc", "N", "!@#!@%"];
-
-  const zeroTest = ["0", "0.0"];
-
-  const goodPositiveNumberTestCases = [
-    "123",
-    "123.00",
-    "123..00",
-    "1,230",
-    "1,2,30",
-    "1230",
-    "123450123..,,,.123123123123",
-  ];
-
-  const negativeNumberTestCases = [
-    "-123",
-    "-123.00",
-    "-123..00",
-    "-1,230",
-    "-1,2,30",
-    "-1230",
-    "-123450123..,,,.123123123123",
-  ];
+  const badNumberTestCases = ["abc", "N", "!@#!@%", "-1"];
 
   const goodRatioTestCases = [
     "1:1",
@@ -73,9 +48,6 @@ describe("Schemas", () => {
   const goodDateTestCases = ["01/01/1990", "12/31/2020", "01012000"];
   const badDateTestCases = ["01-01-1990", "13/13/1990", "12/32/1990"];
 
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
   // nested
   const fieldValidationObject = {
     type: "text",
@@ -98,48 +70,9 @@ describe("Schemas", () => {
     }
   };
 
-  const testValidNumber = (
-    schemaToUse: MixedSchema,
-    testCases: Array<string | number>,
-    expectedReturn: boolean
-  ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
-  };
-
   test("Evaluate Number Schema using number scheme", () => {
     testSchema(number(), goodNumberTestCases, true);
     testSchema(number(), badNumberTestCases, false);
-  });
-
-  // testing numberNotLessThanOne scheme
-  test("Evaluate Number Schema using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanOne(), badNumberTestCases, false);
-  });
-
-  test("Test zero values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), zeroTest, false);
-  });
-
-  test("Test negative values using numberNotLessThanOne scheme", () => {
-    testSchema(numberNotLessThanOne(), negativeNumberTestCases, false);
-  });
-
-  // testing numberNotLessThanZero scheme
-  test("Evaluate Number Schema using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), goodPositiveNumberTestCases, true);
-    testSchema(numberNotLessThanZero(), badNumberTestCases, false);
-  });
-
-  test("Test zero values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), zeroTest, true);
-  });
-
-  test("Test negative values using numberNotLessThanZero scheme", () => {
-    testSchema(numberNotLessThanZero(), negativeNumberTestCases, false);
   });
 
   test("Evaluate Number Schema using ratio scheme", () => {
@@ -163,10 +96,5 @@ describe("Schemas", () => {
       ["string"],
       true
     );
-  });
-
-  test("Test validNumber schema", () => {
-    testValidNumber(validNumber(), goodValidNumberTestCases, true);
-    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -14,14 +14,11 @@ const error = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
-  NUMBER_LESS_THAN_ONE: "Response must be greater than or equal to one",
   NUMBER_LESS_THAN_ZERO: "Response must be greater than or equal to zero",
   INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',
   INVALID_RATIO: "Response must be a valid ratio",
 };
-
-const isWhitespaceString = (value?: string) => value?.trim().length === 0;
 
 // TEXT
 export const text = (): StringSchema => string();
@@ -40,67 +37,28 @@ const valueCleaningNumberSchema = (value: string, charsToReplace: RegExp) => {
 const validNumberRegex = /^\.$|[0-9]/;
 
 // NUMBER - Number or Valid Strings
-
 export const number = () =>
-  string().test({
-    message: error.INVALID_NUMBER_OR_NA,
-    test: (value) => {
-      if (value) {
-        const isValidStringValue = validNAValues.includes(value);
-        const isValidNumberValue = validNumberRegex.test(value);
-        return isValidStringValue || isValidNumberValue;
-      } else return true;
-    },
-  });
-
-// NUMBER NOT LESS THAN ONE
-export const numberNotLessThanOne = () =>
   string()
-    .required(error.REQUIRED_GENERIC)
     .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
+      message: error.INVALID_NUMBER_OR_NA,
+      test: (value) => {
+        if (value) {
+          const isValidStringValue = validNAValues.includes(value);
+          const isValidNumberValue = validNumberRegex.test(value);
+          return isValidStringValue || isValidNumberValue;
+        } else return true;
+      },
     })
     .test({
-      test: (value) => parseInt(value!) >= 1,
-      message: error.NUMBER_LESS_THAN_ONE,
-    });
-
-// NUMBER NOT LESS THAN ZERO
-export const numberNotLessThanZero = () =>
-  string()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => validNumberRegex.test(value!),
-      message: error.INVALID_NUMBER,
-    })
-    .test({
-      test: (value) => parseFloat(value!) >= 0,
+      test: (value) => {
+        if (validNumberRegex.test(value!)) {
+          return parseFloat(value!) >= 0;
+        } else return true;
+      },
       message: error.NUMBER_LESS_THAN_ZERO,
     });
 
 export const numberOptional = () => number();
-
-const validNumberSchema = () =>
-  string().test({
-    message: error.INVALID_NUMBER,
-    test: (value) => {
-      return typeof value !== "undefined"
-        ? validNumberRegex.test(value)
-        : false;
-    },
-  });
-
-export const validNumber = () =>
-  validNumberSchema()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    });
-
-export const validNumberOptional = () =>
-  validNumberSchema().notRequired().nullable();
 
 // Number - Ratio
 export const ratio = () =>
@@ -243,7 +201,6 @@ export const schemaMap: any = {
   email: email(),
   emailOptional: emailOptional(),
   number: number(),
-  numberNotLessThanOne: numberNotLessThanOne(),
   numberOptional: numberOptional(),
   objectArray: objectArray(),
   radio: radio(),

--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -1,5 +1,5 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { number, ratio, validNumber } from "./schemas";
+import { number, ratio } from "./schemas";
 
 describe("Schemas", () => {
   const goodNumberTestCases = [
@@ -12,7 +12,7 @@ describe("Schemas", () => {
     "N/A",
     "Data not available",
   ];
-  const badNumberTestCases = ["abc", "N", "", "!@#!@%"];
+  const badNumberTestCases = ["abc", "N", "", "!@#!@%", "-1"];
 
   const goodRatioTestCases = [
     "1:1",
@@ -35,24 +35,9 @@ describe("Schemas", () => {
     "%@#$!ASDF",
   ];
 
-  const goodValidNumberTestCases = [1, "1", "100000", "1,000,000"];
-
-  const badValidNumberTestCases = ["N/A", "number", "foo"];
-
   const testNumberSchema = (
     schemaToUse: MixedSchema,
     testCases: Array<string>,
-    expectedReturn: boolean
-  ) => {
-    for (let testCase of testCases) {
-      let test = schemaToUse.isValidSync(testCase);
-      expect(test).toEqual(expectedReturn);
-    }
-  };
-
-  const testValidNumber = (
-    schemaToUse: MixedSchema,
-    testCases: Array<string | number>,
     expectedReturn: boolean
   ) => {
     for (let testCase of testCases) {
@@ -69,10 +54,5 @@ describe("Schemas", () => {
   test("Evaluate Number Schema using ratio scheme", () => {
     testNumberSchema(ratio(), goodRatioTestCases, true);
     testNumberSchema(ratio(), badRatioTestCases, false);
-  });
-
-  test("Test validNumber schema", () => {
-    testValidNumber(validNumber(), goodValidNumberTestCases, true);
-    testValidNumber(validNumber(), badValidNumberTestCases, false);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -25,17 +25,26 @@ const validNAValues = ["N/A", "Data not available"];
 
 // NUMBER - Number or Valid Strings
 export const numberSchema = () =>
-  string().test({
-    message: error.INVALID_NUMBER_OR_NA,
-    test: (value) => {
-      if (value) {
-        const isValidStringValue = validNAValues.includes(value);
-        const isValidNumberValue =
-          checkStandardNumberInputAgainstRegexes(value);
-        return isValidStringValue || isValidNumberValue;
-      } else return true;
-    },
-  });
+  string()
+    .test({
+      message: error.INVALID_NUMBER_OR_NA,
+      test: (value) => {
+        if (value) {
+          const isValidStringValue = validNAValues.includes(value);
+          const isValidNumberValue =
+            checkStandardNumberInputAgainstRegexes(value);
+          return isValidStringValue || isValidNumberValue;
+        } else return true;
+      },
+    })
+    .test({
+      test: (value) => {
+        if (checkStandardNumberInputAgainstRegexes(value!)) {
+          return parseFloat(value!) >= 0;
+        } else return true;
+      },
+      message: error.NUMBER_LESS_THAN_ZERO,
+    });
 
 export const number = () =>
   numberSchema()
@@ -46,44 +55,6 @@ export const number = () =>
     });
 
 export const numberOptional = () => numberSchema().notRequired().nullable();
-
-const validNumberSchema = () =>
-  string().test({
-    message: error.INVALID_NUMBER,
-    test: (value) => {
-      return typeof value !== "undefined"
-        ? checkStandardNumberInputAgainstRegexes(value)
-        : false;
-    },
-  });
-
-// this is in case there are any fields that should only accept integers
-export const validNumber = () =>
-  validNumberSchema()
-    .required(error.REQUIRED_GENERIC)
-    .test({
-      test: (value) => !isWhitespaceString(value),
-      message: error.REQUIRED_GENERIC,
-    });
-
-export const validNumberOptional = () =>
-  validNumberSchema().notRequired().nullable();
-
-// NUMBER NOT LESS THAN ONE
-export const numberNotLessThanOne = () =>
-  validNumber().test({
-    test: (value) => {
-      return parseFloat(value!) >= 1;
-    },
-    message: error.NUMBER_LESS_THAN_ONE,
-  });
-
-// NUMBER NOT LESS THAN ZERO
-export const numberNotLessThanZero = () =>
-  validNumber().test({
-    test: (value) => parseFloat(value!) >= 0,
-    message: error.NUMBER_LESS_THAN_ZERO,
-  });
 
 // Number - Ratio
 export const ratio = () =>

--- a/services/ui-src/src/verbiage/errors.ts
+++ b/services/ui-src/src/verbiage/errors.ts
@@ -15,7 +15,6 @@ export const validationErrors = {
   INVALID_URL: "Response must be a valid hyperlink/URL",
   INVALID_DATE: "Response must be a valid date",
   INVALID_END_DATE: "End date can't be before start date",
-  NUMBER_LESS_THAN_ONE: "Response must be greater than or equal to one",
   NUMBER_LESS_THAN_ZERO: "Response must be greater than or equal to zero",
   INVALID_NUMBER: "Response must be a valid number",
   INVALID_NUMBER_OR_NA: 'Response must be a valid number or "N/A"',


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Added test to frontend and backend number schemas to prevent negative numbers from being entered
- Update test files to check for this case
- Removed unused `validNumber` and `numberNotLessThan*` schemas from frontend and backend (wasn't in WP or SAR and would cause more problems than it's worth maintaining. I imagine all schemas may end up in core eventually, in which case we'd only pull in what we need.)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3100

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Go to Transition Benchmarks and open one of them
- Click "Yes" and play around with inputs to any number field
- Verify
  - Negative numbers aren't allowed, and receive the proper error message
  - "N/A" and "Data not available" are valid inputs
  - Numbers with decimals are allowed

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---