### PR TITLE
Remove styling from html where it did nothing and to avoid console error

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -625,12 +625,7 @@
                 },
                 {
                   "type": "html",
-                  "content": "<br>If a recipient updates the MFP Work Plan to indicate that an initiative will no longer be sustained with MFP funding or state or territory-equivalent funding, the recipient must explain whether the initiative will be terminated or sustained through another funding source.<br><br>",
-                  "props": {
-                    "style": {
-                      "paddingBottom": "2rem"
-                    }
-                  }
+                  "content": "<br>If a recipient updates the MFP Work Plan to indicate that an initiative will no longer be sustained with MFP funding or state or territory-equivalent funding, the recipient must explain whether the initiative will be terminated or sustained through another funding source.<br><br>"
                 },
                 {
                   "type": "text",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
React Fragments cannot accept properties other than key and children.

Because of how we do content parsing any blob provided as `"type": "html"` is rendered inside a react fragment
[html assignment](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/ui-src/src/utils/other/parsing.ts#L30)
[element creation logic](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/ui-src/src/utils/other/parsing.ts#L62-L68)

This was causing a console error when "style" was passed into the fragments properties. It turns out only one piece of content of type html was using props, and it didn't actually change the view, so I removed it. Now the error doesn't show up

Feedback:
- Do we want to instead remove styling from anything that is of type html? this feels wasteful because then you might not know that while writing content, and it also creates room for unnecessary code where you may have style props on an html type and it's being discarded on render anyway
- Is there a good place where we can note not to use properties in the json when working with type html?


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3110

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- navigate to initative instructions in the report
- Verify the spacing is not affected by this change (compare to mdct dev)
- Verify no console errors on that page (refresh to verify render)

Video comparison of branch and dev:
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/e706b310-5ab7-4b91-973e-727a36d820c1

---
### Author checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
---