### PR TITLE
[BUG] Update verbiage on Funding Sources Modal

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1177,7 +1177,7 @@
                         },
                         {
                           "id": "2VLpZCRWieGr1Z49QX5Aqc",
-                          "label": "MFP funding for demonstrated services"
+                          "label": "MFP funding for demonstration services"
                         },
                         {
                           "id": "2VLq8ASzZNfxbu520if449",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This change updates the verbiage on the Funding Sources modal

Before:  
![Screenshot 2024-01-08 at 8 10 22 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/291e4ff6-99fe-48e4-b80e-7636da32502e)

After:
![Screenshot 2024-01-08 at 8 09 04 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/9246062/4605fb5a-66bc-41f7-97e4-6b334e3b35ea)



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3153

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign as as state user
2. Navigate to the State- or Territory Specific Initiatives
3. Create an initiative
4. Edit the initiative
5. Add a funding source
6. Click modal to add a funding source. Validate the verbiage

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
