### PR TITLE
SAR State or Territory Initiative Page

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -1396,64 +1396,45 @@
       "verbiage": {
         "intro": {
           "section": "",
-          "subsection": "State- or Territory-Specific Initiatives",
-          "accordion": {
-            "buttonLabel": "Instructions",
-            "info": [
-              {
-                "type": "span",
-                "content": "This section requests information on current, new, or expanded initiatives implemented under the MFP demonstration. These initiatives can be funded using one or more of these funding sources:"
-              },
-              {
-                "type": "ul",
-                "children": [
-                  {
-                    "type": "li",
-                    "content": "MFP cooperative agreement funds for:",
-                    "children": [
-                      {
-                        "type": "li",
-                        "content": "Qualified HCBS and demonstration services"
-                      },
-                      {
-                        "type": "li",
-                        "content": "Supplemental services"
-                      },
-                      {
-                        "type": "li",
-                        "content": "Administrative activities"
-                      },
-                      {
-                        "type": "li",
-                        "content": "Capacity building initiatives"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "li",
-                    "content": "State/Territory equivalent funds attributable to the MFP-enhanced match"
-                  }
-                ]
-              },
-              {
-                "type": "p",
-                "content": "State or territory-specific initiatives are a distinct set of activities designed to increase the use of HCBS rather than institutional long-term services and supports (LTSS). These initiatives are specified in your MFP Work Plan and imported into the form below."
-              },
-              {
-                "type": "p",
-                "content": "Recipients must report on the progress of initiatives that were ongoing during the current reporting period. For each initiative, enter information on expenditures and activities, whether continuing from prior reporting periods or initiated during this reporting period."
-              },
-              {
-                "type": "p",
-                "content": "For each initiative, recipients must also report on progress toward achieving the objective(s) identified in the MFP Work Plan. Progress towards these objectives indicates the state or territory's greater ability to provide HCBS instead of services in institutional settings. If your state or territory has not achieved the targets for performance measures or expected time frames for deliverables set in the MFP Work plan, use the following questions to explain the barriers or challenges that have hindered progress and describe plans to address them."
-              }
-            ]
-          }
+          "subsection": "State- or Territory-Specific Initiatives"
+        },
+        "accordion": {
+          "buttonLabel": "Instructions",
+          "intro": [
+            {
+              "type": "html",
+              "content": "This section requests information on current, new, or expanded initiatives implemented under the MFP demonstration. These initiatives can be funded using one or more of these funding sources:"
+            }
+          ],
+          "list": [
+            "MFP cooperative agreement funds for:",
+            [
+              "Qualified HCBS and demonstration services",
+              "Supplemental services",
+              "Administrative activities",
+              "Capacity building initiatives"
+            ],
+            "State/Territory equivalent funds attributable to the MFP-enhanced match"
+          ],
+          "text": [
+            {
+              "type": "html",
+              "content": "State or territory-specific initiatives are a distinct set of activities designed to increase the use of HCBS rather than institutional long-term services and supports (LTSS). These initiatives are specified in your MFP Work Plan and imported into the form below."
+            },
+            {
+              "type": "html",
+              "content": "<br><br>Recipients must report on the progress of initiatives that were ongoing during the current reporting period. For each initiative, enter information on expenditures and activities, whether continuing from prior reporting periods or initiated during this reporting period."
+            },
+            {
+              "type": "html",
+              "content": "<br><br>For each initiative, recipients must also report on progress toward achieving the objective(s) identified in the MFP Work Plan. Progress towards these objectives indicates the state or territory's greater ability to provide HCBS instead of services in institutional settings. If your state or territory has not achieved the targets for performance measures or expected time frames for deliverables set in the MFP Work plan, use the following questions to explain the barriers or challenges that have hindered progress and describe plans to address them."
+            }
+          ]
         },
         "enterEntityDetailsButtonText": "Edit",
         "readOnlyEntityDetailsButtonText": "View",
         "dashboardTitle": "Report progress for each initiative",
-        "dashboardSubtitle": "Initiatives and Work Plan topics are auto-populated from your most recent approved Work Plan.",
+        "dashboardSubtitle": "Initiatives and Work Plan topics are auto-populated from your most recent approved Work Plan. Note: Initiative topics with * are required topics.",
         "tableHeader": "Initiative name <br/> Work Plan topic",
         "countEntitiesInTitle": false
       },
@@ -1471,10 +1452,6 @@
             ]
           }
         }
-      },
-      "modalForm": {
-        "id": "",
-        "fields": []
       },
       "entitySteps": [
         {

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -161,7 +161,7 @@ export const createReport = handler(
     if (workPlanFieldData) {
       validatedFieldData = {
         ...validatedFieldData,
-        workPlanData: workPlanFieldData,
+        ...workPlanFieldData,
       };
     }
 

--- a/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
+++ b/services/ui-src/src/components/accordions/InstructionsAccordion.tsx
@@ -12,14 +12,24 @@ export const InstructionsAccordion = ({ verbiage, ...props }: Props) => {
     <Accordion allowToggle={true} allowMultiple={true} sx={sx.root} {...props}>
       <AccordionItem label={buttonLabel} sx={sx.item}>
         <Box sx={sx.textBox}>{parseCustomHtml(intro)}</Box>
-        <UnorderedList sx={sx.list}>
-          {list?.map((listItem: string, index: number) => (
-            <ListItem key={index}>{sanitizeAndParseHtml(listItem)}</ListItem>
-          ))}
-        </UnorderedList>
-        <Box sx={sx.textBox}>{parseCustomHtml(text)}</Box>
+        {list && parseList(list)}
+        {text && <Box sx={sx.textBox}>{parseCustomHtml(text)}</Box>}
       </AccordionItem>
     </Accordion>
+  );
+};
+
+export const parseList = (list: any) => {
+  return (
+    <UnorderedList sx={sx.list}>
+      {list?.map((listItem: string | AnyObject, index: number) =>
+        typeof listItem === "string" ? (
+          <ListItem key={index}>{sanitizeAndParseHtml(listItem)}</ListItem>
+        ) : (
+          parseList(listItem)
+        )
+      )}
+    </UnorderedList>
   );
 };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -135,6 +135,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   }, [reportsByState]);
 
   const isReportEditable = (selectedReport: ReportShape) => {
+    //the wp is only editable only when the user is a state user and the form has not been submitted or approved, all over users are in view mode
     return (
       !userIsAdmin &&
       !userIsReadOnly &&

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -50,7 +50,9 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   );
 
   if (report?.reportType === ReportType.SAR) {
-    (reportFieldDataEntities as any[]).map((entity) => (entity["true"] = true));
+    (reportFieldDataEntities as any[]).map(
+      (entity) => (entity["isCopied"] = true)
+    );
   }
 
   const showAlert =

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -26,6 +26,7 @@ import alertVerbiage from "../../verbiage/pages/wp/wp-alerts";
 // assets
 import addIcon from "assets/icons/icon_add_white.png";
 import { getWPAlertStatus } from "../alerts/getWPAlertStatus";
+import { AnyObject } from "yup/lib/types";
 
 interface AlertVerbiage {
   [key: string]: { title: string; description: string };
@@ -48,11 +49,14 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   );
 
   const showAlert =
-    report && (alertVerbiage as AlertVerbiage)[entityType]
+    report && modalForm && (alertVerbiage as AlertVerbiage)[entityType]
       ? getWPAlertStatus(report, entityType)
       : false;
 
-  const dashTitle = `${verbiage.dashboardTitle} ${reportFieldDataEntities.length}`;
+  const dashTitle = `${verbiage.dashboardTitle} ${
+    modalForm ? reportFieldDataEntities.length : ""
+  }`;
+  const dashSubTitle = (verbiage as AnyObject)?.dashboardSubtitle;
   const tableHeaders = () => {
     if (isTablet || isMobile) return { headRow: ["", ""] };
     return { headRow: ["", verbiage.tableHeader, ""] };
@@ -119,7 +123,10 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
         </EntityProvider>
       ) : (
         <Box sx={sx.content}>
-          <ReportPageIntro text={verbiage.intro} />
+          <ReportPageIntro
+            text={verbiage.intro}
+            accordion={verbiage.accordion}
+          />
           {showAlert && (
             <Alert
               title={(alertVerbiage as AlertVerbiage)[route.entityType].title}
@@ -132,6 +139,9 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
           <Box>
             <Heading as="h3" sx={sx.dashboardTitle}>
               {dashTitle}
+            </Heading>
+            <Heading as="h2" sx={sx.subsectionHeading}>
+              {dashSubTitle}
             </Heading>
             {reportFieldDataEntities.length === 0 ? (
               <Box>{verbiage.emptyDashboardText}</Box>
@@ -151,26 +161,32 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
                 ))}
               </Table>
             )}
-            <Button
-              sx={sx.addEntityButton}
-              onClick={() => openAddEditEntityModal()}
-              rightIcon={<Image src={addIcon} alt="Previous" sx={sx.addIcon} />}
-            >
-              {verbiage.addEntityButtonText}
-            </Button>
+            {modalForm && (
+              <Button
+                sx={sx.addEntityButton}
+                onClick={() => openAddEditEntityModal()}
+                rightIcon={
+                  <Image src={addIcon} alt="Previous" sx={sx.addIcon} />
+                }
+              >
+                {verbiage.addEntityButtonText}
+              </Button>
+            )}
           </Box>
           {/* Modals */}
-          <AddEditEntityModal
-            entityType={entityType}
-            selectedEntity={selectedEntity}
-            verbiage={verbiage}
-            form={modalForm}
-            setError={() => {}}
-            modalDisclosure={{
-              isOpen: addEditEntityModalIsOpen,
-              onClose: closeAddEditEntityModal,
-            }}
-          />
+          {modalForm && (
+            <AddEditEntityModal
+              entityType={entityType}
+              selectedEntity={selectedEntity}
+              verbiage={verbiage}
+              form={modalForm}
+              setError={() => {}}
+              modalDisclosure={{
+                isOpen: addEditEntityModalIsOpen,
+                onClose: closeAddEditEntityModal,
+              }}
+            />
+          )}
           <DeleteEntityModal
             entityType={entityType}
             selectedEntity={selectedEntity}
@@ -207,6 +223,16 @@ const sx = {
     ".tablet &, .mobile &": {
       paddingBottom: "0",
     },
+  },
+  subsectionHeading: {
+    fontSize: "md",
+    fontWeight: "normal",
+    color: "palette.gray_medium_dark",
+    textAlign: "left",
+    ".tablet &, .mobile &": {
+      paddingBottom: "0",
+    },
+    paddingBottom: "1rem",
   },
   table: {
     tableLayout: "fixed",

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -18,6 +18,7 @@ import {
   EntityShape,
   ModalOverlayReportPageShape,
   EntityDetailsDashboardOverlayShape,
+  ReportType,
 } from "types";
 // utils
 import { resetClearProp, useBreakpoint, useStore } from "utils";
@@ -47,6 +48,10 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   (reportFieldDataEntities as any[]).map(
     (entity) => (entity["isOtherEntity"] = true)
   );
+
+  if (report?.reportType === ReportType.SAR) {
+    (reportFieldDataEntities as any[]).map((entity) => (entity["true"] = true));
+  }
 
   const showAlert =
     report && (alertVerbiage as AlertVerbiage)[entityType]

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -49,7 +49,7 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   );
 
   const showAlert =
-    report && modalForm && (alertVerbiage as AlertVerbiage)[entityType]
+    report && (alertVerbiage as AlertVerbiage)[entityType]
       ? getWPAlertStatus(report, entityType)
       : false;
 

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -18,7 +18,7 @@ export const getValidationList = (fields: AnyObject[], entity: AnyObject) => {
   const fieldsNestedChoices = fields
     .flatMap((field) => {
       validationIdList.push(field.id);
-      if (field.props.choices) {
+      if (field.props?.choices) {
         return field.props.choices;
       }
     })
@@ -105,9 +105,9 @@ export const getInitiativeStatus = (
   //get the intiative report child
   const reportChild: EntityDetailsDashboardOverlayShape = (
     reportRoute?.children! as EntityDetailsOverlayShape[]
-  ).find((child) => child.entityType === OverlayModalTypes.INITIATIVE)!;
+  )?.find((child) => child.entityType === OverlayModalTypes.INITIATIVE)!;
 
-  if (reportChild.entitySteps) {
+  if (reportChild?.entitySteps) {
     const entitySteps: (EntityDetailsOverlayShape | OverlayModalPageShape)[] =
       reportChild.entitySteps;
 

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -51,7 +51,7 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
   } else {
     elementArray = element;
     // handle arrays of custom element objects
-    return elementArray.map((element: CustomHtmlElement) => {
+    return elementArray?.map((element: CustomHtmlElement) => {
       let { type, content, as, props } = element;
       const elementType: string = customElementMap[type] || type;
       const elementProps = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Changed the data structure of how we saved WP data in SAR so that the State- or Territory-Specific Initiatives page will render in SAR and cleaned up some of the text rendering.

The logic for ModalOverlayReport page is if there's no modal being used, certain items won't render or display.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-32

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP, any state user
2) Fill out a WP and submit it
3) Create a SAR
4) In the SAR, select State-or-Territory Initiative 
5) Check to see that the page renders with the initiative from the WP and looks more or less like this: https://www.figma.com/file/oOJMUZerbafZefLQQ33GwI/MFP_Playground?type=design&node-id=21-4592&mode=design&t=B0BP0dH3mJg0ylWY-4

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
