### PR TITLE
Add MFP to report names

### DIFF
--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -21,7 +21,7 @@ export const createReportName = (
     reportType === ReportType.SAR ? workPlan?.reportPeriod : reportPeriod;
 
   const fullStateName = States[state as keyof typeof States];
-  return `${fullStateName} ${reportName} ${reportYear} - Period ${period}`;
+  return `${fullStateName} MFP ${reportName} ${reportYear} - Period ${period}`;
 };
 
 export const lastCreatedWorkPlan = (

--- a/services/app-api/utils/testing/mocks/mockReport.ts
+++ b/services/app-api/utils/testing/mocks/mockReport.ts
@@ -78,7 +78,7 @@ export const mockWPDynamoData = {
 };
 
 export const mockWPMetadata = {
-  submissionName: "New Jersey Work Plan 2023 - Period 2",
+  submissionName: "New Jersey MFP Work Plan 2023 - Period 2",
   dueDate: 1699496172798,
   formTemplateId: "wp-form-template",
   lastAlteredBy: "Anthony Soprano",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adds 'MFP' to report names between state and report type

I only found one test that used this so let me know if you know of more places! Tests pass.

Note: Product said existing reports are ok to leave as is

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3139

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Verify the name is follows the format `{state} MFP Work Plan ....`
- If you feel up for it fill out and submit the WP and create a SAR to test that one too

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---