### PR TITLE
main -> val (sprint #49, part 2)

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -625,12 +625,7 @@
                 },
                 {
                   "type": "html",
-                  "content": "<br>If a recipient updates the MFP Work Plan to indicate that an initiative will no longer be sustained with MFP funding or state or territory-equivalent funding, the recipient must explain whether the initiative will be terminated or sustained through another funding source.<br><br>",
-                  "props": {
-                    "style": {
-                      "paddingBottom": "2rem"
-                    }
-                  }
+                  "content": "<br>If a recipient updates the MFP Work Plan to indicate that an initiative will no longer be sustained with MFP funding or state or territory-equivalent funding, the recipient must explain whether the initiative will be terminated or sustained through another funding source.<br><br>"
                 },
                 {
                   "type": "text",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1057,7 +1057,7 @@
                     "validation": "radio",
                     "props": {
                       "label": "Does the performance measure include quantitative targets?",
-                      "hint": "Note: If 'Yes', fields use calendar year quarters.",
+                      "hint": "Note: If 'Yes', fields use calendar year quarters.  Enter N/A for quarters you do not expect to report.",
                       "choices": [
                         {
                           "id": "UL4dAeyyvCFAXttxZioacR",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -208,7 +208,8 @@
             "type": "textarea",
             "validation": "text",
             "props": {
-              "label": "Please provide additional detail on strategies or approaches the state or territory will use to achieve transition targets here and through a required state or territory specific initiative."
+              "label": "Please provide additional detail on strategies or approaches the state or territory will use to achieve transition targets here and through a required state or territory specific initiative.",
+              "className": "tbs-bottom-margin"
             }
           }
         ]

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -52,14 +52,14 @@ export const updateReport = handler(async (event, context) => {
     };
   }
 
-  // Blacklisted keys
-  const metadataBlacklist = [
+  // Blocklisted keys
+  const metadataBlocklist = [
     "submittedBy",
     "submittedOnDate",
     "locked",
     "archive",
   ];
-  const fieldDataBlacklist = [
+  const fieldDataBlocklist = [
     "submitterName",
     "submitterEmailAddress",
     "reportSubmissionDate",
@@ -70,11 +70,11 @@ export const updateReport = handler(async (event, context) => {
     if (
       (eventBody.metadata &&
         Object.keys(eventBody.metadata).some((_) =>
-          metadataBlacklist.includes(_)
+          metadataBlocklist.includes(_)
         )) ||
       (eventBody.fieldData &&
         Object.keys(eventBody.fieldData).some((_) =>
-          fieldDataBlacklist.includes(_)
+          fieldDataBlocklist.includes(_)
         ))
     ) {
       return {

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -12,7 +12,7 @@ export const EntityStepCardTopSection = ({
     case OverlayModalStepTypes.EVALUATION_PLAN:
       return (
         <>
-          <Heading as="h4" sx={sx.heading}>
+          <Heading sx={sx.mainHeading}>
             {formattedEntityData.objectiveName}
           </Heading>
           <Text sx={sx.subtitle}>
@@ -65,7 +65,7 @@ export const EntityStepCardTopSection = ({
     case OverlayModalStepTypes.FUNDING_SOURCES:
       return (
         <>
-          <Heading as="h3" sx={sx.heading}>
+          <Heading sx={sx.mainHeading}>
             {formattedEntityData.fundingSource}
           </Heading>
           {formattedEntityData.quarters.length > 0 && (
@@ -107,6 +107,9 @@ interface Props {
 }
 
 const sx = {
+  mainHeading: {
+    fontSize: "md",
+  },
   heading: {
     fontSize: "sm",
   },

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -146,6 +146,7 @@ export function renderModalOverlayTableBody(
 ) {
   const reportType = report.reportType as ReportType;
   const entitySteps = getEntityStepFields(section.entitySteps ?? []);
+  const isPdf = true;
   switch (reportType) {
     case ReportType.WP:
       return entities.map((entity, idx) => {
@@ -155,8 +156,8 @@ export function renderModalOverlayTableBody(
               <Td sx={sx.statusIcon}>
                 <EntityStatusIcon
                   entity={entity}
-                  isPdf={true}
-                  entityStatus={getInitiativeStatus(report, entity)}
+                  isPdf={isPdf}
+                  entityStatus={getInitiativeStatus(report, entity, isPdf)}
                 />
               </Td>
               <Td>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -140,6 +140,9 @@ interface Props {
 }
 
 const sx = {
+  ".tbs-bottom-margin": {
+    marginBottom: "2.5rem",
+  },
   // default
   ".ds-c-field, .ds-c-label": {
     maxWidth: "32rem",

--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -237,7 +237,7 @@ const sx = {
   link: {
     margin: "0.5rem 0",
     ".desktop &": {
-      "&:first-child": {
+      "&:first-of-type": {
         paddingRight: ".5rem",
         borderRight: "1px solid",
         borderColor: "palette.white",

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -33,16 +33,14 @@ export const DashboardTable = ({
       <Tr key={report.id}>
         {/* Edit Button */}
         {isStateLevelUser &&
-        !report?.locked &&
-        reportType === ReportType.SAR ? (
-          <EditReportButton
-            report={report}
-            openAddEditReportModal={openAddEditReportModal}
-            sxOverride={sxOverride}
-          />
-        ) : (
-          <Td></Td>
-        )}
+          !report?.locked &&
+          reportType === ReportType.SAR && (
+            <EditReportButton
+              report={report}
+              openAddEditReportModal={openAddEditReportModal}
+              sxOverride={sxOverride}
+            />
+          )}
         {/* Report Name */}
         {reportType === ReportType.WP ? (
           <Td sx={sxOverride.wpSubmissionNameText}>{report.submissionName}</Td>
@@ -303,7 +301,6 @@ const sx = {
         paddingRight: 0,
       },
       "&:first-of-type": {
-        width: "2rem",
         minWidth: "2rem",
       },
     },

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -113,9 +113,6 @@ export const OverlayModalPage = ({
         />
       )}
       <Box>
-        <Heading as="h3" sx={sx.dashboardTitle}>
-          {dashTitle}
-        </Heading>
         <Button
           sx={sx.addEntityButton}
           onClick={addEditEntityModalOnOpenHandler}
@@ -123,6 +120,9 @@ export const OverlayModalPage = ({
         >
           {verbiage.addEntityButtonText}
         </Button>
+        <Heading as="h3" sx={sx.dashboardTitle}>
+          {dashTitle}
+        </Heading>
         <Box>
           {reportFieldDataEntities?.map(
             (entity: EntityShape, entityIndex: number) => (
@@ -219,13 +219,13 @@ const sx = {
   },
   dashboardTitle: {
     paddingTop: "1rem",
-    paddingBottom: "0",
+    marginBottom: "1rem",
     fontWeight: "bold",
     color: "palette.gray_medium",
   },
   addEntityButton: {
     marginTop: "1.5rem",
-    marginBottom: "2rem",
+    marginBottom: "1rem",
   },
   buttonFlex: {
     justifyContent: "end",

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -30,7 +30,7 @@ export const ReportPageFooter = ({
       : "Continue";
 
   return (
-    <Box sx={sx.footerBox} {...props}>
+    <Box sx={sx.footerBox}>
       <Box>
         <Flex sx={hidePrevious ? sx.floatButtonRight : sx.buttonFlex}>
           {!hidePrevious && (

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -52,15 +52,18 @@ export const EntityRow = ({
           if (isInitiativeClosed) {
             return EntityStatuses.CLOSE;
           } else {
-            const isCloseOutEnabled = getInitiativeStatus(report!, entity, [
-              stepType,
-            ]);
+            const isCloseOutEnabled = getInitiativeStatus(
+              report!,
+              entity,
+              false,
+              [stepType]
+            );
             return isCloseOutEnabled && isCopied
               ? EntityStatuses.NO_STATUS
               : EntityStatuses.DISABLED;
           }
         } else {
-          return getInitiativeStatus(report!, entity, [
+          return getInitiativeStatus(report!, entity, false, [
             EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
           ]);
         }

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -94,6 +94,7 @@ export const getEntityStatus = (
 export const getInitiativeStatus = (
   report: ReportShape,
   entity: EntityShape,
+  isPdf?: boolean,
   ignore?: string[]
 ) => {
   if (entity?.isInitiativeClosed) return EntityStatuses.CLOSE;
@@ -118,6 +119,15 @@ export const getInitiativeStatus = (
       return getInitiativeDashboardStatus(step, entity);
     });
 
+    /**
+     * Currently, on exporting a PDF of the Work Plan does not take into consideration the Close-out initiatives entity step,
+     * but the status is always returning "incomplete" because that step is used to calculate the initiative status.
+     * This removes the Close-out initiative step status from the PDF statusing calculation if this is not a copy-over.
+     */
+    if (isPdf && !entity.isCopied) {
+      stepStatuses.splice(-1);
+    }
+
     return stepStatuses.every((field: boolean | EntityStatuses) => field);
   }
 
@@ -138,6 +148,7 @@ export const getInitiativeDashboardStatus = (
 
   //this step is to consolidate the code by converting entity into a loopable array if there's no array of stepType to loop through
   const entities = entity[stepType] ? (entity[stepType] as []) : [entity];
+
   if (entities.length > 0) {
     let isFilled = true;
 

--- a/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-dashboard.ts
@@ -7,7 +7,6 @@ export default {
     table: {
       caption: "WP Programs",
       headRow: [
-        "",
         "Submission name",
         "Due date",
         "Last edited",


### PR DESCRIPTION
## MAIN -> VAL

### In this deployment:
<!-- List all work that is part of this deployment -->
<!-- - Description of work (CMDCT-<ticket-number>) -->

- Remove props spread from report footer to avoid console errors (CMDCT-none) [PR](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/298)
- fix ":first-child" console error in footer (CMDCT-none) [PR](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/299)
- [PDF] Statusing Fix for WP Initiatives on Export (CMDCT-3128)
- Remove styling from html where it did nothing and to avoid console error (CMDCT-3110)
- Update copy on evaluation plan modal [PR](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/296)
- Variable rename: Change blacklist to blocklist [PR](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/304)