### PR TITLE
Add some tests around completionStatus.ts

### DIFF
--- a/services/app-api/utils/types/formFields.ts
+++ b/services/app-api/utils/types/formFields.ts
@@ -65,7 +65,6 @@ export interface FormField {
   hydrate?: string;
   props?: AnyObject;
   choices?: FieldChoice[];
-  repeat?: string;
   repeatable?: Repeatable;
 }
 

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -94,37 +94,22 @@ export const calculateCompletionStatus = async (
     };
     // Iterate over all fields in form
     for (var formField of nestedFormTemplate?.fields || []) {
-      if (formField.repeat) {
-        // This is a repeated field, and must be handled differently
-        if (fieldData[formField.repeat] !== undefined)
-          for (var repeatEntity of fieldData[formField.repeat]) {
-            // Iterate over each entity from the repeat section, build new value id, and validate it
-            repeatersValid &&= await areFieldsValid({
-              [formField.id]:
-                dataForObject[`${formField.id}_${repeatEntity.id}`],
-            });
-          }
-        else {
-          repeatersValid = false;
-        }
-      } else {
-        // Key: Form Field ID, Value: Report Data for field
-        if (Array.isArray(dataForObject[formField.id])) {
-          let nestedFields: string[] = getNestedFields(
-            formField.props?.choices,
-            dataForObject[formField.id]
-          );
-          nestedFields?.forEach((nestedField: string) => {
-            fieldsToBeValidated[nestedField] = dataForObject[nestedField]
-              ? dataForObject[nestedField]
-              : null;
-          });
-        }
-
-        fieldsToBeValidated[formField.id] = dataForObject[formField.id]
-          ? dataForObject[formField.id]
-          : null;
+      // Key: Form Field ID, Value: Report Data for field
+      if (Array.isArray(dataForObject[formField.id])) {
+        let nestedFields: string[] = getNestedFields(
+          formField.props?.choices,
+          dataForObject[formField.id]
+        );
+        nestedFields?.forEach((nestedField: string) => {
+          fieldsToBeValidated[nestedField] = dataForObject[nestedField]
+            ? dataForObject[nestedField]
+            : null;
+        });
       }
+
+      fieldsToBeValidated[formField.id] = dataForObject[formField.id]
+        ? dataForObject[formField.id]
+        : null;
     }
     // Validate all fields en masse, passing flag that uses required validation schema
     return repeatersValid && (await areFieldsValid(fieldsToBeValidated));

--- a/services/ui-src/src/types/formFields.ts
+++ b/services/ui-src/src/types/formFields.ts
@@ -68,7 +68,6 @@ export interface FormField {
   hydrate?: string;
   props?: AnyObject;
   choices?: FieldChoice[];
-  repeat?: string;
 }
 
 export function isFieldElement(


### PR DESCRIPTION
### Description
This is mostly additional unit tests, but there is also some dead code removal.

MCPAR in MCR has a FormField property called `repeat`. This is distinct, and behaves differently from the MFP FormField property called `repeatable`. The `repeat` validation code only existed in MFP because it was copied from MCR, so I have removed it rather than adding tests for it.

### Related ticket(s)
n/a

---
### How to test
1. Run the unit tests
2. Verify that the only instances of `/\brepeat\b/` in the entire app are inside comments (or yarn.lock files), so there is no way the `repeat` validation code could have been doing anything.

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
