### PR TITLE
SAR objective progress - add modal

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -990,9 +990,9 @@
               "dashboardTitle": "Objectives progress"
             },
             "editEntityButtonText": "Report objective progress",
+            "addEditModalEditTitle": "Report progress for ",
             "enterEntityDetailsButtonText": "Edit",
             "readOnlyEntityDetailsButtonText": "View",
-            "modalTitle": "Report progress for ",
             "editEntityHint": "Select \"Edit\" to report the objectives progress.",
             "reviewPdfHint": "To view totals and percent target achieved, Save & close, click <i>Review PDF</i> button and it will open a summary in a new tab."
           },
@@ -1012,30 +1012,33 @@
                 "type": "radio",
                 "validation": "radio",
                 "props": {
-                  "label": "Were targets for performance measures and/or expected time frames for deliverables met?"
-                },
-                "choices": [
-                  {
-                    "id": "2WaO1Jj3pyUN0j9KjeOqR",
-                    "label": "Yes"
-                  },
-                  {
-                    "id": "2WaO1K5umgZcZV4bAW5sPu",
-                    "label": "No",
-                    "children": [
-                      {
-                        "id": "objectivesProgress_deliverablesMet-otherText",
-                        "type": "textarea",
-                        "validation": {
-                          "type": "text",
-                          "parentFieldName": "objectivesProgress_deliverablesMet",
-                          "parentOptionId": "2WaO1K5umgZcZV4bAW5sPu",
-                          "nested": true
+                  "label": "Were targets for performance measures and/or expected time frames for deliverables met?",
+                  "choices": [
+                    {
+                      "id": "2WaO1Jj3pyUN0j9KjeOqR",
+                      "label": "Yes"
+                    },
+                    {
+                      "id": "2WaO1K5umgZcZV4bAW5sPu",
+                      "label": "No",
+                      "children": [
+                        {
+                          "id": "objectivesProgress_deliverablesMet-otherText",
+                          "props": {
+                            "label": "Describe progress toward reaching the target/milestone during the reporting period. How close are you to meeting the target? How do you plan to address any obstacle(s) to meeting the target?"
+                          },
+                          "type": "textarea",
+                          "validation": {
+                            "type": "text",
+                            "parentFieldName": "objectivesProgress_deliverablesMet",
+                            "parentOptionId": "2WaO1K5umgZcZV4bAW5sPu",
+                            "nested": true
+                          }
                         }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               }
             ]
           }

--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -989,7 +989,8 @@
               ],
               "dashboardTitle": "Objectives progress"
             },
-            "editEntityButtonText": "Report objective progress",
+            "editEntityButtonText": "Edit objective progress",
+            "reportProgressButtonText": "Report objective progress",
             "addEditModalEditTitle": "Report progress for ",
             "enterEntityDetailsButtonText": "Edit",
             "readOnlyEntityDetailsButtonText": "View",
@@ -1023,7 +1024,7 @@
                       "label": "No",
                       "children": [
                         {
-                          "id": "objectivesProgress_deliverablesMet-otherText",
+                          "id": "objectivesProgress_deliverablesMet_otherText",
                           "props": {
                             "label": "Describe progress toward reaching the target/milestone during the reporting period. How close are you to meeting the target? How do you plan to address any obstacle(s) to meeting the target?"
                           },

--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -994,6 +994,7 @@
             "addEditModalEditTitle": "Report progress for ",
             "enterEntityDetailsButtonText": "Edit",
             "readOnlyEntityDetailsButtonText": "View",
+            "readOnlyEntityButtonText": "View",
             "editEntityHint": "Select \"Edit\" to report the objectives progress.",
             "reviewPdfHint": "To view totals and percent target achieved, Save & close, click <i>Review PDF</i> button and it will open a summary in a new tab."
           },

--- a/services/ui-src/src/components/cards/EntityCardBottomSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.test.tsx
@@ -1,5 +1,10 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { EntityStepCardBottomSection } from "./EntityCardBottomSection";
+import { mockGenericEntity, mockUseSARStore } from "utils/testing/setupJest";
+import { useStore } from "utils";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 const verbiage = {
   entityMissingResponseMessage: "test string",
@@ -11,6 +16,15 @@ const entityStepCardBottomSection = (
     stepType={"mockStepType"}
     verbiage={verbiage}
     formattedEntityData={{}}
+  />
+);
+
+const cardWithQualitativeAnswers = (
+  <EntityStepCardBottomSection
+    stepType={"evaluationPlan"}
+    verbiage={verbiage}
+    formattedEntityData={{}}
+    entity={mockGenericEntity}
   />
 );
 describe("Test EntityStepCardBottomSection renders", () => {
@@ -39,5 +53,30 @@ describe("Test EntityStepCardBottomSection renders", () => {
       />
     );
     expect(bottomSection.container).toBeEmptyDOMElement();
+  });
+  test("EntityStepCardBottomSection returns default if evaluationStep but not SAR", () => {
+    let entityStepCardBottomSectionSwitchCase = (
+      <EntityStepCardBottomSection
+        stepType={"evaluationPlan"}
+        verbiage={verbiage}
+        formattedEntityData={{}}
+      />
+    );
+
+    const bottomSection = render(entityStepCardBottomSectionSwitchCase);
+    expect(bottomSection.container).toBeEmptyDOMElement();
+  });
+});
+
+describe("Test EntityStepCardBottomSection renders the evalutionStep correctly", () => {
+  beforeEach(async () => {
+    mockedUseStore.mockReturnValue(mockUseSARStore);
+  });
+  test("EntityStepCardBottomSection renders evalutionStep correctly", () => {
+    render(cardWithQualitativeAnswers);
+    const progressBox = screen.getByTestId("objective-progress-box");
+    expect(progressBox).toBeVisible();
+    const deliverablesOther = screen.getByTestId("deliverables-other");
+    expect(deliverablesOther).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
@@ -29,14 +29,19 @@ export const EntityStepCardBottomSection = ({ stepType, entity }: Props) => {
                 {entity?.objectivesProgress_deliverablesMet[0].value}
               </Text>
 
-              {/* this one should be optional, based on if they asnwered no to the above */}
-              <Text sx={sx.subtitle}>
-                Describe progress toward reaching the target/milestone during
-                the reporting period. How close are you to meeting the target?
-                How do you plan to address any obstacle(s) to meeting the
-                target?
-              </Text>
-              <Text sx={sx.description}>placeholder text</Text>
+              {entity?.objectivesProgress_deliverablesMet_otherText && (
+                <>
+                  <Text sx={sx.subtitle}>
+                    Describe progress toward reaching the target/milestone
+                    during the reporting period. How close are you to meeting
+                    the target? How do you plan to address any obstacle(s) to
+                    meeting the target?
+                  </Text>
+                  <Text sx={sx.description}>
+                    {entity?.objectivesProgress_deliverablesMet_otherText}
+                  </Text>
+                </>
+              )}
             </Box>
           </>
         );

--- a/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
@@ -11,7 +11,10 @@ export const EntityStepCardBottomSection = ({ stepType, entity }: Props) => {
       if (report?.reportType === ReportType.SAR) {
         return (
           <>
-            <Box sx={sx.objectiveProgressBox}>
+            <Box
+              sx={sx.objectiveProgressBox}
+              data-testid="objective-progress-box"
+            >
               <Text sx={sx.subtitle}>
                 Performance measure progress toward milestones and key
                 deliverables for current reporting period
@@ -31,7 +34,7 @@ export const EntityStepCardBottomSection = ({ stepType, entity }: Props) => {
 
               {entity?.objectivesProgress_deliverablesMet_otherText && (
                 <>
-                  <Text sx={sx.subtitle}>
+                  <Text sx={sx.subtitle} data-testid="deliverables-other">
                     Describe progress toward reaching the target/milestone
                     during the reporting period. How close are you to meeting
                     the target? How do you plan to address any obstacle(s) to

--- a/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
@@ -1,8 +1,48 @@
 // utils
-import { AnyObject } from "types";
+import { AnyObject, ReportType } from "types";
+import { Text, Box } from "@chakra-ui/react";
 
-export const EntityStepCardBottomSection = ({ stepType }: Props) => {
+import { useStore } from "utils";
+
+export const EntityStepCardBottomSection = ({ stepType, entity }: Props) => {
+  const { report } = useStore() ?? {};
   switch (stepType) {
+    case "evaluationPlan":
+      if (report?.reportType === ReportType.SAR) {
+        return (
+          <>
+            <Box sx={sx.objectiveProgressBox}>
+              <Text sx={sx.subtitle}>
+                Performance measure progress toward milestones and key
+                deliverables for current reporting period
+              </Text>
+              <Text sx={sx.description}>
+                {entity?.objectivesProgress_performanceMeasuresIndicators}
+              </Text>
+            </Box>
+            <Box sx={sx.objectiveProgressBox}>
+              <Text sx={sx.subtitle}>
+                Were targets for performance measures and/or expected time
+                frames for deliverables met?
+              </Text>
+              <Text sx={sx.description}>
+                {entity?.objectivesProgress_deliverablesMet[0].value}
+              </Text>
+
+              {/* this one should be optional, based on if they asnwered no to the above */}
+              <Text sx={sx.subtitle}>
+                Describe progress toward reaching the target/milestone during
+                the reporting period. How close are you to meeting the target?
+                How do you plan to address any obstacle(s) to meeting the
+                target?
+              </Text>
+              <Text sx={sx.description}>placeholder text</Text>
+            </Box>
+          </>
+        );
+      } else {
+        return <></>;
+      }
     default:
       return <></>;
   }
@@ -12,8 +52,27 @@ interface Props {
   stepType: string;
   formattedEntityData: AnyObject;
   printVersion?: boolean;
+  entity?: AnyObject;
   verbiage?: {
     entityMissingResponseMessage?: string;
     entityEmptyResponseMessage?: string;
   };
 }
+
+const sx = {
+  objectiveProgressBox: {
+    backgroundColor: "#EEFBFF",
+    padding: "0.5rem 1rem",
+    marginBottom: "1rem",
+  },
+  description: {
+    marginTop: "0.25rem",
+    marginBottom: "1.25rem",
+    fontSize: "sm",
+  },
+  subtitle: {
+    marginTop: "1rem",
+    fontSize: "xs",
+    fontWeight: "bold",
+  },
+};

--- a/services/ui-src/src/components/cards/EntityCardTopSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.test.tsx
@@ -1,7 +1,14 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { EntityStepCardTopSection } from "./EntityCardTopSection";
 import { OverlayModalStepTypes } from "../../types";
-import { mockCompletedGenericFormattedEntityData } from "../../utils/testing/setupJest";
+import {
+  mockCompletedGenericFormattedEntityData,
+  mockUseSARStore,
+} from "../../utils/testing/setupJest";
+import { useStore } from "utils";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 const genericEntityStepCardTopSection = (
   <EntityStepCardTopSection
@@ -55,5 +62,16 @@ describe("Test EntityStepCardTopSection renders", () => {
     expect(
       topSection.getByText("Projected quarterly expenditures")
     ).toBeVisible();
+  });
+});
+
+describe("Test EntityStepCardTopSection renders correctly for SAR", () => {
+  beforeEach(async () => {
+    mockedUseStore.mockReturnValue(mockUseSARStore);
+  });
+  test("EntityStepCardTopSection grid renders correctly for SAR", () => {
+    render(evaluationPlanEntityStepCardTopSection);
+    const sarGrid = screen.getByTestId("sar-grid");
+    expect(sarGrid).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -61,7 +61,7 @@ export const EntityStepCardTopSection = ({
               </>
             ) : (
               <>
-                <Text sx={sx.subtitle}>
+                <Text sx={sx.subtitle} data-testid="sar-grid">
                   Quantitative targets for this reporting period
                 </Text>
                 <Grid sx={sx.sarGrid}>

--- a/services/ui-src/src/components/cards/EntityStepCard.test.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.test.tsx
@@ -8,6 +8,7 @@ import {
   mockCompletedGenericFormattedEntityData,
   mockUnfinishedGenericFormattedEntityData,
   mockUseStore,
+  mockUseSARStore,
 } from "utils/testing/setupJest";
 import { EntityStepCard } from "./EntityStepCard";
 import { OverlayModalStepTypes } from "types";
@@ -165,6 +166,19 @@ const CompletedFundingSourcesCardComponent = (
   />
 );
 
+const NoOpenAddEditEntityFunction = (
+  <EntityStepCard
+    entity={mockGenericEntity}
+    entityIndex={0}
+    stepType="mock-step-type"
+    formattedEntityData={mockUnfinishedGenericFormattedEntityData}
+    verbiage={mockModalDrawerReportPageJson.verbiage}
+    openDeleteEntityModal={openDeleteEntityModal}
+    openDrawer={mockOpenDrawer}
+    printVersion={false}
+  />
+);
+
 describe("Test Completed EntityCard", () => {
   beforeEach(() => {
     render(GenericEntityTypeEntityCardComponent);
@@ -274,5 +288,23 @@ describe("PrintOnly TESTS", () => {
     render(PrintViewEntityTypeEntityCardComponent);
     const element = screen.getByTestId("print-status-indicator");
     expect(element).toBeVisible();
+  });
+});
+
+describe("SAR TESTS", () => {
+  beforeEach(async () => {
+    mockedUseStore.mockReturnValue(mockUseSARStore);
+  });
+  test("Completed evaluation plan card should have a button to edit details", async () => {
+    render(CompletedEvaluationPlanCardComponent);
+    const reportEntityButton = screen.getByTestId("report-button");
+    expect(reportEntityButton).toBeVisible();
+    await userEvent.click(reportEntityButton);
+    await expect(openAddEditEntityModal).toBeCalledTimes(1);
+  });
+  test("Completed evaluation plan card without OpenAddEditModal function doesn't show a button", async () => {
+    render(NoOpenAddEditEntityFunction);
+    const reportEntityButton = screen.queryByTestId("report-button");
+    expect(reportEntityButton).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/cards/EntityStepCard.test.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.test.tsx
@@ -8,14 +8,12 @@ import {
   mockCompletedGenericFormattedEntityData,
   mockUnfinishedGenericFormattedEntityData,
   mockUseStore,
-  mockUseSARStore,
 } from "utils/testing/setupJest";
 import { EntityStepCard } from "./EntityStepCard";
 import { OverlayModalStepTypes } from "types";
 import { useStore } from "utils";
 
 const openAddEditEntityModal = jest.fn();
-const openReportEntityModal = jest.fn();
 const openDeleteEntityModal = jest.fn();
 const mockOpenDrawer = jest.fn();
 jest.mock("utils/state/useStore");
@@ -113,7 +111,6 @@ const CompletedEvaluationPlanCardComponent = (
     formattedEntityData={mockCompletedGenericFormattedEntityData}
     verbiage={mockModalDrawerReportPageJson.verbiage}
     openAddEditEntityModal={openAddEditEntityModal}
-    openReportEntityModal={openReportEntityModal}
     openDeleteEntityModal={openDeleteEntityModal}
     openDrawer={mockOpenDrawer}
     printVersion={false}
@@ -269,18 +266,6 @@ describe("Test Generic EntityCard accessibility", () => {
     const { container } = render(GenericEntityTypeEntityCardComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
-  });
-});
-
-describe("SAR TESTS", () => {
-  beforeEach(async () => {
-    mockedUseStore.mockReturnValue(mockUseSARStore);
-  });
-  test("Completed evaluation plan card should have a button to edit details", async () => {
-    render(CompletedEvaluationPlanCardComponent);
-    const reportEntityButton = screen.getByText(editEntityButtonText);
-    await userEvent.click(reportEntityButton);
-    await expect(openReportEntityModal).toBeCalledTimes(1);
   });
 });
 

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -42,6 +42,12 @@ export const EntityStepCard = ({
   switch (stepType) {
     case OverlayModalStepTypes.EVALUATION_PLAN:
       entityCompleted = formattedEntityData?.objectiveName;
+      if (report?.reportType === ReportType.SAR) {
+        // still need to add conditional for quantitative objectives
+        entityCompleted =
+          entity?.objectivesProgress_performanceMeasuresIndicators &&
+          entity?.objectivesProgress_deliverablesMet[0].value;
+      }
       if (entityCompleted && formattedEntityData?.includesTargets === "Yes") {
         entityCompleted = formattedEntityData?.quarters.length === 12;
         if (formattedEntityData?.quarters)
@@ -132,6 +138,7 @@ export const EntityStepCard = ({
           <EntityStepCardBottomSection
             stepType={stepType}
             verbiage={verbiage}
+            entity={entity}
             formattedEntityData={{
               ...formattedEntityData,
               isPartiallyComplete: !entityCompleted,

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -98,6 +98,7 @@ export const EntityStepCard = ({
     ) {
       return (
         <Button
+          data-testid="report-button"
           size="md"
           sx={sx.reportButton}
           onClick={() => openAddEditEntityModal(entity)}

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -27,7 +27,6 @@ export const EntityStepCard = ({
   formattedEntityData,
   verbiage,
   openAddEditEntityModal,
-  openReportEntityModal,
   openDeleteEntityModal,
   openDrawer,
   printVersion,
@@ -72,6 +71,44 @@ export const EntityStepCard = ({
   const boxShadow = hasBoxShadow ? "0px 3px 9px rgba(0, 0, 0, 0.2)" : "none";
   const border = hasBorder ? "1px" : "none";
   const borderColor = hasBorder ? "#D3D3D3" : "none";
+  const addEditEntitybutton = () => {
+    if (
+      (openAddEditEntityModal && report?.reportType === ReportType.WP) ||
+      (openAddEditEntityModal &&
+        report?.reportType === ReportType.SAR &&
+        entityCompleted)
+    ) {
+      return (
+        <Button
+          variant="outline"
+          size="sm"
+          sx={sx.editButton}
+          leftIcon={<Image src={editIcon} alt="edit icon" height="1rem" />}
+          onClick={() => openAddEditEntityModal(entity)}
+        >
+          {props?.disabled
+            ? verbiage.readOnlyEntityButtonText
+            : verbiage.editEntityButtonText}
+        </Button>
+      );
+    } else if (
+      openAddEditEntityModal &&
+      report?.reportType === ReportType.SAR &&
+      !entityCompleted
+    ) {
+      return (
+        <Button
+          size="md"
+          sx={sx.reportButton}
+          onClick={() => openAddEditEntityModal(entity)}
+        >
+          {verbiage.reportProgressButtonText}
+        </Button>
+      );
+    } else {
+      return;
+    }
+  };
 
   return (
     <Card
@@ -150,35 +187,7 @@ export const EntityStepCard = ({
             {verbiage.entityUnfinishedMessage}
           </Text>
         )}
-        {(openAddEditEntityModal && report?.reportType === ReportType.WP) ||
-          (openAddEditEntityModal &&
-            report?.reportType === ReportType.SAR &&
-            entityCompleted && (
-              <Button
-                variant="outline"
-                size="sm"
-                sx={sx.editButton}
-                leftIcon={
-                  <Image src={editIcon} alt="edit icon" height="1rem" />
-                }
-                onClick={() => openAddEditEntityModal(entity)}
-              >
-                {props?.disabled
-                  ? verbiage.readOnlyEntityButtonText
-                  : verbiage.editEntityButtonText}
-              </Button>
-            ))}
-        {openReportEntityModal &&
-          report?.reportType === ReportType.SAR &&
-          !entityCompleted && (
-            <Button
-              size="md"
-              sx={sx.reportButton}
-              onClick={() => openReportEntityModal(entity)}
-            >
-              {verbiage.reportProgressButtonText}
-            </Button>
-          )}
+        {addEditEntitybutton()}
         {openDrawer && (
           <Button
             size="sm"
@@ -211,7 +220,6 @@ interface Props {
   formattedEntityData: AnyObject;
   verbiage: AnyObject;
   openAddEditEntityModal?: Function;
-  openReportEntityModal?: Function;
   openDeleteEntityModal?: Function;
   openDrawer?: Function;
   printVersion?: boolean;

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -150,28 +150,35 @@ export const EntityStepCard = ({
             {verbiage.entityUnfinishedMessage}
           </Text>
         )}
-        {openAddEditEntityModal && report?.reportType === ReportType.WP && (
-          <Button
-            variant="outline"
-            size="sm"
-            sx={sx.editButton}
-            leftIcon={<Image src={editIcon} alt="edit icon" height="1rem" />}
-            onClick={() => openAddEditEntityModal(entity)}
-          >
-            {props?.disabled
-              ? verbiage.readOnlyEntityButtonText
-              : verbiage.editEntityButtonText}
-          </Button>
-        )}
-        {openReportEntityModal && report?.reportType === ReportType.SAR && (
-          <Button
-            size="md"
-            sx={sx.reportButton}
-            onClick={() => openReportEntityModal(entity)}
-          >
-            {verbiage.editEntityButtonText}
-          </Button>
-        )}
+        {(openAddEditEntityModal && report?.reportType === ReportType.WP) ||
+          (openAddEditEntityModal &&
+            report?.reportType === ReportType.SAR &&
+            entityCompleted && (
+              <Button
+                variant="outline"
+                size="sm"
+                sx={sx.editButton}
+                leftIcon={
+                  <Image src={editIcon} alt="edit icon" height="1rem" />
+                }
+                onClick={() => openAddEditEntityModal(entity)}
+              >
+                {props?.disabled
+                  ? verbiage.readOnlyEntityButtonText
+                  : verbiage.editEntityButtonText}
+              </Button>
+            ))}
+        {openReportEntityModal &&
+          report?.reportType === ReportType.SAR &&
+          !entityCompleted && (
+            <Button
+              size="md"
+              sx={sx.reportButton}
+              onClick={() => openReportEntityModal(entity)}
+            >
+              {verbiage.reportProgressButtonText}
+            </Button>
+          )}
         {openDrawer && (
           <Button
             size="sm"

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -71,8 +71,10 @@ export const OverlayModalPage = ({
     addEditEntityModalOnOpenHandler();
   };
 
-  const openReportEntityModal = () => {
-    // functionality to come
+  const openReportEntityModal = (entity?: EntityShape) => {
+    if (entity) setSelectedStepEntity(entity);
+    addEditEntityModalOnOpenHandler();
+    //probably just remove this in favor of reusing the openAddEditEntityModal function
     return;
   };
 

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -151,15 +151,16 @@ export const OverlayModalPage = ({
               />
             )
           )}
-          {reportFieldDataEntities.length > 1 && (
-            <Button
-              sx={sx.addEntityButton}
-              onClick={addEditEntityModalOnOpenHandler}
-              leftIcon={<Image sx={sx.buttonIcons} src={addIcon} alt="Add" />}
-            >
-              {verbiage.addEntityButtonText}
-            </Button>
-          )}
+          {reportFieldDataEntities.length > 1 &&
+            report?.reportType === ReportType.WP && (
+              <Button
+                sx={sx.addEntityButton}
+                onClick={addEditEntityModalOnOpenHandler}
+                leftIcon={<Image sx={sx.buttonIcons} src={addIcon} alt="Add" />}
+              >
+                {verbiage.addEntityButtonText}
+              </Button>
+            )}
         </Box>
         <hr />
         {/* MODALS */}

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -71,13 +71,6 @@ export const OverlayModalPage = ({
     addEditEntityModalOnOpenHandler();
   };
 
-  const openReportEntityModal = (entity?: EntityShape) => {
-    if (entity) setSelectedStepEntity(entity);
-    addEditEntityModalOnOpenHandler();
-    //probably just remove this in favor of reusing the openAddEditEntityModal function
-    return;
-  };
-
   const closeAddEditEntityModal = () => {
     setSelectedStepEntity(undefined);
     addEditEntityModalOnCloseHandler();
@@ -146,7 +139,6 @@ export const OverlayModalPage = ({
                 printVersion={false}
                 formattedEntityData={getFormattedEntityData(stepType, entity)}
                 openAddEditEntityModal={openAddEditEntityModal}
-                openReportEntityModal={openReportEntityModal}
                 openDeleteEntityModal={openDeleteEntityModal}
                 disabled={userDisabled}
                 hasBoxShadow={true}

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -18,8 +18,6 @@ export const mockGenericEntity = {
   generic_oversightMethodFrequency: [
     { value: "mock-oversight-method-frequency" },
   ],
-  objectivesProgress_performanceMeasuresIndicators:
-    "mock performace indicator answer",
   objectivesProgress_deliverablesMet: [{ value: "No" }],
   objectivesProgress_deliverablesMet_otherText:
     "mock deliverables met other text",

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -18,6 +18,11 @@ export const mockGenericEntity = {
   generic_oversightMethodFrequency: [
     { value: "mock-oversight-method-frequency" },
   ],
+  objectivesProgress_performanceMeasuresIndicators:
+    "mock performace indicator answer",
+  objectivesProgress_deliverablesMet: [{ value: "No" }],
+  objectivesProgress_deliverablesMet_otherText:
+    "mock deliverables met other text",
 };
 
 export const mockUnfinishedGenericFormattedEntityData = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR addresses the answers for Qualitative Objectives (not quantitative, that comes in a future PR).
The status symbol should be correct
the Report/Edit buttons should show up correctly based on if the state user has updated their progress or not
State users responses should show up in the blue boxes after they submit via the modal


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-44

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- create a work plan, add some fun data to an initiative - evaluation plan (that's what you'll see later in the test)
- approve the WP
- create a SAR and head to the State- or Territory-Specific Initiatives section and click into an initiative
- click into the Objective Progress step
- view the Objective Progress card and verify that it matches the figma designs
- click the "Report Objective Progress" button
- modal appears, answer the questions.
- the Yes/No radio button shows a conditional textbox based on "No"

<img width="789" alt="Screenshot 2024-01-07 at 4 53 18 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/a9203c9c-b472-4e5c-985d-72c163ec29f6">
<img width="793" alt="Screenshot 2024-01-07 at 4 53 33 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/3d4ab785-5a5b-4232-965c-bf83b99dc37a">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
