### PR TITLE
UI Updates pt 2

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -208,7 +208,10 @@
             "type": "textarea",
             "validation": "text",
             "props": {
-              "label": "Please provide additional detail on strategies or approaches the state or territory will use to achieve transition targets here and through a required state or territory specific initiative."
+              "label": "Please provide additional detail on strategies or approaches the state or territory will use to achieve transition targets here and through a required state or territory specific initiative.",
+              "style": {
+                "marginBottom": "2.5rem"
+              }
             }
           }
         ]

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -209,9 +209,7 @@
             "validation": "text",
             "props": {
               "label": "Please provide additional detail on strategies or approaches the state or territory will use to achieve transition targets here and through a required state or territory specific initiative.",
-              "style": {
-                "marginBottom": "2.5rem"
-              }
+              "className": "tbs-bottom-margin"
             }
           }
         ]

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -12,7 +12,7 @@ export const EntityStepCardTopSection = ({
     case OverlayModalStepTypes.EVALUATION_PLAN:
       return (
         <>
-          <Heading as="h4" sx={sx.heading}>
+          <Heading sx={sx.mainHeading}>
             {formattedEntityData.objectiveName}
           </Heading>
           <Text sx={sx.subtitle}>
@@ -65,7 +65,7 @@ export const EntityStepCardTopSection = ({
     case OverlayModalStepTypes.FUNDING_SOURCES:
       return (
         <>
-          <Heading as="h3" sx={sx.heading}>
+          <Heading sx={sx.mainHeading}>
             {formattedEntityData.fundingSource}
           </Heading>
           {formattedEntityData.quarters.length > 0 && (
@@ -107,6 +107,9 @@ interface Props {
 }
 
 const sx = {
+  mainHeading: {
+    fontSize: "md",
+  },
   heading: {
     fontSize: "sm",
   },

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -140,6 +140,9 @@ interface Props {
 }
 
 const sx = {
+  ".tbs-bottom-margin": {
+    marginBottom: "2.5rem",
+  },
   // default
   ".ds-c-field, .ds-c-label": {
     maxWidth: "32rem",

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -33,16 +33,14 @@ export const DashboardTable = ({
       <Tr key={report.id}>
         {/* Edit Button */}
         {isStateLevelUser &&
-        !report?.locked &&
-        reportType === ReportType.SAR ? (
-          <EditReportButton
-            report={report}
-            openAddEditReportModal={openAddEditReportModal}
-            sxOverride={sxOverride}
-          />
-        ) : (
-          <Td></Td>
-        )}
+          !report?.locked &&
+          reportType === ReportType.SAR && (
+            <EditReportButton
+              report={report}
+              openAddEditReportModal={openAddEditReportModal}
+              sxOverride={sxOverride}
+            />
+          )}
         {/* Report Name */}
         {reportType === ReportType.WP ? (
           <Td sx={sxOverride.wpSubmissionNameText}>{report.submissionName}</Td>
@@ -305,7 +303,6 @@ const sx = {
         paddingRight: 0,
       },
       "&:first-of-type": {
-        width: "2rem",
         minWidth: "2rem",
       },
     },

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -113,9 +113,6 @@ export const OverlayModalPage = ({
         />
       )}
       <Box>
-        <Heading as="h3" sx={sx.dashboardTitle}>
-          {dashTitle}
-        </Heading>
         <Button
           sx={sx.addEntityButton}
           onClick={addEditEntityModalOnOpenHandler}
@@ -123,6 +120,9 @@ export const OverlayModalPage = ({
         >
           {verbiage.addEntityButtonText}
         </Button>
+        <Heading as="h3" sx={sx.dashboardTitle}>
+          {dashTitle}
+        </Heading>
         <Box>
           {reportFieldDataEntities?.map(
             (entity: EntityShape, entityIndex: number) => (
@@ -219,13 +219,13 @@ const sx = {
   },
   dashboardTitle: {
     paddingTop: "1rem",
-    paddingBottom: "0",
+    marginBottom: "1rem",
     fontWeight: "bold",
     color: "palette.gray_medium",
   },
   addEntityButton: {
     marginTop: "1.5rem",
-    marginBottom: "2rem",
+    marginBottom: "1rem",
   },
   buttonFlex: {
     justifyContent: "end",

--- a/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
@@ -7,7 +7,6 @@ export default {
     table: {
       caption: "WP Programs",
       headRow: [
-        "",
         "Submission name",
         "Due date",
         "Last edited",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
addressed more UI issues from the QA doc - these updates have been reviewed and approved by Kim

- Addressed left alignment in WP submission dashboard  (admin SAR view will be addressed in CMDCT-3137)
<img width="1041" alt="Screenshot 2023-12-12 at 2 15 31 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/f1908833-97ac-42fd-8317-3354537f5672">

------------------------------------------------------------------

- place AddEntityButton above the dashboardTitle in the Evaluation and Funding pages
<img width="935" alt="Screenshot 2023-12-14 at 11 30 16 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/c9c528e2-069e-4fab-a2c0-cce36907f94d">

------------------------------------------------------------------

- update funding and evaluation card headers to be 16px, and spacing
![Screenshot 2023-12-14 at 4 50 00 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/a3e8cdae-ee15-42f0-b5e8-7d494d942104)

------------------------------------------------------------------

- add 2.5rem of space between footer and transition benchmark strategy form
![Screenshot 2023-12-14 at 4 35 18 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/6b15e3a6-b519-4091-89bf-3c62171a59db)

------------------------------------------------------------------

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3125

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- go to the pages where these items are and compare them against the Figma doc


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
