### PR TITLE
CMDCT-3097: Allow state user to re-submit WP that is "In Revision" status

### DIFF
--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -163,7 +163,6 @@ export const releaseReport = handler(async (event) => {
       updatedFieldData,
       formTemplate
     ),
-    isComplete: false,
   };
 
   const putReportMetadataParams: DynamoWrite = {

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -233,7 +233,7 @@ describe("When loading a sucessfully submitted report (Success Message Generator
   });
 });
 
-describe("Test McparReviewSubmitPage view accessibility", () => {
+describe("Test ReviewSubmitPage view accessibility", () => {
   it("Should not have basic accessibility issues when report status is 'not started", async () => {
     mockedUseStore.mockReturnValue(mockUseStore);
     const { container } = render(WpReviewSubmitPage);

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -62,9 +62,8 @@ export const ReviewSubmitPage = () => {
 
   useEffect(() => {
     setIsPermittedToSubmit(
-      (userIsEndUser &&
-        report?.status === ReportStatus.IN_PROGRESS &&
-        !hasError) ||
+      (userIsEndUser && report?.status === ReportStatus.IN_PROGRESS) ||
+        (report?.status === ReportStatus.IN_REVISION && !hasError) ||
         false
     );
   }, [userIsEndUser, report?.status, hasError]);
@@ -274,7 +273,6 @@ export const SuccessMessage = ({
         <Text sx={sx.additionalInfoHeader}>{intro.additionalInfoHeader}</Text>
         <Text sx={sx.additionalInfo}>{intro.additionalInfo}</Text>
       </Box>
-
       <Box sx={sx.infoTextBox}>
         <PrintButton reviewVerbiage={reviewVerbiage} />
       </Box>

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -62,7 +62,9 @@ export const ReviewSubmitPage = () => {
 
   useEffect(() => {
     setIsPermittedToSubmit(
-      (userIsEndUser && report?.status === ReportStatus.IN_PROGRESS) ||
+      (userIsEndUser &&
+        report?.status === ReportStatus.IN_PROGRESS &&
+        !hasError) ||
         (report?.status === ReportStatus.IN_REVISION && !hasError) ||
         false
     );

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -73,6 +73,7 @@ export interface ReportContextShape extends ReportContextMethods {
 export enum ReportStatus {
   NOT_STARTED = "Not started",
   IN_PROGRESS = "In progress",
+  IN_REVISION = "In revision",
   SUBMITTED = "Submitted",
   APPROVED = "Approved",
 }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
State users should be able to re-submit a Work Plan after it's been unlocked by an Admin user and it is `In revision` (even if they haven't made any changes since it unlocked)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3097

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create and submit a new WP
- Log in as an admin user
- Unlock the submitted WP
- Log back in as the state user

Check for these two use-cases:

**You haven't made any changes**
- Navigate directly to `Review & submit`
- The `Submit WP` button should be enabled and you are able to submit

**You've made some new changes in this revision**
- Change anything in the WP, I'd recommend adding a new Transition Benchmark and NOT completing it yet
- Navigate to `Review & submit` 
- The `Submit WP` button should be disabled 'cause your WP is not complete
- Complete the WP
- Now you should be able to submit ✨ 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
