### PR TITLE
CMDCT-3118: Close-Out Initiative w/o Projected End Date (Copy Updates)

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1187,6 +1187,7 @@
                     "validation": "textOptional",
                     "props": {
                       "label": "Projected end date",
+                      "hint": "Auto-populates from “I. Define initiative”.",
                       "disabled": true
                     }
                   },

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -97,6 +97,7 @@ export const hydrateFormFields = (
   formFields.forEach((field: FormField | FormLayoutElement) => {
     const fieldFormIndex = formFields.indexOf(field!);
     const fieldProps = formFields[fieldFormIndex].props!;
+
     // check for children on each choice in field props
     if (fieldProps) {
       const choices = fieldProps.choices;
@@ -112,8 +113,23 @@ export const hydrateFormFields = (
       // if no props on field, initialize props as empty object
       formFields[fieldFormIndex].props = {};
     }
+
     // set props.hydrate
-    const fieldHydrationValue = formData?.[field.id];
+    let fieldHydrationValue = formData?.[field.id];
+
+    /**
+     * NOTE: this is an edge case specific to the MFP WP.
+     * If the Projected end date of a Close-out initiative is not entered,
+     * the value of that disabled field should be set to "No"
+     */
+    if (
+      field.id === "defineInitiative_projectedEndDate_value" &&
+      !fieldProps.hydrate &&
+      fieldProps.disabled
+    ) {
+      fieldHydrationValue = "No";
+    }
+
     formFields[fieldFormIndex].props!.hydrate = fieldHydrationValue;
   });
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR covers a couple of copy changes for when a user has selected that their Initiative has no projected end date on step `I. Define initiative`.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3118

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
In order to test this one, you'll have to simulate closing out an initiative following a few steps (shoutout to @ailZhou 👑 for putting these together). They're a lot considering this is a quick copy update, so feel free to skip 'em if you want 🙉  

- Navigate to `DashboardPage.tsx` and comment out [Line 370](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/15efc0963d87b6fc9825930f9cb3c89caedfb524/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx#L370) 

<img width="552" alt="Screenshot 2023-12-07 at 4 11 12 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/fc213201-6ec8-4a60-bdc3-0d645a8602a7">

- Navigate to `/reports/create.ts` and add the following code on [Line 181](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/15efc0963d87b6fc9825930f9cb3c89caedfb524/services/app-api/handlers/reports/create.ts#L181):

` Date.prototype.getMonth = () => {
        //if reporting period is 1, we want to generate period 2 but returning a month in the later half of the year
        return unvalidatedMetadata?.copyReport.reportPeriod === 1 ? 11 : 2;
      };
      Date.prototype.getFullYear = () => {
        //if reporting period is 1, we want to return the same year but period 2, else next year
        return unvalidatedMetadata?.copyReport.reportPeriod === 1
          ? unvalidatedMetadata?.copyReport.reportYear
          : unvalidatedMetadata?.copyReport.reportYear + 1;
      };`

<img width="928" alt="Screenshot 2023-12-07 at 4 13 39 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/c90a1bdb-9bf1-42a2-817c-8ef1abcd4f71">

Alright, now that we're half-Gallifreyan, let's get testing!

- Log in as a state user
- Create a WP
- On `I. Define initiative` make sure to selected "No" on the Projected End Date question for at least one of your initiatives
- Fill the rest of the form and submit it
- Go to the reports dashboard
- Click on the **Continue WP** button
- Navigate to your initiatives (specifically, the one you've selected "No" on the Projected End Date question for)
- Open the `V. Close-out information` step

You should see the following:

![Screenshot 2023-12-07 at 4 05 28 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/f28f8255-6507-4f3c-9837-f27425e52b2c)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
