### PR TITLE
Fix formtemplate and fieldData getting saved in WP metadata upon SAR creation

### DIFF
--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -91,9 +91,12 @@ export const getLastCreatedWorkPlan = async (
     const workPlan = await fetchReport(fetchWPReportEvent, _context);
     const workPlanBody: ReportShape = JSON.parse(workPlan.body);
 
-    // And get its metadata and field data from the response and return it!
-    const workPlanMetadata: ReportMetadataShape = workPlanBody;
+    // fetchReport returns fieldData and formTemplate together with metadata
+    const workPlanMetadata: any = structuredClone(workPlanBody);
     const workPlanFieldData = workPlanBody.fieldData;
+    // Remove these from our metadata so they don't get saved into the metadata table
+    delete workPlanMetadata.fieldData;
+    delete workPlanMetadata.formTemplate;
     return { workPlanMetadata, workPlanFieldData };
   }
   // If there wasn't an eligble work plan to copy from, return undefined


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When creating a SAR we also update the associated WP. We fetch the WP, [spread its metadata](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/app-api/handlers/reports/create.ts#L308), adding the `associatedSar` field, and update it. The problem is this uses our report fetch, which [returns metadata, formTemplate, and fieldData all together](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/app-api/handlers/reports/fetch.ts#L98-L104) for the frontend. Then `formTemplate` and `fieldData` mistakenly get spread in as metadata when we add the field for the SAR.

This takes a structured clone of the fetch and removes those two fields so that the metadata is pure.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3167

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- As a state user, create and submit a WP
- As an admin user, approve that WP
- Open up dynamodbadmin and check the size of the WP metadata
- As a state user, create a SAR
- Refresh dynamodbadmin and ensure the WP metadata only added one line for `associatedSar`


---
### Author checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
---