### PR TITLE
add exportedReportWrapper tests CMDCT-3154

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -303,9 +303,11 @@ export const ExportedModalDrawerReportSection = ({
       data-testid="exportedModalDrawerReportSection"
       sx={sx.container}
     >
-      <Heading as="h2" sx={sx.dashboardTitle} data-testid="headerCount">
-        {verbiage.pdfDashboardTitle}
-      </Heading>
+      {verbiage.pdfDashboardTitle && (
+        <Heading as="h2" sx={sx.dashboardTitle} data-testid="headerCount">
+          {verbiage.pdfDashboardTitle}
+        </Heading>
+      )}
       <small>{"*asterisk denotes sum of incomplete fields"}</small>
       <Box sx={overflow ? sx.overflowStyles : {}}>
         <Table sx={sx.table} content={generateMainTable()}></Table>

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -5,6 +5,7 @@ import {
   mockReportStore,
   mockModalDrawerReportPageJson,
   mockStandardReportPageJson,
+  mockDrawerReportPageJson,
 } from "utils/testing/setupJest";
 import { mockWpReportContext } from "../../utils/testing/mockReport";
 
@@ -14,28 +15,40 @@ jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue(mockReportStore);
 
+const exportedStandardReportWrapperComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockStandardReportPageJson} />
+  </ReportContext.Provider>
+);
+
+const exportedDrawerReportPageWrapperComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockDrawerReportPageJson} />
+  </ReportContext.Provider>
+);
 const exportedModalDrawerReportWrapperComponent = (
   <ReportContext.Provider value={mockWpReportContext}>
     <ExportedReportWrapper section={mockModalDrawerReportPageJson} />
   </ReportContext.Provider>
 );
 
-const exportedStandardReportWrapperComponent = (
-  <ReportContext.Provider value={mockWpReportContext}>
-    <ExportedReportWrapper section={mockStandardReportPageJson} />
-  </ReportContext.Provider>
-);
 describe("ExportedReportWrapper rendering", () => {
-  test("ExportedModalDrawerReportSection renders", () => {
-    render(exportedModalDrawerReportWrapperComponent);
-    expect(
-      screen.getByTestId("exportedModalDrawerReportSection")
-    ).toBeInTheDocument();
-  });
   test("exportedStandardReportWrapperComponent renders", () => {
     render(exportedStandardReportWrapperComponent);
     expect(
       screen.getByTestId("exportedStandardReportSection")
+    ).toBeInTheDocument();
+  });
+  test("exportedDrawerReportPageWrapperComponent renders", () => {
+    render(exportedDrawerReportPageWrapperComponent);
+    expect(
+      screen.getByTestId("exportedDrawerReportSection")
+    ).toBeInTheDocument();
+  });
+  test("ExportedModalDrawerReportSection renders", () => {
+    render(exportedModalDrawerReportWrapperComponent);
+    expect(
+      screen.getByTestId("exportedModalDrawerReportSection")
     ).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+// import { axe } from "jest-axe";
+import { useStore } from "utils";
+import {
+  mockReportStore,
+  mockModalDrawerReportPageJson,
+  mockStandardReportPageJson,
+} from "utils/testing/setupJest";
+import { mockWpReportContext } from "../../utils/testing/mockReport";
+
+import { ReportContext, ExportedReportWrapper } from "components";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockReportStore);
+
+const exportedModalDrawerReportWrapperComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockModalDrawerReportPageJson} />
+  </ReportContext.Provider>
+);
+
+const exportedStandardReportWrapperComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockStandardReportPageJson} />
+  </ReportContext.Provider>
+);
+describe("ExportedReportWrapper rendering", () => {
+  test("ExportedModalDrawerReportSection renders", () => {
+    render(exportedModalDrawerReportWrapperComponent);
+    expect(
+      screen.getByTestId("exportedModalDrawerReportSection")
+    ).toBeInTheDocument();
+  });
+  test("exportedStandardReportWrapperComponent renders", () => {
+    render(exportedStandardReportWrapperComponent);
+    expect(
+      screen.getByTestId("exportedStandardReportSection")
+    ).toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-// import { axe } from "jest-axe";
+import { axe } from "jest-axe";
 import { useStore } from "utils";
 import {
   mockReportStore,
@@ -20,7 +20,6 @@ const exportedStandardReportWrapperComponent = (
     <ExportedReportWrapper section={mockStandardReportPageJson} />
   </ReportContext.Provider>
 );
-
 const exportedDrawerReportPageWrapperComponent = (
   <ReportContext.Provider value={mockWpReportContext}>
     <ExportedReportWrapper section={mockDrawerReportPageJson} />
@@ -50,5 +49,23 @@ describe("ExportedReportWrapper rendering", () => {
     expect(
       screen.getByTestId("exportedModalDrawerReportSection")
     ).toBeInTheDocument();
+  });
+});
+
+describe("Test ExportedReportWrapper accessibility", () => {
+  it("exportedStandardReportWrapperComponent should not have basic accessibility issues", async () => {
+    const { container } = render(exportedStandardReportWrapperComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it("exportedDrawerReportPageWrapperComponent should not have basic accessibility issues", async () => {
+    const { container } = render(exportedDrawerReportPageWrapperComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it("exportedModalDrawerReportWrapperComponent should not have basic accessibility issues", async () => {
+    const { container } = render(exportedModalDrawerReportWrapperComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add jest tests for ExportedReportWrapper
Update the ExportedModalDrawer component to not show an empty h2 if there isn't a pdfDashboardTitle
### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3154

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
