### PR TITLE
WP - Edit / View Mode UI

### DIFF
--- a/services/ui-src/src/components/cards/TemplateCard.test.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.test.tsx
@@ -39,6 +39,8 @@ const mockUseStoreNoReports: MfpReportState & MfpUserState = {
   submittedReportsByState: [],
   lastSavedTime: "12:30 PM",
   workPlanToCopyFrom: undefined,
+  autosaveState: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -46,7 +48,7 @@ const mockUseStoreNoReports: MfpReportState & MfpUserState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
-  autosaveState: false,
+  setEditable: () => {},
   // We need to add the user store, as that is where the "lastAlteredBy" field is fetched from
   ...mockStateUserStore,
 };

--- a/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
@@ -8,6 +8,7 @@ import {
   mockGenericEntity,
   mockModalDrawerReportPageVerbiage,
   mockStateUserStore,
+  mockUseStore,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 // utils
@@ -43,14 +44,16 @@ describe("Test ReportDrawer rendering", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it("Should render save text for state user", async () => {
-    mockedUseStore.mockReturnValue(mockStateUserStore);
+  it("Should render save text if form is editable", async () => {
+    mockUseStore.editable = true;
+    mockedUseStore.mockReturnValue(mockUseStore);
     render(drawerComponent);
     expect(screen.getByText(saveAndCloseText)).toBeVisible();
   });
 
-  it("Should not render save text for admin user", async () => {
-    mockedUseStore.mockReturnValue(mockAdminUserStore);
+  it("Should not render save text if form is not editable", async () => {
+    mockUseStore.editable = false;
+    mockedUseStore.mockReturnValue(mockUseStore);
     render(drawerComponent);
     expect(screen.queryByText(saveAndCloseText)).not.toBeInTheDocument();
   });

--- a/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 //components
 import {
-  mockAdminUserStore,
   mockDrawerForm,
   mockEmptyDrawerForm,
   mockGenericEntity,

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -26,8 +26,6 @@ export const ReportDrawer = ({
   validateOnRender,
   ...props
 }: Props) => {
-  // determine if fields should be disabled (based on admin and read-only roles)
-  const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
   const { editable } = useStore();
   const buttonText = !editable ? closeText : saveAndCloseText;
   const formFieldsExist = form.fields.length;
@@ -52,14 +50,12 @@ export const ReportDrawer = ({
       )}
       <Box sx={sx.footerBox}>
         <Flex sx={sx.buttonFlex}>
-          {(!userIsAdmin || !userIsReadOnly) && (
-            <Button
-              variant="outline"
-              onClick={drawerDisclosure.onClose as MouseEventHandler}
-            >
-              Cancel
-            </Button>
-          )}
+          <Button
+            variant="outline"
+            onClick={drawerDisclosure.onClose as MouseEventHandler}
+          >
+            Cancel
+          </Button>
           <Button
             type="submit"
             form={form.id}

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -28,8 +28,8 @@ export const ReportDrawer = ({
 }: Props) => {
   // determine if fields should be disabled (based on admin and read-only roles)
   const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
-  const buttonText =
-    userIsAdmin || userIsReadOnly ? closeText : saveAndCloseText;
+  const { editable } = useStore();
+  const buttonText = !editable ? closeText : saveAndCloseText;
   const formFieldsExist = form.fields.length;
   return (
     <Drawer

--- a/services/ui-src/src/components/export/ExportedReportBanner.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.test.tsx
@@ -68,6 +68,8 @@ describe("ExportedReportBanner", () => {
       submittedReportsByState: [],
       lastSavedTime: "1:58 PM",
       workPlanToCopyFrom: undefined,
+      autosaveState: false,
+      editable: true,
       setReport: () => {},
       setReportsByState: () => {},
       clearReportsByState: () => {},
@@ -75,7 +77,7 @@ describe("ExportedReportBanner", () => {
       setLastSavedTime: () => {},
       setWorkPlanToCopyFrom: () => {},
       setAutosaveState: () => {},
-      autosaveState: false,
+      setEditable: () => {},
       ...mockStateUserStore,
       ...mockBannerStore,
     };

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -40,16 +40,14 @@ export const ChoiceListField = ({
   const defaultValue: Choice[] = [];
   const [displayValue, setDisplayValue] = useState<Choice[]>(defaultValue);
 
-  const { state, userIsReadOnly, userIsAdmin, full_name } =
-    useStore().user ?? {};
+  const { state, full_name } = useStore().user ?? {};
 
-  const { report, selectedEntity, setAutosaveState } = useStore();
+  const { report, selectedEntity, setAutosaveState, editable } = useStore();
   const { updateReport } = useContext(ReportContext);
   const { prepareEntityPayload } = useContext(EntityContext);
 
   //closeout will disables only certain parts of an active form
-  const shouldDisableChildFields =
-    userIsAdmin || userIsReadOnly || !!props?.disabled || report?.locked;
+  const shouldDisableChildFields = !editable || !!props?.disabled;
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -26,8 +26,6 @@ import {
   FormField,
   isFieldElement,
   FormLayoutElement,
-  ReportStatus,
-  ReportType,
 } from "types";
 
 export const Form = ({
@@ -49,16 +47,12 @@ export const Form = ({
   let location = useLocation();
 
   // determine if fields should be disabled (based on admin roles )
-  const { userIsAdmin, userIsReadOnly } = useStore().user ?? {};
+  const { userIsAdmin } = useStore().user ?? {};
 
-  const { report } = useStore();
+  const { report, editable } = useStore();
 
   const fieldInputDisabled =
-    ((userIsAdmin || userIsReadOnly) && !formJson.editableByAdmins) ||
-    (report?.status === ReportStatus.SUBMITTED &&
-      report?.reportType === ReportType.WP) ||
-    report?.status === ReportStatus.APPROVED ||
-    userDisabled;
+    (userIsAdmin && !formJson.editableByAdmins) || !editable || userDisabled;
 
   // create validation schema
   const formValidationJson = compileValidationJsonFromFields(

--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -47,6 +47,7 @@ const mockUseStore: MfpReportState & MfpUserState = {
   lastSavedTime: "12:30 PM",
   workPlanToCopyFrom: undefined,
   autosaveState: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -54,6 +55,7 @@ const mockUseStore: MfpReportState & MfpUserState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
+  setEditable: () => {},
   // We need to add the user store, as that is where the "lastAlteredBy" field is fetched from
   ...mockStateUserStore,
 };

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -30,7 +30,7 @@ export const AddEditEntityModal = ({
   selectedEntity,
   modalDisclosure,
 }: Props) => {
-  const { report } = useStore();
+  const { report, editable } = useStore();
   const { updateReport } = useContext(ReportContext);
   const { full_name } = useStore().user ?? {};
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -146,7 +146,7 @@ export const AddEditEntityModal = ({
         actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}
-      submitButtonDisabled={!!error}
+      submitButtonDisabled={!!error || !editable}
     >
       {error && <ErrorAlert error={error} />}
       <Form

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
@@ -65,6 +65,8 @@ const mockUseStore: MfpReportState & MfpUserState = {
   submittedReportsByState: [mockWPFullReport],
   lastSavedTime: "12:30 PM",
   workPlanToCopyFrom: undefined,
+  autosaveState: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -72,7 +74,7 @@ const mockUseStore: MfpReportState & MfpUserState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
-  autosaveState: false,
+  setEditable: () => {},
   // We need to add the user store, as that is where the "lastAlteredBy" field is fetched from
   ...mockStateUserStore,
 };

--- a/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
@@ -48,7 +48,7 @@ const mockUseStore: MfpReportState & MfpUserState = {
   lastSavedTime: "12:30 PM",
   workPlanToCopyFrom: undefined,
   autosaveState: false,
-  editable: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},

--- a/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
@@ -47,6 +47,8 @@ const mockUseStore: MfpReportState & MfpUserState = {
   submittedReportsByState: [mockWPFullReport],
   lastSavedTime: "12:30 PM",
   workPlanToCopyFrom: undefined,
+  autosaveState: false,
+  editable: false,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -54,7 +56,7 @@ const mockUseStore: MfpReportState & MfpUserState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
-  autosaveState: false,
+  setEditable: () => {},
   // We need to add the user store, as that is where the "lastAlteredBy" field is fetched from
   ...mockStateUserStore,
 };

--- a/services/ui-src/src/components/modals/DeleteEntityModal.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.tsx
@@ -14,7 +14,7 @@ export const DeleteEntityModal = ({
   verbiage,
   modalDisclosure,
 }: Props) => {
-  const { report } = useStore();
+  const { report, editable } = useStore();
   const { updateReport } = useContext(ReportContext);
   const { full_name } = useStore().user ?? {};
   const [deleting, setDeleting] = useState<boolean>(false);
@@ -97,6 +97,7 @@ export const DeleteEntityModal = ({
         actionButtonText: verbiage.deleteModalConfirmButtonText,
         closeButtonText: "Cancel",
       }}
+      submitButtonDisabled={!editable}
     >
       <Text>{verbiage.deleteModalWarning}</Text>
     </Modal>

--- a/services/ui-src/src/components/modals/DeleteEntityModal.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.tsx
@@ -13,6 +13,7 @@ export const DeleteEntityModal = ({
   selectedEntity,
   verbiage,
   modalDisclosure,
+  userDisabled,
 }: Props) => {
   const { report, editable } = useStore();
   const { updateReport } = useContext(ReportContext);
@@ -97,7 +98,7 @@ export const DeleteEntityModal = ({
         actionButtonText: verbiage.deleteModalConfirmButtonText,
         closeButtonText: "Cancel",
       }}
-      submitButtonDisabled={!editable}
+      submitButtonDisabled={!editable || userDisabled}
     >
       <Text>{verbiage.deleteModalWarning}</Text>
     </Modal>
@@ -113,4 +114,5 @@ interface Props {
     isOpen: boolean;
     onClose: any;
   };
+  userDisabled?: boolean;
 }

--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -72,6 +72,7 @@ export const Modal = ({
                 sx={sx.action}
                 onClick={() => onConfirmHandler()}
                 data-testid="modal-submit-button"
+                disabled={submitButtonDisabled}
               >
                 {submitting ? <Spinner size="md" /> : content.actionButtonText}
               </Button>

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
@@ -6,13 +6,13 @@ import { EntityDetailsOverlay } from "components";
 import {
   mockEntityDetailsOverlayJson,
   RouterWrappedComponent,
-  mockEntityStore,
+  mockUseEntityStore,
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue(mockEntityStore);
+mockedUseStore.mockReturnValue(mockUseEntityStore);
 
 const { closeOutWarning, closeOutModal } =
   mockEntityDetailsOverlayJson.verbiage;

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -45,7 +45,7 @@ export const EntityDetailsOverlay = ({
 }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const { entityType, form, verbiage } = route;
-  const { report, selectedEntity, setSelectedEntity, autosaveState } =
+  const { report, selectedEntity, setSelectedEntity, autosaveState, editable } =
     useStore();
   const [disableCloseOut, setDisableCloseOut] = useState<boolean>();
 
@@ -282,7 +282,7 @@ export const EntityDetailsOverlay = ({
           <Button type="submit" form={form.id} sx={sx.saveButton}>
             {submitting ? (
               <Spinner size="md" />
-            ) : !selectedEntity?.isInitiativeClosed ? (
+            ) : editable && !selectedEntity?.isInitiativeClosed ? (
               "Save & return"
             ) : (
               "Return"

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -61,7 +61,7 @@ export const EntityDetailsOverlay = ({
   useEffect(() => {
     if (selectedEntity) {
       setSelectedEntity(
-        report?.fieldData?.[selectedEntity.type].find(
+        report?.fieldData?.[selectedEntity.type]?.find(
           (entity: EntityShape) => entity.id == selectedEntity.id
         )
       );

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -134,6 +134,16 @@ export const DashboardPage = ({ reportType }: Props) => {
     setPreviousReport(newReportsToDisplay?.[0]);
   }, [reportsByState]);
 
+  const isReportEditable = (selectedReport: ReportShape) => {
+    return (
+      !userIsAdmin &&
+      !userIsReadOnly &&
+      !selectedReport.locked &&
+      selectedReport.status !== ReportStatus.APPROVED &&
+      selectedReport.status !== ReportStatus.SUBMITTED
+    );
+  };
+
   const enterSelectedReport = async (report: ReportMetadataShape) => {
     clearSelectedEntity();
     setReportId(report.id);
@@ -150,15 +160,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     setEntering(false);
     const firstReportPagePath =
       selectedReport?.formTemplate.flatRoutes![0].path;
-
-    //set if form can be edit or only viewed
-    const editable =
-      !userIsAdmin &&
-      !userIsReadOnly &&
-      selectedReport.status !== ReportStatus.APPROVED &&
-      selectedReport.status !== ReportStatus.SUBMITTED;
-
-    setEditable(editable);
+    setEditable(isReportEditable(selectedReport));
     navigate(firstReportPagePath);
   };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -138,9 +138,9 @@ export const DashboardPage = ({ reportType }: Props) => {
     return (
       !userIsAdmin &&
       !userIsReadOnly &&
-      !selectedReport.locked &&
-      selectedReport.status !== ReportStatus.APPROVED &&
-      selectedReport.status !== ReportStatus.SUBMITTED
+      !selectedReport?.locked &&
+      selectedReport?.status !== ReportStatus.APPROVED &&
+      selectedReport?.status !== ReportStatus.SUBMITTED
     );
   };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -62,12 +62,17 @@ export const DashboardPage = ({ reportType }: Props) => {
     releaseReport,
     fetchReport,
   } = useContext(ReportContext);
-  const { reportsByState, workPlanToCopyFrom, clearSelectedEntity } =
-    useStore();
+  const {
+    reportsByState,
+    workPlanToCopyFrom,
+    clearSelectedEntity,
+    setEditable,
+  } = useStore();
   const navigate = useNavigate();
   const {
     state: userState,
     userIsEndUser,
+    userIsReadOnly,
     userIsAdmin,
   } = useStore().user ?? {};
   const { isTablet, isMobile } = useBreakpoint();
@@ -145,6 +150,15 @@ export const DashboardPage = ({ reportType }: Props) => {
     setEntering(false);
     const firstReportPagePath =
       selectedReport?.formTemplate.flatRoutes![0].path;
+
+    //set if form can be edit or only viewed
+    const editable =
+      !userIsAdmin &&
+      !userIsReadOnly &&
+      selectedReport.status !== ReportStatus.APPROVED &&
+      selectedReport.status !== ReportStatus.SUBMITTED;
+
+    setEditable(editable);
     navigate(firstReportPagePath);
   };
 

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -76,7 +76,7 @@ export const ReviewSubmitPage = () => {
   const submitForm = async () => {
     setSubmitting(true);
     if (isPermittedToSubmit) {
-      await submitReport(reportKeys).then(() => {
+      await submitReport(reportKeys)?.then(() => {
         setEditable(false);
       });
     }

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -28,7 +28,7 @@ import checkIcon from "assets/icons/icon_check_circle.png";
 
 export const ReviewSubmitPage = () => {
   const { fetchReport, submitReport } = useContext(ReportContext);
-  const report = useStore().report;
+  const { report, setEditable } = useStore();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -76,7 +76,9 @@ export const ReviewSubmitPage = () => {
   const submitForm = async () => {
     setSubmitting(true);
     if (isPermittedToSubmit) {
-      await submitReport(reportKeys);
+      await submitReport(reportKeys).then(() => {
+        setEditable(false);
+      });
     }
     await fetchReport(reportKeys);
     setSubmitting(false);

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -40,9 +40,6 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
     useStore();
   const [isEntityDetailsOpen, setIsEntityDetailsOpen] = useState<boolean>();
 
-  // Determine whether form is locked or unlocked based on user and route
-  const isLocked = report?.locked;
-
   // Display Variables
   let reportFieldDataEntities = report?.fieldData[entityType] || [];
 
@@ -147,7 +144,6 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
                     entityType={entityType}
                     entityInfo={entityInfo}
                     verbiage={verbiage}
-                    locked={isLocked}
                     openOverlayOrDrawer={openEntityDetailsOverlay}
                     openAddEditEntityModal={openAddEditEntityModal}
                     openDeleteEntityModal={openDeleteEntityModal}

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -157,7 +157,6 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
             )}
             <Button
               sx={sx.addEntityButton}
-              disabled={isLocked}
               onClick={() => openAddEditEntityModal()}
               rightIcon={<Image src={addIcon} alt="Previous" sx={sx.addIcon} />}
             >

--- a/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
@@ -10,6 +10,7 @@ import {
   RouterWrappedComponent,
   mockReportStore,
   mockEntityStore,
+  mockUseEntityStore,
 } from "utils/testing/setupJest";
 
 const mockUseNavigate = jest.fn();
@@ -35,8 +36,7 @@ const overlayModalPageComponentWithEntities = (
 
 describe("Test overlayModalPage with entities", () => {
   beforeEach(() => {
-    mockedUseStore.mockReturnValue(mockReportStore);
-    mockedUseStore.mockReturnValue(mockEntityStore);
+    mockedUseStore.mockReturnValue(mockUseEntityStore);
     render(overlayModalPageComponentWithEntities);
   });
 

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -43,7 +43,7 @@ export const OverlayModalPage = ({
   useEffect(() => {
     if (selectedEntity) {
       setSelectedEntity(
-        report?.fieldData?.[selectedEntity.type].find(
+        report?.fieldData?.[selectedEntity.type]?.find(
           (entity: EntityShape) => entity.id == selectedEntity.id
         )
       );

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -16,7 +16,6 @@ import {
 } from "components";
 // assets
 import addIcon from "assets/icons/icon_add_white.png";
-import addIconGray from "assets/icons/icon_add_gray.png";
 import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 // types
 import { EntityShape, OverlayModalPageShape } from "types";
@@ -28,13 +27,13 @@ export const OverlayModalPage = ({
   route,
 }: Props) => {
   const { verbiage, modalForm, stepType } = route;
-  const { report, selectedEntity, setSelectedEntity } = useStore();
+  const { report, selectedEntity, setSelectedEntity, editable } = useStore();
   const [selectedStepEntity, setSelectedStepEntity] = useState<
     EntityShape | undefined
   >(undefined);
 
   const entityType = selectedEntity!.type;
-  const userDisabled = selectedEntity?.isInitiativeClosed;
+  const userDisabled = !editable || selectedEntity?.isInitiativeClosed;
 
   /**
    * Any time the report is updated on this page,
@@ -85,11 +84,9 @@ export const OverlayModalPage = ({
   } = useDisclosure();
 
   const openDeleteEntityModal = (entity?: EntityShape) => {
-    if (!userDisabled) {
-      setSelectedStepEntity(entity);
-      resetClearProp(modalForm.fields);
-      deleteEntityModalOnOpenHandler();
-    }
+    setSelectedStepEntity(entity);
+    resetClearProp(modalForm.fields);
+    deleteEntityModalOnOpenHandler();
   };
 
   const closeDeleteEntityModal = () => {
@@ -122,14 +119,7 @@ export const OverlayModalPage = ({
         <Button
           sx={sx.addEntityButton}
           onClick={addEditEntityModalOnOpenHandler}
-          leftIcon={
-            <Image
-              sx={sx.buttonIcons}
-              src={userDisabled ? addIconGray : addIcon}
-              alt="Add"
-            />
-          }
-          disabled={userDisabled}
+          rightIcon={<Image sx={sx.buttonIcons} src={addIcon} alt="Add" />}
         >
           {verbiage.addEntityButtonText}
         </Button>

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -174,6 +174,7 @@ export const OverlayModalPage = ({
             isOpen: deleteEntityModalIsOpen,
             onClose: closeDeleteEntityModal,
           }}
+          userDisabled={userDisabled}
         />
       </Box>
       <Box>

--- a/services/ui-src/src/components/statusing/StatusTable.tsx
+++ b/services/ui-src/src/components/statusing/StatusTable.tsx
@@ -16,7 +16,7 @@ import successIcon from "assets/icons/icon_check_circle.png";
 import { assertExhaustive } from "utils/other/typing";
 
 export const StatusTable = () => {
-  const report = useStore().report;
+  const { report } = useStore();
   const { review } = verbiage;
   const rowDepth = 1;
   return report ? (
@@ -84,19 +84,19 @@ export const StatusIcon = ({
 const TableRow = ({ page, depth }: RowProps) => {
   const { isMobile } = useBreakpoint();
   const { name, path, children, status } = page;
-  const buttonAriaLabel = `Edit  ${name}`;
-  const report = useStore().report;
+  const { report, editable } = useStore();
+  const buttonAriaLabel = editable ? `Edit  ${name}` : `View  ${name}`;
   return (
     <Tr>
       {depth == 1 ? (
         <Td sx={sx.parent} pl={!isMobile ? "1rem" : "0"}>
           <Text>{name}</Text>
-          {isMobile && !children && EditButton(buttonAriaLabel, path)}
+          {isMobile && !children && EditButton(buttonAriaLabel, path, editable)}
         </Td>
       ) : (
         <Td sx={sx.subparent} pl={!isMobile ? `${1.25 * depth}rem` : "0"}>
           <Text>{name}</Text>
-          {isMobile && !children && EditButton(buttonAriaLabel, path)}
+          {isMobile && !children && EditButton(buttonAriaLabel, path, editable)}
         </Td>
       )}
       <Td
@@ -117,7 +117,9 @@ const TableRow = ({ page, depth }: RowProps) => {
         />
       </Td>
       {!isMobile && (
-        <Td>{!children && EditButton(buttonAriaLabel, path, true)}</Td>
+        <Td>
+          {!children && EditButton(buttonAriaLabel, path, editable, true)}
+        </Td>
       )}
     </Tr>
   );
@@ -126,6 +128,7 @@ const TableRow = ({ page, depth }: RowProps) => {
 const EditButton = (
   buttonAriaLabel: string,
   path: string,
+  editable: boolean,
   showIcon = false
 ) => {
   const navigate = useNavigate();
@@ -137,7 +140,7 @@ const EditButton = (
       onClick={() => navigate(path, { state: { validateOnRender: true } })}
     >
       {showIcon && <Image src={editIcon} alt="Edit Program" />}
-      Edit
+      {editable ? "Edit" : "View"}
     </Button>
   );
 };

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -9,7 +9,6 @@ import {
   ModalDrawerEntityTypes,
   ReportShape,
   OverlayModalTypes,
-  ReportStatus,
   EntityDetailsOverlayTypes,
 } from "types";
 // utils
@@ -32,7 +31,6 @@ export const EntityRow = ({
   openDeleteEntityModal,
   openOverlayOrDrawer,
 }: Props) => {
-  const { userIsEndUser } = useStore().user ?? {};
   const { report, editable } = useStore();
 
   // check for "other" target population entities

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -28,13 +28,12 @@ export const EntityRow = ({
   entityType,
   formEntity,
   verbiage,
-  locked,
   openAddEditEntityModal,
   openDeleteEntityModal,
   openOverlayOrDrawer,
 }: Props) => {
   const { userIsEndUser } = useStore().user ?? {};
-  const { report } = useStore();
+  const { report, editable } = useStore();
 
   // check for "other" target population entities
   const { isRequired, isCopied, isInitiativeClosed, closedBy } = entity;
@@ -155,9 +154,7 @@ export const EntityRow = ({
               variant="none"
               onClick={() => openAddEditEntityModal(entity)}
             >
-              {report?.status === ReportStatus.SUBMITTED ||
-              report?.status === ReportStatus.APPROVED ||
-              isInitiativeClosed
+              {!editable || isInitiativeClosed
                 ? verbiage.readOnlyEntityButtonText
                 : verbiage.editEntityButtonText}
             </Button>
@@ -172,9 +169,7 @@ export const EntityRow = ({
             variant="outline"
             disabled={entityStatus === EntityStatuses.DISABLED}
           >
-            {report?.status === ReportStatus.SUBMITTED ||
-            report?.status === ReportStatus.APPROVED ||
-            isInitiativeClosed
+            {!editable || isInitiativeClosed
               ? verbiage.readOnlyEntityDetailsButtonText
               : verbiage.enterEntityDetailsButtonText}
           </Button>
@@ -183,7 +178,6 @@ export const EntityRow = ({
               sx={sx.deleteButton}
               data-testid="delete-entity"
               onClick={() => openDeleteEntityModal(entity)}
-              disabled={locked || !userIsEndUser}
             >
               <Image src={deleteIcon} alt="delete icon" boxSize="3x3" />
             </Button>
@@ -268,7 +262,7 @@ const sx = {
     marginRight: "0.4rem",
     marginBottom: "0.25rem",
     background: "white",
-    "&:hover, &:hover:disabled": {
+    "&:hover, &:hover:disabled, :disabled": {
       background: "white",
     },
   },

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -42,6 +42,7 @@ export interface MfpReportState {
   lastSavedTime: string | undefined;
   workPlanToCopyFrom: ReportShape | undefined;
   autosaveState: boolean;
+  editable: boolean;
   // ACTIONS
   setReport: (newReport: ReportShape | undefined) => void;
   setReportsByState: (
@@ -54,6 +55,7 @@ export interface MfpReportState {
   setLastSavedTime: (lastSavedTime: string | undefined) => void;
   setWorkPlanToCopyFrom: (planToCopy: ReportShape | undefined) => void;
   setAutosaveState: (state: boolean) => void;
+  setEditable: (state: boolean) => void;
 }
 
 // initial entity state

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -67,6 +67,7 @@ const reportStore = (set: Function) => ({
   lastSavedTime: undefined,
   workPlanToCopyFrom: undefined,
   autosaveState: false,
+  editable: true,
   // actions
   setReport: (newReport: ReportShape | undefined) =>
     set(() => ({ report: newReport }), false, { type: "setReport" }),
@@ -97,6 +98,10 @@ const reportStore = (set: Function) => ({
   setAutosaveState: (state: boolean) =>
     set(() => ({ autosaveState: state }), false, {
       type: "setAutosaveState",
+    }),
+  setEditable: (state: boolean) =>
+    set(() => ({ editable: state }), false, {
+      type: "setEditable",
     }),
 });
 

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -198,6 +198,7 @@ export const mockReportStore: MfpReportState = {
   lastSavedTime: "1:58 PM",
   workPlanToCopyFrom: undefined,
   autosaveState: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -205,6 +206,7 @@ export const mockReportStore: MfpReportState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
+  setEditable: () => {},
 };
 
 export const mockEntityStore: MfpEntityState = {
@@ -225,6 +227,7 @@ export const mockEmptyReportStore: MfpReportState = {
   lastSavedTime: undefined,
   workPlanToCopyFrom: undefined,
   autosaveState: false,
+  editable: true,
   setReport: () => {},
   setReportsByState: () => {},
   clearReportsByState: () => {},
@@ -232,6 +235,7 @@ export const mockEmptyReportStore: MfpReportState = {
   setLastSavedTime: () => {},
   setWorkPlanToCopyFrom: () => {},
   setAutosaveState: () => {},
+  setEditable: () => {},
 };
 
 // BOUND STORE


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This branch is to address the missing parts as well as consolidate some of the logic when differentiate edit / view mode of a report.

From Kim:
State users are the only users who can ever add, edit, delete data to the form, and only when the form is unlocked — the following statuses:
- In progress
- Not started
- In revision

All other times the form is view-only for them.
All other users (Admin, Help desk) the form itself is always view only. Admin have the ability to approve, lock/unlock, and archive/unarchive.

---
As a means to make switching between modes easier and updating, I added the tracking to the state management. When you enter the report, it checks the state it should show the form in and adjust accordingly.

[Figma for reference](https://www.figma.com/file/oOJMUZerbafZefLQQ33GwI/MFP_Playground?type=design&node-id=4952%3A46638&mode=design&t=CIlaTqXfrfFIvbN7-1)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3096
CMDCT-3095
CMDCT-3098

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP, any stateuser
2) Create a new WP
3) Go through WP filling it out. Do not submit.
4) Sign out and sign in as Admin.
5) Go to the WP you made and run through it. It should be in view mode and you should not be able to edit it.
6) Notable differences:
- Button text should change from [Edit] to [View]
- Modal Button text should change from [Save] to [Close] 
- Add / Edit/ Delete Modals will still open but the save button will be greyed out
7) Sign out of Admin and sign back in as state user
8) Submit form, it should go into view mode
9) Same for after approving the form

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
