### PR TITLE
CMDCT-3137: SAR Admin Dashboard Updates

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -20,7 +20,7 @@ export const AddEditReportModal = ({
 }: Props) => {
   const { createReport, fetchReportsByState, updateReport } =
     useContext(ReportContext);
-  const { full_name } = useStore().user ?? {};
+  const { full_name, userIsAdmin } = useStore().user ?? {};
   const [submitting, setSubmitting] = useState<boolean>(false);
   const { workPlanToCopyFrom } = useStore();
 
@@ -178,7 +178,7 @@ export const AddEditReportModal = ({
     if (reportType === ReportType.WP) {
       return "";
     }
-    return submitting ? <Spinner size="md" /> : "Save";
+    return submitting ? <Spinner size="md" /> : userIsAdmin ? "Return" : "Save";
   };
 
   const isCopyDisabled = () => {
@@ -210,7 +210,8 @@ export const AddEditReportModal = ({
               ? previousReport
               : selectedReport?.formData
           }
-          onSubmit={writeReport}
+          // if view-only (user is admin), close modal
+          onSubmit={userIsAdmin ? modalDisclosure.onClose : writeReport}
           validateOnRender={false}
           dontReset={true}
         />

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -32,15 +32,13 @@ export const DashboardTable = ({
     {reportsByState.map((report: ReportMetadataShape) => (
       <Tr key={report.id}>
         {/* Edit Button */}
-        {isStateLevelUser &&
-          !report?.locked &&
-          reportType === ReportType.SAR && (
-            <EditReportButton
-              report={report}
-              openAddEditReportModal={openAddEditReportModal}
-              sxOverride={sxOverride}
-            />
-          )}
+        {!report?.locked && reportType === ReportType.SAR && (
+          <EditReportButton
+            report={report}
+            openAddEditReportModal={openAddEditReportModal}
+            sxOverride={sxOverride}
+          />
+        )}
         {/* Report Name */}
         {reportType === ReportType.WP ? (
           <Td sx={sxOverride.wpSubmissionNameText}>{report.submissionName}</Td>
@@ -48,7 +46,7 @@ export const DashboardTable = ({
           <Td sx={sxOverride.sarSubmissionNameText}>{report.submissionName}</Td>
         )}
         {/* Target populations */}
-        {reportType === ReportType.SAR && report?.populations && (
+        {!isAdmin && reportType === ReportType.SAR && report?.populations && (
           <Td>{prettifyChoices(report?.populations)}</Td>
         )}
         {/* Date Fields */}
@@ -162,7 +160,7 @@ const tableBody = (body: TableContentShape, isAdmin: boolean) => {
     return tableContent;
   } else {
     tableContent.headRow = tableContent.headRow!.filter(
-      (e) => e !== "Due date"
+      (e) => e !== "Due date" && e !== "Target populations"
     );
   }
   return body;

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -28,7 +28,7 @@ export const MobileDashboardTable = ({
         <Box sx={sx.labelGroup}>
           <Text sx={sx.label}>{"Submission name"}</Text>
           <Flex alignContent="flex-start">
-            {isStateLevelUser && reportType === "SAR" && !report?.locked && (
+            {reportType === "SAR" && !report?.locked && (
               <Box sx={sxOverride.editReport}>
                 <button onClick={() => openAddEditReportModal(report)}>
                   <Image
@@ -44,7 +44,7 @@ export const MobileDashboardTable = ({
             </Text>
           </Flex>
         </Box>
-        {reportType === "SAR" && report?.populations && (
+        {!isAdmin && reportType === "SAR" && report?.populations && (
           <Box sx={sx.labelGroup}>
             <Text sx={sx.label}>Target populations</Text>
             <Text>{prettifyChoices(report?.populations)}</Text>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Removing the `Target populations` column from the SAR admin dashboard and adding the `Edit` button.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3137

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create and submit a Work Plan
- Log in as an admin
- Approve that Work Plan
- Log back in as a state user
- Create (no need to submit) a SAR
- Log back in as an admin

You should see an `Edit` icon button on the SAR dashboard that opens a view-only modal and the `Target populations` column should be gone.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
