### PR TITLE
Adding Flag to Toggle Copy Over Testing

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -119,7 +119,10 @@ export const createReport = handler(
       unvalidatedPayload;
 
     //override the date in the system to generate the next report based on the previous reporting period. adding flag to turn it on and off
-    if (unvalidatedMetadata?.copyReport) {
+    if (
+      unvalidatedMetadata?.copyReport &&
+      unvalidatedMetadata?.copyReport?.isCopyOverTest
+    ) {
       overriderDate(unvalidatedMetadata?.copyReport);
     }
 

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -41,7 +41,7 @@ import {
 import { getOrCreateFormTemplate } from "../../utils/formTemplates/formTemplates";
 import { logger } from "../../utils/logging";
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { copyFieldDataFromSource } from "../../utils/other/copy";
+import { copyFieldDataFromSource, overriderDate } from "../../utils/other/copy";
 
 export const createReport = handler(
   async (event: APIGatewayProxyEvent, _context) => {
@@ -117,6 +117,11 @@ export const createReport = handler(
     const unvalidatedPayload = JSON.parse(event.body!);
     const { metadata: unvalidatedMetadata, fieldData: unvalidatedFieldData } =
       unvalidatedPayload;
+
+    //override the date in the system to generate the next report based on the previous reporting period. adding flag to turn it on and off
+    if (unvalidatedMetadata?.copyReport) {
+      overriderDate(unvalidatedMetadata?.copyReport);
+    }
 
     const creationValidationJson = {
       reportPeriod: "text",

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -105,3 +105,18 @@ function pruneEntityData(
     delete sourceFieldData[key];
   }
 }
+
+export function overriderDate(copyReport:AnyObject){
+  if (copyReport) {
+    Date.prototype.getMonth = () => {
+      //if reporting period is 1, we want to generate period 2 but returning a month in the later half of the year
+      return copyReport.reportPeriod === 1 ? 11 : 2;
+    };
+    Date.prototype.getFullYear = () => {
+      //if reporting period is 1, we want to return the same year but period 2, else next year
+      return copyReport.reportPeriod === 1
+        ? copyReport.reportYear
+        : (copyReport.reportYear + 1);
+    };
+  }
+}

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -106,7 +106,7 @@ function pruneEntityData(
   }
 }
 
-export function overriderDate(copyReport:AnyObject){
+export function overriderDate(copyReport: AnyObject) {
   if (copyReport) {
     Date.prototype.getMonth = () => {
       //if reporting period is 1, we want to generate period 2 but returning a month in the later half of the year
@@ -116,7 +116,7 @@ export function overriderDate(copyReport:AnyObject){
       //if reporting period is 1, we want to return the same year but period 2, else next year
       return copyReport.reportPeriod === 1
         ? copyReport.reportYear
-        : (copyReport.reportYear + 1);
+        : copyReport.reportYear + 1;
     };
   }
 }

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -9,6 +9,7 @@ import sarFormJson from "forms/addEditSarReport/addEditSarReport.json";
 import { AnyObject, FormJson, ReportStatus, ReportType } from "types";
 import { States } from "../../constants";
 import { injectFormWithTargetPopulations, useStore } from "utils";
+import { useFlags } from "launchdarkly-react-client-sdk";
 
 export const AddEditReportModal = ({
   activeState,
@@ -38,6 +39,9 @@ export const AddEditReportModal = ({
 
   const modalFormJson = modalFormJsonMap[reportType]!;
   const form: FormJson = modalFormJson;
+
+  //temporary flag for testing copyover
+  const isCopyOverTest = useFlags()?.isCopyOverTest;
 
   // WP report payload
   const prepareWpPayload = () => {
@@ -72,6 +76,11 @@ export const AddEditReportModal = ({
         isRequired: true,
       },
     ];
+
+    //add a flag to be passed to the backend for copy over testing
+    if (previousReport) {
+      previousReport.isCopyOverTest = isCopyOverTest;
+    }
 
     return {
       metadata: {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -246,19 +246,6 @@ export const DashboardPage = ({ reportType }: Props) => {
         if (!previousReport) {
           return false;
         } else {
-          /** turning this off atm for testing copy over
-           * const currentDate = new Date();
-           * const period = currentDate.getMonth() + 1 > 6 ? 2 : 1;
-           * const year = currentDate.getFullYear();
-           * const isNextPeriod =
-           *  year > previousReport.reportYear ||
-           *  (year === previousReport.reportYear &&
-           *  period > previousReport.reportPeriod);
-           *  return (
-           *    previousReport.status !== ReportStatus.APPROVED || !isNextPeriod
-           *  );
-           **/
-
           return previousReport.status !== ReportStatus.APPROVED;
         }
       default:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A request by design to be able to toggle the testing for copy over on and off. It will generate the next report based on the previous report whenever the previous report is Approved.

@karla-vm helped me create a flag and its turned on in dev. 

The flag is not turned on locally so you'll have to turn it on manually in the code.

In AddEditReportModal.tsx line 44, check isCOpyOverTest to equal true
<img width="505" alt="Screenshot 2023-12-11 at 12 41 32 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/bdab1bb9-08ea-4302-87cb-6d187c74a7ac">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Change code in script first
2) Sign into MFP as a state user.
3) Create a new WP
4) Fill out the form and submit
5) Go into admin an approve
6) Go back to state user and you should be able to create a new form.
7) Process should be repeatable.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
