### PR TITLE
Disable create report button while creating is in progress

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -207,7 +207,7 @@ export const AddEditReportModal = ({
         <>
           <Button
             sx={sx.copyBtn}
-            disabled={isCopyDisabled()}
+            disabled={isCopyDisabled() || submitting}
             onClick={writeReport}
             type="submit"
           >
@@ -217,6 +217,7 @@ export const AddEditReportModal = ({
             <Button
               sx={sx.close}
               onClick={writeReport}
+              disabled={submitting}
               type="submit"
               variant="outline"
               data-testid="modal-logout-button"
@@ -227,6 +228,7 @@ export const AddEditReportModal = ({
             <Button
               sx={sx.resetBtn}
               onClick={resetReport}
+              disabled={submitting}
               type="submit"
               variant="outline"
               data-testid="modal-logout-button"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When you are in the AddEditReportModal you can click the "Start new" button fast and it'll create multiple reports. Now these buttons are disabled when `submitting` is set to true, which happens at the top of the `writeReport` method the button triggers.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3101

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Go to WP dashboard and click "Start MFP Work Plan" 
- Click "Start new" as fast as you can multiple times
- Ensure only one WP gets created

To retest you can log in as an admin and archive the created WP, or restart the app.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---
