### PR TITLE
Fix Define Initiative end date not populated error

### DIFF
--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -123,7 +123,7 @@ export const hydrateFormFields = (
      * the value of the V. Close-out initiative disabled field should be set to "No"
      */
     if (
-      formData?.["defineInitiative_projectedEndDate"]?.[0].value === "No" &&
+      formData?.["defineInitiative_projectedEndDate"]?.[0]?.value === "No" &&
       field.id === "defineInitiative_projectedEndDate_value" &&
       !fieldProps.hydrate &&
       fieldProps.disabled


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Report was crashing when skipping a question because it performed a check on the empty field without null handling
Video of bug in action (tab through Define Initiative and skip the radio options for end date)
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/fadceadb-bce1-4345-90c5-3ea540b25edf

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3124

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Do the same steps in this branch and verify that it doesn't crash
- Create an initiative
- Go to Define Initative
- **TAB THROUGH** each option, skipping the final radio and hitting spacebar on "Save & Return"
- Verify it triggers validation on the radio instead of crashing

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---