### PR TITLE
Make not applicable target populations show as NA in export

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -42,10 +42,16 @@ export const ExportedModalDrawerReportSection = ({
   // creates arrays of 'only' quarterly values
   const quarterValueArray = entities.map((entity: AnyObject) => {
     let quarterArray = [];
-    for (const key in entity) {
-      // push key values into quarterArray that are quarters
-      if (key.includes("quarterly")) {
-        quarterArray.push(entity[key]);
+
+    if (
+      entity?.transitionBenchmarks_applicableToMfpDemonstration?.[0].value !==
+      "No"
+    ) {
+      for (const key in entity) {
+        // push key values into quarterArray that are quarters
+        if (key.includes("quarterly")) {
+          quarterArray.push(entity[key]);
+        }
       }
     }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Target Populations that were marked as Not Applicable were showing up in red and marked as No Answer. Changed to black and marked as N/A

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3129

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create a work plan
Go to Target Populations
Edit one and mark it as Not Applicable (Answer No)
Check the PDF to see that its black and marked as N/A
Create a new Target Population
Edit one and mark it as Not Applicable (Answer No)
Check the PDF to see that its black and marked as N/A

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
