### PR TITLE
Admin Unlock Bugs

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -238,7 +238,7 @@ describe("Test WP Admin Report Dashboard View (with reports, desktop view, mobil
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[0];
+      const unlockButton = screen.getAllByText("Unlock")[1];
       expect(unlockButton).toBeVisible();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
@@ -277,7 +277,7 @@ describe("Test WP Admin Report Dashboard View (with reports, desktop view, mobil
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[0];
+      const unlockButton = screen.getAllByText("Unlock")[1];
       expect(unlockButton).toBeVisible();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -224,9 +224,7 @@ const AdminReleaseButton = ({
     report.archived,
     report.submissionCount
   );
-  const isDisabled = !(
-    reportStatus === "Submitted" || reportStatus === "Approved"
-  );
+  const isDisabled = !(reportStatus === "Submitted");
 
   return (
     <Td>

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -188,9 +188,7 @@ const AdminReleaseButton = ({
     report.archived,
     report.submissionCount
   );
-  const isDisabled = !(
-    reportStatus === "Submitted" || reportStatus === "Approved"
-  );
+  const isDisabled = !(reportStatus === "Submitted");
 
   return (
     <Button

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
@@ -230,16 +230,11 @@ const sx = {
   },
   adminUnlockBtn: {
     marginRight: "1rem",
-    "&:disabled": {
+    "&disabled": {
       opacity: 1,
       background: "white",
       color: "palette.gray_lighter",
       borderColor: "palette.gray_lighter",
-    },
-    "&disabled:hover": {
-      opacity: 1,
-      background: "white",
-      color: "palette.gray_lighter",
     },
   },
   adminApproveBtn: {

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -192,8 +192,7 @@ export const ReportProvider = ({ children }: Props) => {
 
   const releaseReport = async (reportKeys: ReportKeys) => {
     try {
-      const result = await releaseReportRequest(reportKeys);
-      hydrateAndSetReport(result);
+      await releaseReportRequest(reportKeys);
     } catch (e: any) {
       setError(reportErrors.SET_REPORT_FAILED);
     }

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -67,6 +67,7 @@ export const ReportProvider = ({ children }: Props) => {
   } = useStore();
 
   const { state: userState } = useStore().user ?? {};
+  const { setEditable } = useStore();
 
   const hydrateAndSetReport = (report: ReportShape | undefined) => {
     if (report) {
@@ -204,6 +205,9 @@ export const ReportProvider = ({ children }: Props) => {
     hydrateAndSetReport(undefined);
     setLastSavedTime(undefined);
     localStorage.setItem("selectedReport", "");
+
+    //reset editable state when report selection is cleared
+    setEditable(true);
   };
 
   const setReportSelection = async (report: ReportShape) => {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -106,6 +106,31 @@ export const mockWPFullReport = {
   reportYear: 2023,
 };
 
+export const mockWPSubmittedReport = {
+  ...mockReportKeys,
+  reportType: "WP",
+  formTemplate: mockReportJson,
+  submissionName: "2023 - Alabama 1",
+  status: ReportStatus.SUBMITTED,
+  dueDate: 168515200000,
+  createdAt: 162515200000,
+  lastAltered: 162515200000,
+  lastAlteredBy: "Thelonious States",
+  submittedOnDate: Date.now(),
+  fieldData: mockReportFieldData,
+  completionStatus: {
+    "/mock/mock-route-1": true,
+    "/mock/mock-route-2": {
+      "/mock/mock-route-2a": false,
+      "/mock/mock-route-2b": true,
+      "/mock/mock-route-2c": true,
+    },
+  },
+  isComplete: true,
+  reportPeriod: 1,
+  reportYear: 2023,
+};
+
 export const mockWPApprovedFullReport = {
   ...mockReportKeys,
   reportType: "WP",

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -16,7 +16,11 @@ import {
 } from "types";
 // utils
 import { mockBannerData } from "./mockBanner";
-import { mockWPApprovedFullReport, mockWPFullReport } from "./mockReport";
+import {
+  mockWPApprovedFullReport,
+  mockWPSubmittedReport,
+  mockWPFullReport,
+} from "./mockReport";
 
 // GLOBALS
 
@@ -193,7 +197,11 @@ export const mockBannerStore: AdminBannerState = {
 
 export const mockReportStore: MfpReportState = {
   report: mockWPFullReport as ReportShape,
-  reportsByState: [mockWPFullReport, mockWPApprovedFullReport],
+  reportsByState: [
+    mockWPFullReport,
+    mockWPSubmittedReport,
+    mockWPApprovedFullReport,
+  ],
   submittedReportsByState: [mockWPFullReport],
   lastSavedTime: "1:58 PM",
   workPlanToCopyFrom: undefined,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
A couple of issues with the admin unlock feature.

All of this is happening on the Admin dashboard
_1) Approved WP was still unlockable, which should not be the case._
Fix: I thought approved was an unlockable state, just needed to remove the check.

_2) Admin state selector page became view only after going to a view only WP._
Fix: The editable state management did not update after exiting the WP so any button / fields was stuck in the previous state.

_3) An error message pops up when unlocking a WP from the dashboard, there should be no error message_
Fix: There was a call for hydrating in the api call which does not exist in MCR unlock and also passed in an empty report. Removed because it looked to be an accident that was causing us to get an error. If this is not okay, please let me know!

_4) In Review and Submit page, the disabled unlock button has a hover state_
Fix: The css selector had an extra character in it and a hover state. Both were removed.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3127

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP, any state user
2) Fill out a WP and submit
3) Sign out and sign in as admin
4) Unlock the WP, there should be no error message (item 3)
5) View the WP and go into the review & submit, check if the Unlock button has a hover state. (it should not) (item 4)
6) Sign back in as the stateuser and resubmit
7) Go back to admin and approve the WP. Unlock should be disabled (item 1)
8) At the top left corner of the page click [Return home] and you should be able to select other states (item 2)

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
