### PR TITLE
fix first child console error in footer

### DIFF
--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -237,7 +237,7 @@ const sx = {
   link: {
     margin: "0.5rem 0",
     ".desktop &": {
-      "&:first-child": {
+      "&:first-of-type": {
         paddingRight: ".5rem",
         borderRight: "1px solid",
         borderColor: "palette.white",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The page footer was creating a console error related to using `:first-child` in the styling for links.

The top answer in [this stack overflow post](https://stackoverflow.com/a/24657721) does a pretty good job explaining the difference between these selectors. In this use case it does not matter that they don't work exactly the same because they do the same thing when applied here.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- On branch `main`
- Before logging in open the console
- Log in as a state user
- Verify that an error about `:first-child` shows up in the console
- Switch to this branch `fix-first-el-error`
- Logout and relog in with the console open
- Verify the same error does not come up
- Verify the "Contact Us | Accessibility Statement" links in the footer look the same (spacing, bar between, etc.)
  - You can change the selector in Footer.tsx back and forth to check

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---