### PR TITLE
CMDCT-3138: Updated WP and SAR Homepage (Verbiage + Styling)

### DIFF
--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.test.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.test.tsx
@@ -33,9 +33,7 @@ describe("Test TemplateCardAccordion", () => {
     expect(
       screen.getByText(verbiage.cards.WP.accordion.buttonLabel)
     ).toBeVisible();
-    expect(
-      screen.getByText(verbiage.cards.WP.accordion.text)
-    ).not.toBeVisible();
+    expect(screen.getByTestId("accordion-contents")).not.toBeVisible();
   });
 
   test("Accordion should show answer on click", async () => {
@@ -44,12 +42,10 @@ describe("Test TemplateCardAccordion", () => {
       verbiage.cards.WP.accordion.buttonLabel
     );
     expect(accordionQuestion).toBeVisible();
-    expect(
-      screen.getByText(verbiage.cards.WP.accordion.text)
-    ).not.toBeVisible();
+    expect(screen.getByTestId("accordion-contents")).not.toBeVisible();
     await userEvent.click(accordionQuestion);
     expect(accordionQuestion).toBeVisible();
-    expect(screen.getByText(verbiage.cards.WP.accordion.text)).toBeVisible();
+    expect(screen.getByTestId("accordion-contents")).toBeVisible();
   });
 
   test("Accordion should render a list when given one", async () => {

--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
@@ -3,11 +3,12 @@ import { Accordion, ListItem, Text, UnorderedList } from "@chakra-ui/react";
 import { AccordionItem, Table } from "components";
 // utils
 import { AnyObject } from "types";
+import { parseCustomHtml } from "utils";
 
 export const TemplateCardAccordion = ({ verbiage, ...props }: Props) => (
   <Accordion sx={sx.root} allowToggle={true} {...props}>
     <AccordionItem label={verbiage.buttonLabel}>
-      <Text sx={sx.text}>{verbiage.text}</Text>
+      <Text sx={sx.text}>{parseCustomHtml(verbiage.text)}</Text>
       {verbiage.table && (
         <Table
           content={verbiage.table}

--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
@@ -8,7 +8,9 @@ import { parseCustomHtml } from "utils";
 export const TemplateCardAccordion = ({ verbiage, ...props }: Props) => (
   <Accordion sx={sx.root} allowToggle={true} {...props}>
     <AccordionItem label={verbiage.buttonLabel}>
-      <Text sx={sx.text}>{parseCustomHtml(verbiage.text)}</Text>
+      <Text sx={sx.text} data-testid="accordion-contents">
+        {parseCustomHtml(verbiage.text)}
+      </Text>
       {verbiage.table && (
         <Table
           content={verbiage.table}

--- a/services/ui-src/src/components/cards/TemplateCard.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.tsx
@@ -104,8 +104,8 @@ const sx = {
   actionsFlex: {
     flexFlow: "wrap",
     gridGap: "1rem",
-    justifyContent: "flex-end",
-    marginTop: "1rem",
+    justifyContent: "space-between",
+    margin: "1rem 0 0 1rem",
     ".mobile &": {
       flexDirection: "column",
     },

--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -23,36 +23,30 @@ export default {
         "https://www.govinfo.gov/content/pkg/PLAW-109publ171/pdf/PLAW-109publ171.pdf",
       postLinkText:
         ' as "increasing the use of home and community-based, rather than institutional, long-term care services."',
-      downloadText: "",
+      downloadText: "User Guide and Help File",
       link: {
         text: "Enter Work Plan online",
         route: "wp",
       },
       accordion: {
         buttonLabel: "When is the MFP Work Plan due?",
-        text: "The MFP Work Plan will be created and submitted initially and then amended semi-annually. CMS will review and approve all MFP Work Plans and proposed changes.The MFP Work Plan deadlines are May 1st for Reporting Period 1 and November 1st for Reporting Period 2. Updates to existing state or territory-specific initiatives or the addition of new initiatives can occur during either of these periods, however, changes to transition benchmark projections should be made between July - November 1st and align with program budget requests. CMS approved changes will be integrated into the MFP recipient’s Semi-Annual Progress Report for the following reporting period.",
+        text: "The MFP Work Plan will be created and submitted initially and then amended semi-annually. CMS will review and approve all MFP Work Plans and proposed changes.<br/><br/>The MFP Work Plan deadlines are May 1st for inclusion in January through June reporting (Reporting Period 1) and November 1st for inclusion in July through December reporting (Reporting Period 2). Updates to existing state or territory-specific initiatives or the addition of new initiatives can occur during either of these periods, however, changes to transition benchmark projections should be made between July - November 1st to align with program budget requests.<br/><br/>CMS approved changes will be integrated into the MFP recipient's Semi-Annual Progress Report for the following reporting period.",
       },
     },
     SAR: {
       title: "MFP Semi-Annual Progress Report (SAR)",
       body: {
         available:
-          "This reporting tool is to be used by MFP recipients for semi-annual reporting of MFP program data. The information provided in this report will allow CMS to monitor MFP recipient progress and identify challenges and improvement opportunities.",
+          "The MFP Semi-Annual Progress Report (SAR) is used to present the recipient's analysis and the status of the various operational areas in reaching the objectives of the demonstration. Through the SARs, the recipient will further enumerate how they have, or intend to, meet or align with the recipient's MFP operational procedures and processes; transition benchmarks; program goals for expanding and enhancing home and community-based services (HCBS); and sustainability plans.",
       },
-      linkText: "User Guide",
-      linkText2: "Help File",
-      midText: " and ",
-      linkLocation: "https://www.google.com",
-      linkLocation2: "https://www.google.com",
-      postLinkText: ".",
-      downloadText: "",
+      downloadText: "User Guide and Help File",
       link: {
         text: "Enter SAR online",
         route: "sar/",
       },
       accordion: {
-        buttonLabel: "When is the SAR due?",
-        text: "The Semi-Annual Progress Report (SAR) will need to be reviewed and submitted twice a year, within 60 days following the end of each second and fourth calendar year quarter. For example, the SAR Reporting Period 1 covers January-June activity and MFP recipients must submit their data within 60 days following June 30.",
+        buttonLabel: "When is the MFP SAR due?",
+        text: "The MFP Semi-Annual Progress Report will need to be reviewed and submitted twice a year, within 60 days following the end of each second and fourth calendar year quarter. For example, the SAR Reporting Period 1 represents January-June and MFP recipients must submit their data within 60 days following June 30. The recipient must submit the progress report through the final reporting period of the recipient's demonstration period of performance, even if the recipient has not operated for a complete reporting period.",
       },
     },
   },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Updating the WP and SAR homepage to match the latest verbiage, as well as adding a link for `User Guide and Help File` download. 

**NOTE:** The links themselves are not available yet, they will be updated as part of a follow-up ticket. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3138

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in as a state user and verify that the updated verbiage and new links match the Figma mockups:

<img width="619" alt="Screenshot 2024-01-04 at 11 49 43 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/51f62774-07b3-423e-a31b-042a0c7400e6">

<img width="645" alt="Screenshot 2024-01-04 at 11 49 49 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/bda73998-597e-466b-82ee-f75d2a222b49">

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
