### PR TITLE
Remove props spread from report footer to avoid console errors

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -30,7 +30,7 @@ export const ReportPageFooter = ({
       : "Continue";
 
   return (
-    <Box sx={sx.footerBox} {...props}>
+    <Box sx={sx.footerBox}>
       <Box>
         <Flex sx={hidePrevious ? sx.floatButtonRight : sx.buttonFlex}>
           {!hidePrevious && (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Page one of the WP was generating a console error because of `praDisclosure` being spread as a property into the ReportPageFooter

If you do a search in the repository for `<ReportPageFooter` the results indicate there is never a case where we pass in unexpected props (not in Props for that component) we want to spread

Removing this spread eliminates this issue.

We could even go further to declare `praDisclosure` in the Props definition for ReportPageFooter and remove the `[key: string]: any` only used for that property. Let me know if you want to go that course.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- On branch `main`
- Log in as a state user
- Create a WP
- Open your console and clear it
- Click "Edit" to enter the WP
- Verify there is a console error about `praDisclosure`
- Switch to this branch `pra-console-error`
- Leave the form, clear the console, re-enter the form
- Verify the same error does not come up

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---