### PR TITLE
Update PDF table per design requests

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -44,8 +44,8 @@ export const ExportedModalDrawerReportSection = ({
     let quarterArray = [];
 
     if (
-      entity?.transitionBenchmarks_applicableToMfpDemonstration?.[0].value !==
-      "No"
+      entity?.transitionBenchmarks_applicableToMfpDemonstration?.[0].value ===
+      "Yes"
     ) {
       for (const key in entity) {
         // push key values into quarterArray that are quarters
@@ -53,22 +53,32 @@ export const ExportedModalDrawerReportSection = ({
           quarterArray.push(entity[key]);
         }
       }
+    } else if (
+      entity?.transitionBenchmarks_applicableToMfpDemonstration?.[0].value ===
+      "No"
+    ) {
+      for (const key in entity) {
+        // push key values into quarterArray that are quarters
+        if (key.includes("quarterly")) {
+          quarterArray.push("N/A");
+        }
+      }
     }
 
     if (quarterArray.length === 0) {
       let seedData = [
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
-        "N/A",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
+        "Not answered",
       ];
       quarterArray.push(...seedData);
     }
@@ -120,12 +130,8 @@ export const ExportedModalDrawerReportSection = ({
       columnTotal.forEach((item: any) => {
         sum += convertToNum(item);
       });
-      if (
-        columnTotal.includes("N/A") ||
-        columnTotal.includes("Not Answered") ||
-        columnTotal.includes("-") ||
-        columnTotal.includes("Data not available")
-      ) {
+      // the dash - gets put in totals where the user did not answer the question
+      if (columnTotal.includes("-")) {
         return `${commaMasking(sum.toString())}*`;
       } else {
         return sum === 0 ? "-" : commaMasking(sum.toString());
@@ -139,14 +145,7 @@ export const ExportedModalDrawerReportSection = ({
   };
 
   const markUnfinishedRows = (row: string[]) => {
-    if (
-      row.includes("N/A") ||
-      row.includes(
-        "Not Answered" ||
-          row.includes("-") ||
-          row.includes("Data not available")
-      )
-    ) {
+    if (row.includes("Not answered") || row.includes("-")) {
       return (row[row.length - 1] = `${row[row.length - 1]}*`);
     }
     return;
@@ -189,7 +188,7 @@ export const ExportedModalDrawerReportSection = ({
         // Add Not Answer if cell is empty string,
         valueArray.forEach((array: any[]) => {
           if (!array[item] && array[item] === "") {
-            array[item] = "Not Answered";
+            array[item] = "Not answered";
           }
 
           sum += convertToNum(array[item]);
@@ -246,7 +245,7 @@ export const ExportedModalDrawerReportSection = ({
         // Add Not Answer if cell is empty string,
         overflowQuarterValueArray.forEach((array: any[]) => {
           if (!array[item] && array[item] === "") {
-            array[item] = "Not Answered";
+            array[item] = "Not answered";
           }
           row.push(commaMasking(array[item]));
         });
@@ -340,7 +339,6 @@ const sx = {
     fontWeight: "bold",
     color: "palette.gray_darkest",
   },
-  // TODO: delete this
   table: {
     marginTop: "1.25rem",
     borderLeft: "1px solid",
@@ -404,7 +402,6 @@ const sx = {
     },
   },
   border: {
-    border: "1px solid black",
     marginTop: "1.25rem",
   },
 };

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -62,7 +62,7 @@ export const Table = ({
                   key={cell + index}
                   sx={{
                     tableCell: border ? sx.tableCellBorder : sx.tableCell,
-                    color: cell == "Not Answered" ? "palette.error_darker" : "",
+                    color: cell == "Not answered" ? "palette.error_darker" : "",
                   }}
                 >
                   {sanitizeAndParseHtml(cell)}

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -9,7 +9,7 @@ export const dropdownDefaultOptionText = "- Select an option -";
 
 export const closeText = "Close";
 export const saveAndCloseText = "Save & close";
-export const notAnsweredText = "Not Answered";
+export const notAnsweredText = "Not answered";
 
 // STATES
 export enum States {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The Transition Benchmarks PDF table had some more rules to follow. Some of these didn't work due to "Answered" being capitalized instead of lowercase in some equality checks. See How to test for more details on the rules we are trying to follow

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3151

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Open the PDF and view the `Transition Benchmark Projections` table
- Answer the questions on the transition benchmarks page and verify the table follows these rules as you do so (you'll need to refresh the pdf page after making changes):
  • If a user doesn't answer the drawer (radio buttons) for Transition Benchmarks Projections for a target population (it's still in its default state), then show "Not answered" on the PDF table column for that population (in color-error-darker red). Any sums of cells that include at least 1 "Not answered" should have an asterisk in the total column or row
  • If a user answers "No" in the drawer, put N/As down the entire column for that population in the PDF
  • If a user answers "Yes" in the drawer, the answer can contain a number, 0, or "N/A" and it all counts as answered (should not lead to an asterisk in the total column unless a cell in its column or row has "Not answsered" for another population.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
---