### PR TITLE
CMDCT-3128: [PDF] Statusing Fix for WP Initiatives on Export

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -32,7 +32,7 @@ import unfinishedIcon from "assets/icons/icon_error_circle_bright.png";
 import finishedIcon from "assets/icons/icon_check_circle.png";
 // utils
 import { getWPAlertStatus } from "components/alerts/getWPAlertStatus";
-import { getInitiativeStatus } from "components/tables/getEntityStatus";
+import { getEntityStatus } from "components/tables/getEntityStatus";
 
 const exportVerbiageMap: { [key in ReportType]: any } = {
   WP: wpVerbiage,
@@ -149,6 +149,7 @@ export function renderModalOverlayTableBody(
   switch (reportType) {
     case ReportType.WP:
       return entities.map((entity, idx) => {
+        // console.log("entity", entity);
         return (
           <Box sx={sx.container}>
             <Tr key={idx}>
@@ -156,7 +157,7 @@ export function renderModalOverlayTableBody(
                 <EntityStatusIcon
                   entity={entity}
                   isPdf={true}
-                  entityStatus={getInitiativeStatus(report, entity)}
+                  entityStatus={getEntityStatus(report, entity, entity.type)}
                 />
               </Td>
               <Td>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The Work Plan initiatives status was not being populated correctly on the PDF export.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3128

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Complete an initiative

Upon export, verify that the status for a completed initiative is showing the green check-mark ✅ 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
