### PR TITLE
Add Not Applicable Option to Target Pop. Choice List

### DIFF
--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -321,7 +321,7 @@ export const updateRenderFields = (
 ) => {
   const targetPopulations = report?.fieldData?.targetPopulations;
 
-  const notApplicablePopulation = {
+  const notApplicableOption = {
     id: "3Nc13O5GHA6Hc4KheO5FMSD2",
     transitionBenchmarks_targetPopulationName: "Not applicable",
     type: "targetPopulations",
@@ -331,7 +331,7 @@ export const updateRenderFields = (
   const filteredTargetPopulations =
     removeNotApplicablePopulations(targetPopulations);
 
-  filteredTargetPopulations?.push(notApplicablePopulation);
+  filteredTargetPopulations?.push(notApplicableOption);
 
   const formatChoiceList = convertTargetPopulationsFromWPToSAREntity(
     filteredTargetPopulations

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -252,15 +252,28 @@ export const resetClearProp = (fields: (FormField | FormLayoutElement)[]) => {
   });
 };
 
+export const formatOtherTargetPopulationChoices = (field: AnyObject) => {
+  const defaultTargetPopulations = [
+    "Older adults",
+    "Individuals with physical disabilities (PD)",
+    "Individuals with intellectual and developmental disabilities (I/DD)",
+    "Individuals with mental health and substance use disorders (MH/SUD)",
+    "Not applicable",
+  ];
+  return defaultTargetPopulations.includes(
+    field.transitionBenchmarks_targetPopulationName
+  )
+    ? field.transitionBenchmarks_targetPopulationName
+    : `Other: ${field.transitionBenchmarks_targetPopulationName}`;
+};
+
 export const convertEntityToTargetPopulationChoice = (
   entity: EntityShape[]
 ) => {
   return entity?.map((field: EntityShape) => {
     return {
       key: `targetPopulations-${field.id}`,
-      value: field.isRequired
-        ? field.transitionBenchmarks_targetPopulationName
-        : `Other: ${field.transitionBenchmarks_targetPopulationName}`,
+      value: formatOtherTargetPopulationChoices(field),
     };
   });
 };
@@ -295,13 +308,9 @@ export const convertTargetPopulationsFromWPToSAREntity = (
   return targetPopulations?.map((field: AnyObject) => {
     return {
       id: `targetPopulations-${field.id}`,
-      label: field.isRequired
-        ? field.transitionBenchmarks_targetPopulationName
-        : `Other: ${field.transitionBenchmarks_targetPopulationName}`,
+      label: formatOtherTargetPopulationChoices(field),
       name: field.transitionBenchmarks_targetPopulationName,
-      value: field.isRequired
-        ? field.transitionBenchmarks_targetPopulationName
-        : `Other: ${field.transitionBenchmarks_targetPopulationName}`,
+      value: formatOtherTargetPopulationChoices(field),
     };
   });
 };
@@ -311,8 +320,18 @@ export const updateRenderFields = (
   fields: (FormField | FormLayoutElement)[]
 ) => {
   const targetPopulations = report?.fieldData?.targetPopulations;
-  const filteredTargetPopulations =
-    removeNotApplicablePopulations(targetPopulations);
+
+  const notApplicablePopulation = {
+    id: "3Nc13O5GHA6Hc4KheO5FMSD2",
+    transitionBenchmarks_targetPopulationName: "Not applicable",
+    type: "targetPopulations",
+    isRequired: false,
+  };
+
+  const filteredTargetPopulations = new Array(
+    ...removeNotApplicablePopulations(targetPopulations),
+    notApplicablePopulation
+  );
   const formatChoiceList = convertTargetPopulationsFromWPToSAREntity(
     filteredTargetPopulations
   );

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -328,10 +328,11 @@ export const updateRenderFields = (
     isRequired: false,
   };
 
-  const filteredTargetPopulations = new Array(
-    ...removeNotApplicablePopulations(targetPopulations),
-    notApplicablePopulation
-  );
+  const filteredTargetPopulations =
+    removeNotApplicablePopulations(targetPopulations);
+
+  filteredTargetPopulations?.push(notApplicablePopulation);
+
   const formatChoiceList = convertTargetPopulationsFromWPToSAREntity(
     filteredTargetPopulations
   );


### PR DESCRIPTION
### Description
Adding "Not Applicable" option to the target populations choice list. 

<img width="689" alt="Screenshot 2023-12-11 at 4 54 38 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/0fc0d216-641d-4deb-831f-ffc118112e5c">


### Related ticket(s)
[CMDCT-](https://jiraent.cms.gov/browse/CMDCT-3109)

---
### How to test
1. Create a report 
2. Go to 'State- or Territory-Specific Initiatives' and create and edit a initiative
3. Edit 'I. Define initiative'
4. In the Target population(s) choice list you should see the 'Not applicable' option.




### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
