### PR TITLE
Remove asterisks and 'if applicable' from initiatives

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -354,7 +354,7 @@
                                     },
                                     {
                                       "type": "li",
-                                      "content": "Self-direction (if applicable)",
+                                      "content": "Self-direction",
                                       "props": {
                                         "style": {
                                           "paddingBottom": ".5rem"
@@ -363,7 +363,7 @@
                                     },
                                     {
                                       "type": "li",
-                                      "content": "Tribal initiative (if applicable)",
+                                      "content": "Tribal initiative",
                                       "props": {
                                         "style": {
                                           "paddingBottom": ".5rem"
@@ -701,27 +701,26 @@
                 "validation": "radio",
                 "props": {
                   "label": "Work Plan topic:",
-                  "hint": "Note: Initiative topics with * are required and must be selected at least once across all initiatives.",
                   "choices": [
                     {
                       "id": "VjQ0OFqior9Dxu5RRNiZ5u",
-                      "label": "Transitions and transition coordination services*"
+                      "label": "Transitions and transition coordination services"
                     },
                     {
                       "id": "wbUsMMqVP7q1n10szK5h5S",
-                      "label": "Housing-related supports*"
+                      "label": "Housing-related supports"
                     },
                     {
                       "id": "SdaFlF3DJyzKcHCCu3Zylm",
-                      "label": "Quality measurement and improvement*"
+                      "label": "Quality measurement and improvement"
                     },
                     {
                       "id": "8CpFrev6sMfRijIhafMj7V",
-                      "label": "Self-direction (*if applicable)"
+                      "label": "Self-direction"
                     },
                     {
                       "id": "tVURShWTPfVKGU94QmIwDn",
-                      "label": "Tribal Initiative (*if applicable)"
+                      "label": "Tribal Initiative"
                     },
                     {
                       "id": "1k3EnM5WrizX3hsa6Zn85G",

--- a/services/ui-src/src/components/alerts/getWPAlertStatus.test.tsx
+++ b/services/ui-src/src/components/alerts/getWPAlertStatus.test.tsx
@@ -3,11 +3,11 @@ import { getWPAlertStatus } from "./getWPAlertStatus";
 
 describe("Test WP Alerts", () => {
   const topics = [
-    "Transitions and transition coordination services*",
-    "Housing-related supports*",
-    "Quality measurement and improvement*",
-    "Self-direction (*if applicable)",
-    "Tribal Initiative (*if applicable)",
+    "Transitions and transition coordination services",
+    "Housing-related supports",
+    "Quality measurement and improvement",
+    "Self-direction",
+    "Tribal Initiative",
   ];
 
   const initiative_wpTopic = topics.map((topic) => {

--- a/services/ui-src/src/components/alerts/getWPAlertStatus.tsx
+++ b/services/ui-src/src/components/alerts/getWPAlertStatus.tsx
@@ -3,9 +3,9 @@ import { ReportShape, AnyObject } from "types";
 //setting up function calls using entityType as call
 export const checkInitiativeTopics = (fieldData: any, entities: any[]) => {
   let topics = [
-    "Transitions and transition coordination services*",
-    "Housing-related supports*",
-    "Quality measurement and improvement*",
+    "Transitions and transition coordination services",
+    "Housing-related supports",
+    "Quality measurement and improvement",
   ];
 
   //if user did not answer previous question, alert stays on
@@ -16,10 +16,10 @@ export const checkInitiativeTopics = (fieldData: any, entities: any[]) => {
     return true;
 
   if (fieldData?.instructions_selfDirectedInitiatives[0]?.value === "Yes")
-    topics.push("Self-direction (*if applicable)");
+    topics.push("Self-direction");
 
   if (fieldData?.instructions_tribalInitiatives[0]?.value === "Yes")
-    topics.push("Tribal Initiative (*if applicable)");
+    topics.push("Tribal Initiative");
 
   //filter down to the values of the radio selection
   const values = entities?.flatMap((entity) =>
@@ -28,7 +28,9 @@ export const checkInitiativeTopics = (fieldData: any, entities: any[]) => {
     })
   );
   //check if the values matches all the topics, if all topics is covered, return false
-  return !topics.every((topic) => values?.includes(topic));
+  return !topics.every((topic) =>
+    values.some((value) => value.includes(topic))
+  );
 };
 //store function calls here
 const alertStatusFunctions: AnyObject = {

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -734,7 +734,7 @@ export const mockFullReportJSON: ReportJson = {
                     },
                     {
                       id: "8CpFrev6sMfRijIhafMj7V",
-                      label: "Self-directiom",
+                      label: "Self-direction",
                     },
                     {
                       id: "tVURShWTPfVKGU94QmIwDn",

--- a/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
+++ b/services/ui-src/src/utils/testing/mockFullReportJSON.tsx
@@ -719,28 +719,26 @@ export const mockFullReportJSON: ReportJson = {
                 validation: "radio",
                 props: {
                   label: "Work Plan topic:",
-                  hint: "Note: Initiative topics with * are required and must be selected at least once across all initiatives.",
                   choices: [
                     {
                       id: "VjQ0OFqior9Dxu5RRNiZ5u",
-                      label:
-                        "Transitions and transition coordination services*",
+                      label: "Transitions and transition coordination services",
                     },
                     {
                       id: "wbUsMMqVP7q1n10szK5h5S",
-                      label: "Housing-related supports*",
+                      label: "Housing-related supports",
                     },
                     {
                       id: "SdaFlF3DJyzKcHCCu3Zylm",
-                      label: "Quality measurement and improvement*",
+                      label: "Quality measurement and improvement",
                     },
                     {
                       id: "8CpFrev6sMfRijIhafMj7V",
-                      label: "Self-direction(*if applicable)",
+                      label: "Self-directiom",
                     },
                     {
                       id: "tVURShWTPfVKGU94QmIwDn",
-                      label: "Tribal Initiative (*if applicable)",
+                      label: "Tribal Initiative",
                     },
                     {
                       id: "1k3EnM5WrizX3hsa6Zn85G",

--- a/services/ui-src/src/verbiage/pages/wp/wp-alerts.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-alerts.ts
@@ -2,6 +2,6 @@ export default {
   initiative: {
     title: "Your initiatives do not meet the topic requirements",
     description:
-      "Initiatives must meet the following requirements at least once across all the initiatives: <li>Transitions and transition coordination services</li><li>Housing-related supports</li><li>Quality measurement and improvement</li><li>Self-direction (If applicable)</li><li>Tribal (if applicable)</li>To correct this, ensure you answer the 2 questions at the bottom of <i>State- or Territory-Specific Initiatives Instructions</i> (the previous page), and add at least one initiative for each of these topics. This alert will disappear once they’re met.",
+      "Initiatives must meet the following requirements at least once across all the initiatives: <li>Transitions and transition coordination services</li><li>Housing-related supports</li><li>Quality measurement and improvement</li><li>Self-direction (if applicable)</li><li>Tribal (if applicable)</li>To correct this, ensure you answer the 2 questions at the bottom of <i>State- or Territory-Specific Initiatives Instructions</i> (the previous page), and add at least one initiative for each of these topics. This alert will disappear once they’re met.",
   },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove asterisks and "if applicable" language from the initiative options.
Modified the code that checks if an initiative type has been selected such that it will account for past reports that have the asterisk or 'if applicable' in its name.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3040

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Go to initiatives and validate that creating initiatives and the corresponding error message works as expected

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---