### PR TITLE
[CMDCT-3168] End Date Validation Bug Fix | Removed nested field to fix validation schema creation

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -941,7 +941,6 @@
                               "validation": {
                                 "type": "endDate",
                                 "dependentFieldName": "defineInitiative_projectedStartDate",
-                                "nested": true,
                                 "parentFieldName": "defineInitiative_projectedEndDate"
                               },
                               "props": {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This change removes the `nested: true` field in the validation schema for the `endDate`. 
This was causing a bug in the end date validation schema, as the logic in `ui-src/src/utils/validation/validation.ts` creates the validation schema as follows: 
1. is the validation type a string? if so, create schema
2. does the field validation exist and is it nested? if so, create a nested field schema
3. does the validation type equal `endDate`? If so, create the endDate field schema 

It would equal `true` on the second conditional and then create a nested validation schema that was incorrect: 
```
{
    "type": "string",
    "_whitelist": {
        "list": {},
        "refs": {}
    },
    "_blacklist": {
        "list": {},
        "refs": {}
    },
    "exclusiveTests": {},
    "deps": [
        "defineInitiative_projectedEndDate"
    ],
    "conditions": [
        {
            "refs": [
                {
                    "key": "defineInitiative_projectedEndDate",
                    "isContext": false,
                    "isValue": false,
                    "isSibling": true,
                    "path": "defineInitiative_projectedEndDate"
                }
            ]
        }
    ],
    "tests": [],
    "transforms": [
        null
    ],
    "spec": {
        "strip": false,
        "strict": false,
        "abortEarly": true,
        "recursive": true,
        "nullable": false,
        "presence": "optional"
    }
}
```

https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/33077e22-f69e-4e4a-99a0-a9a9bd9e991b


(note that the `exclusiveTests` is empty and the deps is `"defineInitiative_projectedEndDate"` when it should be `defineInitiative_projectedStartDate`)

I haven't figured out why this was working before and has broken all of a sudden. I am still trying to figure that out. 



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3168

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. sign in as a state user
2. navigate to State- or Territory Initiatives
3. Define an initiative and enter a start date
4. Enter an invalid date and verify that you get the `Response must be a valid date` error
5. Enter a date before the start date and verify that you get a `End date can't be before start date' error

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
