### PR TITLE
Make funding source and objectives modals match view only experience

### DIFF
--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -184,15 +184,10 @@ export const AddEditOverlayEntityModal = ({
         subheading: verbiage.addEditModalHint
           ? verbiage.addEditModalHint
           : undefined,
-        actionButtonText: submitting ? (
-          <Spinner size="md" />
-        ) : !userDisabled ? (
-          "Save"
-        ) : (
-          "Close"
-        ),
+        actionButtonText: submitting ? <Spinner size="md" /> : "Save",
         closeButtonText: "Cancel",
       }}
+      submitButtonDisabled={userDisabled}
     >
       <Form
         data-testid="add-edit-entity-form"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
As per design we want the view only experience for these modals to have the "Save" button disabled, rather than changing the text and enabling it.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3132

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Sign in as a state user
- Create a WP
- Create an initiative
- In the initiative, create an objective and a funding source
- Logout
- Sign in as an admin
- View the initiative you created and verify the objective and funding source modals have a "Save" button that is disabled

---
### Author checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
---