### PR TITLE
Add tests for getEntityStatus

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.tsx
@@ -106,9 +106,9 @@ export const EntityDetailsDashboardOverlay = ({
             initiativeName={selectedEntity?.initiative_name}
           />
           <Table content={tableHeaders()}>
-            {entitySteps?.map((step: any) => (
+            {entitySteps?.map((step, index) => (
               <EntityRow
-                key={step.id}
+                key={`entityrow-${index}`}
                 entity={formatEntityStep(selectedEntity!, step)}
                 entityType={step.entityType}
                 entityInfo={step.stepInfo}

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -7,9 +7,10 @@ import {
   AnyObject,
   EntityShape,
   ModalDrawerEntityTypes,
-  ReportShape,
   OverlayModalTypes,
   EntityDetailsOverlayTypes,
+  EntityDetailsOverlayShape,
+  OverlayModalPageShape,
 } from "types";
 // utils
 import { useStore } from "utils";
@@ -35,7 +36,7 @@ export const EntityRow = ({
 
   // check for "other" target population entities
   const { isRequired, isCopied, isInitiativeClosed, closedBy } = entity;
-  const stepType = (formEntity as AnyObject)?.stepType;
+  const stepType = formEntity?.stepType;
 
   const setStatusByType = (entityType: string) => {
     switch (entityType) {
@@ -192,7 +193,7 @@ export const EntityRow = ({
 interface Props {
   entity: EntityShape;
   entityType?: string;
-  formEntity?: ReportShape;
+  formEntity?: EntityDetailsOverlayShape | OverlayModalPageShape;
   verbiage: AnyObject;
   openAddEditEntityModal: Function;
   openDeleteEntityModal: Function;

--- a/services/ui-src/src/components/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/components/tables/getEntityStatus.test.ts
@@ -1,0 +1,749 @@
+import {
+  EntityDetailsOverlayShape,
+  EntityShape,
+  FormField,
+  OverlayModalPageShape,
+  OverlayModalTypes,
+  ReportShape,
+} from "types";
+import { EntityStatuses } from "./EntityStatusIcon";
+import {
+  getValidationList,
+  getEntityStatus,
+  getInitiativeStatus,
+  getInitiativeDashboardStatus,
+  getCloseoutStatus,
+} from "./getEntityStatus";
+
+describe("Entity status utilities", () => {
+  describe("getValidationList", () => {
+    it("should gather field IDs, nested and otherwise", () => {
+      const fields = [
+        {
+          id: "field1",
+          type: "text",
+          validation: "text",
+        },
+        {
+          id: "field2",
+          type: "radio",
+          validation: "radio",
+          props: {
+            choices: [
+              {
+                id: "choice1",
+                children: [
+                  {
+                    id: "nestedField3",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ];
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        field1: {
+          key: "field1key",
+        },
+        field2: {
+          key: "choice1key",
+        },
+      };
+
+      const result = getValidationList(fields, entity);
+
+      expect(result).toEqual(["field1", "field2", "nestedField3"]);
+    });
+  });
+
+  describe("getEntityStatus", () => {
+    it("should recognize when an entity is complete", () => {
+      const report = {
+        formTemplate: {
+          flatRoutes: [
+            {
+              entityType: "mockEntityType",
+              form: {
+                fields: [
+                  {
+                    id: "field1",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "mockEntityId",
+        type: "initiative" as const,
+        field1: "mock text data",
+      };
+      const entityType = "mockEntityType";
+
+      const result = getEntityStatus(report, entity, entityType);
+
+      expect(result).toBe(true);
+    });
+
+    it("should recognize when an entity is not complete", () => {
+      const report = {
+        formTemplate: {
+          flatRoutes: [
+            {
+              entityType: "mockEntityType",
+              form: {
+                fields: [
+                  {
+                    id: "field1",
+                    type: "text",
+                    validation: "text",
+                  },
+                  {
+                    id: "field2",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "mockEntityId",
+        type: "initiative" as const,
+        field1: "mock text data",
+      };
+      const entityType = "mockEntityType";
+
+      const result = getEntityStatus(report, entity, entityType);
+
+      expect(result).toBe(false);
+    });
+
+    it("should ignore irrelevant routes", () => {
+      const report = {
+        formTemplate: {
+          flatRoutes: [
+            {
+              entityType: "different entity type",
+              form: {
+                fields: [
+                  {
+                    id: "field2",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+            {
+              entityType: "mockEntityType",
+              form: {
+                fields: [
+                  {
+                    id: "field1",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "mockEntityId",
+        type: "initiative" as const,
+        field1: "mock text data",
+      };
+      const entityType = "mockEntityType";
+
+      const result = getEntityStatus(report, entity, entityType);
+
+      expect(result).toBe(true);
+    });
+
+    // TODO this feels like a bug, right? Or can it never come up?
+    it("should ignore subsequent routes?", () => {
+      const report = {
+        formTemplate: {
+          flatRoutes: [
+            {
+              entityType: "mockEntityType",
+              form: {
+                fields: [
+                  {
+                    id: "field1",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+            {
+              entityType: "mockEntityType",
+              form: {
+                fields: [
+                  {
+                    id: "field2",
+                    type: "text",
+                    validation: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "mockEntityId",
+        type: "initiative" as const,
+        field1: "mock text data",
+      };
+      const entityType = "mockEntityType";
+
+      const result = getEntityStatus(report, entity, entityType);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("getInitiativeStatus", () => {
+    it("should return CLOSE for closed initiatives", () => {
+      const report = {} as ReportShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative",
+        isInitiativeClosed: true,
+      } as EntityShape;
+      const isPdf = false;
+      const ignore: string[] = [];
+
+      const result = getInitiativeStatus(report, entity, isPdf, ignore);
+
+      expect(result).toBe(EntityStatuses.CLOSE);
+    });
+
+    it("should return false for entities without steps", () => {
+      const report = {
+        formTemplate: {
+          routes: [
+            {},
+            {},
+            {},
+            {
+              children: [
+                {
+                  entityType: OverlayModalTypes.INITIATIVE,
+                },
+              ],
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative",
+        isInitiativeClosed: false,
+      } as EntityShape;
+      const isPdf = false;
+      const ignore: string[] = [];
+
+      const result = getInitiativeStatus(report, entity, isPdf, ignore);
+
+      expect(result).toBe(false);
+    });
+
+    it("should check all steps for completeness", () => {
+      const report = {
+        formTemplate: {
+          routes: [
+            {},
+            {},
+            {},
+            {
+              children: [
+                {
+                  // we are in reportChild
+                  entityType: OverlayModalTypes.INITIATIVE,
+                  entitySteps: [
+                    {
+                      stepType: "mock step type",
+                      form: {
+                        fields: [
+                          {
+                            id: "field1",
+                            type: "text",
+                            validation: "text",
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      } as ReportShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative",
+        isInitiativeClosed: false,
+      } as EntityShape;
+      const isPdf = false;
+      const ignore: string[] = [];
+
+      let result = getInitiativeStatus(report, entity, isPdf, ignore);
+      expect(result).toBe(false);
+
+      (entity as any).field1 = "mock data";
+      result = getInitiativeStatus(report, entity, isPdf, ignore);
+      expect(result).toBe(true);
+    });
+  });
+
+  it("should ignore specified step types", () => {
+    const report = {
+      formTemplate: {
+        routes: [
+          {},
+          {},
+          {},
+          {
+            children: [
+              {
+                // we are in reportChild
+                entityType: OverlayModalTypes.INITIATIVE,
+                entitySteps: [
+                  {
+                    stepType: "mock step type",
+                    form: {
+                      fields: [
+                        {
+                          id: "field1",
+                          type: "text",
+                          validation: "text",
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    stepType: "other step type",
+                    form: {
+                      fields: [
+                        {
+                          id: "field2",
+                          type: "text",
+                          validation: "text",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as ReportShape;
+    const entity = {
+      id: "entity1",
+      type: "initiative",
+      isInitiativeClosed: false,
+      field1: "mock value",
+    } as EntityShape;
+    const isPdf = false;
+    let ignore: string[] = [];
+
+    let result = getInitiativeStatus(report, entity, isPdf, ignore);
+    expect(result).toBe(false);
+
+    ignore = ["other step type"];
+    result = getInitiativeStatus(report, entity, isPdf, ignore);
+    expect(result).toBe(true);
+  });
+
+  it("should ignore the closeout step when evaluating for PDF", () => {
+    const report = {
+      formTemplate: {
+        routes: [
+          {},
+          {},
+          {},
+          {
+            children: [
+              {
+                // we are in reportChild
+                entityType: OverlayModalTypes.INITIATIVE,
+                entitySteps: [
+                  {
+                    stepType: "fundingSources",
+                    form: {
+                      fields: [
+                        {
+                          id: "field1",
+                          type: "text",
+                          validation: "text",
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    stepType: "closeOutInformation",
+                    form: {
+                      fields: [
+                        {
+                          id: "field2",
+                          type: "text",
+                          validation: "text",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as ReportShape;
+    const entity = {
+      id: "entity1",
+      type: "initiative",
+      isInitiativeClosed: false,
+      field1: "mock value",
+    } as EntityShape;
+    let isPdf = false;
+    const ignore: string[] = [];
+
+    let result = getInitiativeStatus(report, entity, isPdf, ignore);
+    expect(result).toBe(false);
+
+    isPdf = true;
+    result = getInitiativeStatus(report, entity, isPdf, ignore);
+    expect(result).toBe(true);
+  });
+
+  describe("getInitiativeDashboardStatus", () => {
+    it("should find completed fields", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        form: {
+          // TODO test modalForm
+          fields: [
+            {
+              id: "field1",
+              type: "text",
+              validation: "text",
+            },
+          ],
+        },
+      } as EntityDetailsOverlayShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        mockStepType: [
+          {
+            field1: "mock value",
+          },
+        ],
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(true);
+    });
+
+    it("should find when fields are not completed", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        form: {
+          fields: [
+            {
+              id: "field1",
+              type: "text",
+              validation: "text",
+            },
+          ],
+        },
+      } as EntityDetailsOverlayShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        mockStepType: [
+          {
+            /* no data */
+          },
+        ],
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(false);
+    });
+
+    it("should find fields in modalForm when there is no form", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        modalForm: {
+          fields: [
+            {
+              id: "field1",
+              type: "text",
+              validation: "text",
+            },
+          ],
+        },
+      } as OverlayModalPageShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(false);
+    });
+
+    it("should work for entities without steps", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        form: {
+          fields: [
+            {
+              id: "field1",
+              type: "text",
+              validation: "text",
+            },
+          ],
+        },
+      } as EntityDetailsOverlayShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        field1: "mock value",
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(true);
+    });
+
+    it("should require nested form fields", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        form: {
+          fields: [
+            {
+              id: "field1",
+              type: "radio",
+              validation: "radio",
+              props: {
+                choices: [
+                  {
+                    id: "choice1",
+                    children: [
+                      {
+                        id: "nestedField2",
+                        type: "text",
+                        validation: "text",
+                      } as FormField,
+                    ],
+                  },
+                ],
+              },
+            } as FormField,
+          ],
+        },
+      } as EntityDetailsOverlayShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        field1: "mock value",
+        mockObj: {
+          key: "choice1Key",
+        },
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(false);
+    });
+
+    it("should find values for required nested form fields", () => {
+      const formEntity = {
+        stepType: "mockStepType",
+        form: {
+          fields: [
+            {
+              id: "field1",
+              type: "radio",
+              validation: "radio",
+              props: {
+                choices: [
+                  {
+                    id: "choice1",
+                    children: [
+                      {
+                        id: "nestedField2",
+                        type: "text",
+                        validation: "text",
+                      } as FormField,
+                    ],
+                  },
+                ],
+              },
+            } as FormField,
+          ],
+        },
+      } as EntityDetailsOverlayShape;
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        field1: "mock value",
+        mockObj: {
+          key: "choice1Key",
+        },
+        nestedField2: "mock value",
+      };
+
+      const result = getInitiativeDashboardStatus(formEntity, entity);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("getCloseoutStatus", () => {
+    it("should return true when an entity includes all fields ", () => {
+      const form = {
+        id: "form1",
+        fields: [
+          {
+            id: "field1",
+            type: "text",
+            validation: "text",
+          },
+        ],
+      };
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        field1: "mock value",
+      };
+
+      const result = getCloseoutStatus(form, entity);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when an entity does not include all fields", () => {
+      const form = {
+        id: "form1",
+        fields: [
+          {
+            id: "field1",
+            type: "text",
+            validation: "text",
+          },
+        ],
+      };
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+      };
+
+      const result = getCloseoutStatus(form, entity);
+
+      expect(result).toBe(false);
+    });
+
+    it("should not require optional fields", () => {
+      const form = {
+        id: "form1",
+        fields: [
+          {
+            id: "field1",
+            type: "text",
+            validation: "textOptional",
+          },
+          {
+            id: "field2",
+            type: "text",
+            validation: {
+              type: "textOptional",
+            },
+          },
+        ],
+      };
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+      };
+
+      const result = getCloseoutStatus(form, entity);
+
+      expect(result).toBe(true);
+    });
+
+    it("should require the termination reason for discontinued initiatives", () => {
+      const form = {
+        id: "form1",
+        fields: [],
+      };
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        closeOutInformation_initiativeStatus: [
+          {
+            value: "Discontinued initiative",
+          },
+        ],
+      };
+
+      // Without
+      let result = getCloseoutStatus(form, entity);
+      expect(result).toBe(false);
+
+      // With
+      (entity as any)[
+        "closeOutInformation_initiativeStatus-terminationReason"
+      ] = "mock text";
+      result = getCloseoutStatus(form, entity);
+      expect(result).toBe(true);
+    });
+
+    it("should require the alternate funding for Medicaid-sustained initiatives", () => {
+      const form = {
+        id: "form1",
+        fields: [],
+      };
+      const entity = {
+        id: "entity1",
+        type: "initiative" as const,
+        closeOutInformation_initiativeStatus: [
+          {
+            value: "Sustaining initiative through a Medicaid authority",
+          },
+        ],
+      };
+
+      // Without
+      let result = getCloseoutStatus(form, entity);
+      expect(result).toBe(false);
+
+      // With
+      (entity as any)["closeOutInformation_initiativeStatus-alternateFunding"] =
+        "mock text";
+      result = getCloseoutStatus(form, entity);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -136,7 +136,7 @@ export const getInitiativeStatus = (
 
 //NOTE: this function works on the assumption that the fieldData saved is validated
 export const getInitiativeDashboardStatus = (
-  formEntity: AnyObject,
+  formEntity: EntityDetailsOverlayShape | OverlayModalPageShape,
   entity: EntityShape
 ) => {
   const stepType = formEntity.stepType;
@@ -179,9 +179,12 @@ export const getCloseoutStatus = (form: FormJson, entity: EntityShape) => {
   if (entity) {
     const fieldIds = form.fields
       .map((field) => {
-        return !(field as AnyObject)?.validation.includes("Optional")
-          ? field.id
-          : "";
+        // Some fields have validation: "foo", and some have validation: { type: "foo" }
+        let validationType = (field as AnyObject)?.validation ?? "";
+        if (typeof validationType === "object") {
+          validationType = validationType.type ?? "";
+        }
+        return !validationType.includes("Optional") ? field.id : "";
       })
       .filter((field) => field);
     const isFilled = fieldIds.map((id) => {

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -83,6 +83,7 @@ export interface ModalOverlayReportPageShape extends ReportPageShapeBase {
 export interface EntityDetailsOverlayShape extends ReportPageShapeBase {
   stepType: string;
   stepName: string;
+  stepInfo: string[];
   hint: string;
   form: FormJson;
   entityType: string;
@@ -97,6 +98,7 @@ export interface OverlayModalPageShape extends ReportPageShapeBase {
   entityType: string;
   stepType: string;
   stepName: string;
+  stepInfo: string[];
   hint: string;
   verbiage: ModalOverlayReportPageVerbiage;
   modalForm: FormJson;

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -300,6 +300,7 @@ export const mockEntityDetailsOverlayJson = {
   form: mockForm,
   stepType: "mock-step",
   stepName: "Mock step name",
+  stepInfo: ["name", "hint"],
   hint: "Mock hint",
   entityType: "mock-entity-type",
 };

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -346,6 +346,7 @@ export const mockOverlayModalPageJson = {
   modalForm: mockModalForm,
   stepType: "mock-step",
   stepName: "Mock step name",
+  stepInfo: ["name, hint"],
   hint: "Mock hint",
 };
 


### PR DESCRIPTION
### Description
Some new tests, with two changes to "real" code:
1. Fix the type for EntityRow.formEntity.
   * This was set to the wrong type (ReportJson), but it was being cast to `any` on the way in (in EntityDetailsDashboardOverlay) and on the way out (to getEntityStatus.getInitiativeDashboardStatus)
   * This is almost a no-op change; Typescript type annotations have no effect on runtime behavior.
   * However it _did_ expose a bug with the `EntityRow.key`; I believe all rows were getting the same key. Now they will get an index-based key.
2. Fix a potential bug when detecting optional fields in getCloseoutStatus
   * Sometimes validation is a string, sometimes it's an object.
   * I don't believe this bug ever manifested; if I recall correctly, all of our optional fields currently have validation as a string in the form template.
   * But it's better to be safe than sorry! Maybe we'll have such fields in the future.

### Related ticket(s)
CMDCT-3121

---
### How to test
`yarn test --coverage`

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
