### PR TITLE
SAR PDF - Additional Achievements 

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -1402,57 +1402,27 @@
                 },
                 {
                   "type": "li",
-                  "content": "Convenient and accessible transportation options",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Convenient and accessible transportation options"
                 },
                 {
                   "type": "li",
-                  "content": "Data-based decision-making",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Data-based decision-making"
                 },
                 {
                   "type": "li",
-                  "content": "Financing approaches",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Financing approaches"
                 },
                 {
                   "type": "li",
-                  "content": "Stakeholder agreement",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Stakeholder agreement"
                 },
                 {
                   "type": "li",
-                  "content": "Quality measurement and improvement",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Quality measurement and improvement"
                 },
                 {
                   "type": "li",
-                  "content": "Equity and social determinants of health",
-                  "props": {
-                    "style": {
-                      "marginLeft": "1rem"
-                    }
-                  }
+                  "content": "Equity and social determinants of health"
                 }
               ]
             }

--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -105,7 +105,9 @@
           {
             "id": "generalInformation_hasAorChangedSinceLastReport",
             "type": "radio",
-            "validation":"radio",
+            "validation": {
+              "type": "radio"
+            },
             "props": {
               "label": "Has the AOR changed since last report?",
               "choices": [
@@ -989,7 +991,6 @@
               ],
               "dashboardTitle": "Objectives progress"
             },
-            "editEntityButtonText": "Report objective progress",
             "enterEntityDetailsButtonText": "Edit",
             "readOnlyEntityDetailsButtonText": "View",
             "modalTitle": "Report progress for ",

--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -1371,6 +1371,7 @@
               "props": {
                 "style": {
                   "columns": "2",
+                  "columnGap": "2rem",
                   "paddingLeft": "1rem",
                   "color": "#5A5A5A",
                   "li::before": {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -50,7 +50,7 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
 
   const { modalOverlayTableHeaders } = verbiage;
 
-  const headerLabels = Object.values(
+  const headerLabels = Object!.values(
     modalOverlayTableHeaders as Record<string, string>
   );
 
@@ -212,9 +212,23 @@ export function renderModalOverlayTableBody(
         );
       });
     case ReportType.SAR:
-      throw new Error(
-        `The modal overlay table headers for report type '${reportType}' have not been implemented.`
-      );
+      return entities.map((entity, idx) => {
+        return (
+          <Box sx={sx.container}>
+            <Tr key={idx}>
+              <Td>
+                <Heading sx={sx.heading} as="h2">
+                  {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
+                  <br />
+                  <Text sx={sx.headingSubtitle}>
+                    {entity.initiative_wpTopic[0].value}
+                  </Text>
+                </Heading>
+              </Td>
+            </Tr>
+          </Box>
+        );
+      });
     default:
       assertExhaustive(reportType);
       throw new Error(

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -134,7 +134,7 @@ const sx = {
       p: {
         lineHeight: "1.25rem",
       },
-      padding: "0.75rem 0.5rem",
+      padding: "0.75rem 0.5rem 0.75rem 0",
       borderStyle: "none",
       fontWeight: "normal",
       color: "palette.base",

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -11,6 +11,7 @@ import {
   FormLayoutElement,
   isFieldElement,
   ReportType,
+  FieldChoice,
 } from "types";
 // verbiage
 import verbiage from "verbiage/pages/wp/wp-export";
@@ -87,7 +88,17 @@ export const renderFieldTableBody = (
     if (pageType === "drawer") {
       return;
     }
+
+    // Handle rendering nested children
+    if (isFieldElement(formField) && formField.props?.choices) {
+      formField.props.choices.forEach((choice: FieldChoice) => {
+        if (choice.children) {
+          choice.children.forEach((c) => renderFieldRow(c));
+        }
+      });
+    }
   };
+
   // map through form fields and call renderer
   formFields?.map((field: FormField | FormLayoutElement) => {
     if (isFieldElement(field)) {

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -9,6 +9,7 @@ export const ExportedSectionHeading = ({ heading, verbiage }: Props) => {
   const sectionHeading = verbiage?.intro?.exportSectionHeader
     ? verbiage?.intro?.exportSectionHeader
     : verbiage?.intro?.subsection || heading;
+  const sectionHint = verbiage?.intro?.hint ? verbiage?.intro?.hint : null;
   const sectionInfo =
     verbiage?.intro?.exportSectionHeader ||
     verbiage?.intro?.subsection === "State- or Territory-Specific Initiatives"
@@ -22,6 +23,7 @@ export const ExportedSectionHeading = ({ heading, verbiage }: Props) => {
       <Heading as="h2" sx={sx.heading}>
         {sectionHeading}
       </Heading>
+      <Box sx={sx.hintTextBox}>{sectionHint}</Box>
       {!stateAndTerritory && sectionInfo && (
         <Box sx={sx.info}>{parseCustomHtml(sectionInfo)}</Box>
       )}
@@ -47,12 +49,20 @@ const sx = {
     fontWeight: "bold",
   },
   info: {
+    paddingTop: "1.5rem",
     p: {
       margin: "1.5rem 0",
     },
     h3: {
       fontSize: "lg",
     },
+    li: {
+      paddingBottom: "1.5rem",
+    },
+  },
+  hintTextBox: {
+    color: "#5B616B",
+    margin: "1.5rem 0",
   },
   spreadsheet: {
     margin: "1.5rem 0",

--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -57,7 +57,7 @@ const sx = {
       fontSize: "lg",
     },
     li: {
-      paddingBottom: "1.5rem",
+      marginBottom: "1.5rem",
     },
   },
   hintTextBox: {

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -76,7 +76,7 @@ export const reportTitle = (
     case ReportType.WP:
       return `${report.fieldData.stateName} ${reportPage.heading} ${report.reportYear} - Period ${report.reportPeriod}`;
     case ReportType.SAR:
-      return `THIS IS A SARRRRRRRR`;
+      return `${report.fieldData.stateName} ${reportPage.heading} ${report.reportYear} - Period ${report.reportPeriod}`;
     default:
       assertExhaustive(reportType);
       throw new Error(

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -72,6 +72,9 @@ const sx = {
   infoTextBox: {
     marginTop: "1rem",
     color: "palette.gray",
+    li: {
+      paddingBottom: "1.5rem",
+    },
     h3: {
       marginBottom: "-0.75rem",
     },

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -14,6 +14,10 @@ const standardPageSectionComponent = (
   </RouterWrappedComponent>
 );
 
+global.structuredClone = jest.fn((val) => {
+  return JSON.parse(JSON.stringify(val));
+});
+
 describe("Test StandardReportPage", () => {
   test("StandardReportPage view renders", () => {
     render(standardPageSectionComponent);

--- a/services/ui-src/src/components/reports/StandardReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.test.tsx
@@ -8,10 +8,6 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-global.structuredClone = jest.fn((val) => {
-  return JSON.parse(JSON.stringify(val));
-});
-
 const standardPageSectionComponent = (
   <RouterWrappedComponent>
     <StandardReportPage route={mockStandardReportPageJson} />

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -140,7 +140,7 @@ export const renderResponseData = (
   const missingEntryStyle = notApplicable ? sx.notApplicable : sx.noResponse;
   if (!hasResponse)
     return <Text sx={missingEntryStyle}>{missingEntryVerbiage}; required</Text>;
-  // chandle choice list fields (checkbox, radio)
+  // handle choice list fields (checkbox, radio)
   if (isChoiceListField) {
     return renderChoiceListFieldResponse(
       formField,
@@ -236,6 +236,7 @@ export const parseFormFieldInfo = (formFieldProps?: AnyObject) => {
   )
     return {};
   const labelArray = formFieldProps?.label?.split(" ");
+
   return {
     number: labelArray?.[0].match(/[-.0-9]+/) ? labelArray?.[0] : "N/A",
     label: labelArray?.[0].match(/[-.0-9]+/)
@@ -243,6 +244,7 @@ export const parseFormFieldInfo = (formFieldProps?: AnyObject) => {
       : labelArray?.join(" "),
     hint: formFieldProps?.hint,
     indicator: formFieldProps?.indicator,
+    choices: formFieldProps?.choices,
   };
 };
 

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -26,6 +26,7 @@ export default {
         "Enrollees in separate CHIP programs funded under Title XXI should not be reported in the SAR. Please check this box if the state is unable to remove information about Separate CHIP enrollees from its reporting on this program.",
     },
   },
+  modalOverlayTableHeaders: {},
   tableHeaders: {
     number: "Number",
     indicator: "Indicator",


### PR DESCRIPTION
### Description
1. Add Additional Achievements to SAR PDF (w/ style ajustments)
2. Nested choices now render in SAR PDF


### Related ticket(s)
[CMDCT-3108](https://jiraent.cms.gov/browse/CMDCT-3108)

---
### How to test
1. Fill out SAR
2. View PDF and scroll to bottom to check Additional Achievements 

( The red border was already there. It may be to mark the table sections so I left it alone )


<img width="641" alt="Screenshot 2024-01-09 at 2 40 16 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/f542ed72-f8df-4288-b410-a90955bdaf31">


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
