### PR TITLE
CMDCT-3149: Enable Reset Work Plan Functionality

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -42,6 +42,10 @@
                 "target": "_blank",
                 "aria-label": "User Guide and Help File (Link opens in new tab)"
               }
+            },
+            {
+              "type": "html",
+              "content": "."
             }
           ]
         },
@@ -889,11 +893,11 @@
                       "hint": [
                         {
                           "type": "html",
-                          "content": "Select all that apply. Populations you’ve added as “Other” in the Transition Benchmarks section will appear here. Note: if your target population does not appear here, go to"
+                          "content": "Select all that apply. Populations you’ve added as “Other” in the Transition Benchmarks section will appear here. Note: if your target population does not appear here, go to "
                         },
                         {
                           "type": "internalLink",
-                          "content": " Transition Benchmarks",
+                          "content": "Transition Benchmarks",
                           "props": {
                             "to": "/wp/transition-benchmarks"
                           }

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -43,8 +43,12 @@ export const AddEditReportModal = ({
   //temporary flag for testing copyover
   const isCopyOverTest = useFlags()?.isCopyOverTest;
 
-  // WP report payload
-  const prepareWpPayload = () => {
+  /**
+   * @function: Prepare WP payload
+   * @param wpReset: (optional) determine whether the user would like to continue a Work Plan for next period,
+   * but clear / reset any existing data from the previous period
+   */
+  const prepareWpPayload = (wpReset?: boolean) => {
     const submissionName = "Work Plan";
 
     // static entities
@@ -86,7 +90,7 @@ export const AddEditReportModal = ({
       metadata: {
         submissionName,
         lastAlteredBy: full_name,
-        copyReport: previousReport,
+        copyReport: wpReset ? null : previousReport,
         locked: false,
         previousRevisions: [],
       },
@@ -123,12 +127,18 @@ export const AddEditReportModal = ({
     };
   };
 
-  const writeReport = async (formData: any) => {
+  /**
+   * @param wpReset: (optional) determine whether the user would like to continue a Work Plan for next period,
+   * but clear / reset any existing data from the previous period
+   */
+  const writeReport = async (formData: any, wpReset?: boolean) => {
     setSubmitting(true);
     const submitButton = document.querySelector("[form=" + form.id + "]");
     submitButton?.setAttribute("disabled", "true");
     const dataToWrite =
-      reportType === "WP" ? prepareWpPayload() : prepareSarPayload(formData);
+      reportType === "WP"
+        ? prepareWpPayload(wpReset)
+        : prepareSarPayload(formData);
 
     // if an existing program was selected, use that report id
     if (selectedReport?.id) {
@@ -170,7 +180,8 @@ export const AddEditReportModal = ({
     modalDisclosure.onClose();
   };
 
-  const resetReport = () => {
+  const resetReport = (formData: any) => {
+    writeReport(formData, true);
     modalDisclosure.onClose();
   };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Allowing users to reset a "continued" Work Plan for their next reporting period.

**Note:** I also fixed a couple of verbiage issues on the `wp.json`

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3149

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create and submit a new Work Plan
- Log in as an admin
- Approve that Work Plan
- Log BACK in as the same state user
- Click on the `Continue Work Plan for next Period` button
- On the modal, click on `Reset MFP Work Plan`

<img width="272" alt="Screenshot 2024-01-02 at 2 15 49 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/3679110d-3d71-45eb-9dda-20f9200f75da">

You should be able to see, fill, and submit a fresh WP on the dashboard ✨ 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
