### PR TITLE
FormTemplate Versions Option 1 - Hash

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -143,8 +143,13 @@ export const createReport = handler(
       unvalidatedMetadata?.copyReport?.isCopyOverTest;
 
     if (overrideCopyOver) {
+      if (unvalidatedMetadata?.copyReport?.reportPeriod)
+        reportPeriod = unvalidatedMetadata?.copyReport?.reportPeriod;
+      if (unvalidatedMetadata?.copyReport?.reportYear)
+        reportYear = unvalidatedMetadata?.copyReport?.reportYear;
+
       reportYear = reportPeriod == 2 ? reportYear + 1 : reportYear;
-      reportPeriod = reportPeriod == 1 ? 2 : 1;
+      reportPeriod = (reportPeriod % 2) + 1;
     }
 
     // Begin Section - Getting/Creating newest Form Template based on reportType
@@ -155,8 +160,7 @@ export const createReport = handler(
         reportType,
         reportPeriod,
         reportYear,
-        workPlanFieldData,
-        unvalidatedMetadata?.copyReport!
+        workPlanFieldData
       ));
     } catch (err) {
       logger.error(err, "Error getting or creating template");

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -11,7 +11,13 @@ import {
 import wp from "../../forms/wp.json";
 import sar from "../../forms/sar.json";
 import { createHash } from "crypto";
-import { FormJson, ReportJson, ReportRoute, ReportType } from "../types";
+import {
+  AnyObject,
+  FormJson,
+  ReportJson,
+  ReportRoute,
+  ReportType,
+} from "../types";
 import {
   mockDocumentClient,
   mockReportJson,
@@ -19,7 +25,6 @@ import {
 } from "../testing/setupJest";
 import s3Lib from "../s3/s3-lib";
 import dynamodbLib from "../dynamo/dynamodb-lib";
-import { AnyObject } from "yup/lib/types";
 
 const mockWorkPlanFieldData = mockWPMetadata.fieldData;
 const reportPeriod = 2;

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -126,7 +126,7 @@ describe("Test getOrCreateFormTemplate WP", () => {
     const currentWPFormHash = generateReportHash(
       wp,
       reportYear,
-      reportPeriod,
+      reportPeriod - 1,
       mockWorkPlanFieldData
     );
 
@@ -156,7 +156,7 @@ describe("Test getOrCreateFormTemplate WP", () => {
     const result = await getOrCreateFormTemplate(
       "local-wp-reports",
       ReportType.WP,
-      reportPeriod,
+      reportPeriod - 1,
       reportYear,
       mockWorkPlanFieldData
     );
@@ -245,7 +245,7 @@ describe("Test getOrCreateFormTemplate SAR", () => {
     const currentSARFormHash = generateReportHash(
       sar,
       reportYear,
-      reportPeriod,
+      reportPeriod - 1,
       mockWorkPlanFieldData
     );
     const dynamoDBMockReturn = {
@@ -274,7 +274,7 @@ describe("Test getOrCreateFormTemplate SAR", () => {
     const result = await getOrCreateFormTemplate(
       "local-sar-reports",
       ReportType.SAR,
-      reportPeriod,
+      reportPeriod - 1,
       reportYear,
       mockWorkPlanFieldData
     );

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -35,7 +35,7 @@ export async function getNewestTemplateVersion(reportType: ReportType) {
     ScanIndexForward: false, // true = ascending, false = descending
   };
   const result = await dynamodbLib.query(queryParams);
-  return result.Items?.[0];
+  return result?.Items?.[0];
 }
 
 export async function getTemplateVersionByHash(
@@ -53,7 +53,7 @@ export async function getTemplateVersionByHash(
     },
   };
   const result = await dynamodbLib.query(queryParams);
-  return result.Items?.[0];
+  return result?.Items?.[0];
 }
 
 export const formTemplateForReportType = (reportType: ReportType) => {
@@ -429,7 +429,7 @@ export async function getOrCreateFormTemplate(
   );
 
   //if a template of this hash already exist
-  if (matchTemplateVersion) {
+  if (currentTemplateHash === matchTemplateVersion?.md5Hash) {
     return {
       formTemplate: await getTemplate(
         reportBucket,

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -38,6 +38,24 @@ export async function getNewestTemplateVersion(reportType: ReportType) {
   return result.Items?.[0];
 }
 
+export async function getTemplateVersionByHash(
+  reportType: ReportType,
+  hash: string
+) {
+  const queryParams: QueryInput = {
+    TableName: process.env.FORM_TEMPLATE_TABLE_NAME!,
+    IndexName: "HashIndex",
+    KeyConditionExpression: "reportType = :reportType AND md5Hash = :md5Hash",
+    Limit: 1,
+    ExpressionAttributeValues: {
+      ":md5Hash": hash as AttributeValue,
+      ":reportType": reportType as unknown as AttributeValue,
+    },
+  };
+  const result = await dynamodbLib.query(queryParams);
+  return result.Items?.[0];
+}
+
 export const formTemplateForReportType = (reportType: ReportType) => {
   switch (reportType) {
     case ReportType.WP:
@@ -376,50 +394,58 @@ export async function getOrCreateFormTemplate(
   reportType: ReportType,
   reportPeriod: number,
   reportYear: number,
-  workPlanFieldData?: AnyObject,
-  copyReport?: AnyObject
+  workPlanFieldData?: AnyObject
 ) {
   //Make a copy of the form template so we don't accidentally corrupt the original
   const currentFormTemplate = structuredClone(
     formTemplateForReportType(reportType)
   );
-  const stringifiedTemplate = JSON.stringify(currentFormTemplate);
 
-  const currentTemplateHash = createHash("md5")
-    .update(stringifiedTemplate)
-    .digest("hex");
-
-  const mostRecentTemplateVersion = await getNewestTemplateVersion(reportType);
-  const mostRecentTemplateVersionHash = mostRecentTemplateVersion?.md5Hash;
-
-  if (currentTemplateHash === mostRecentTemplateVersionHash && !copyReport) {
-    return {
-      formTemplate: await getTemplate(
-        reportBucket,
-        getFormTemplateKey(mostRecentTemplateVersion?.id)
-      ),
-      formTemplateVersion: mostRecentTemplateVersion,
-    };
-  } else {
-    const newFormTemplateId = KSUID.randomSync().string;
-
+  if (currentFormTemplate?.routes) {
     // traverse routes and scan for conditional field
     currentFormTemplate.routes = scanForConditionalRoutes(
       currentFormTemplate.routes,
       reportPeriod
     );
 
+    //transformation of the formTemplate to generate new quarters
     findAndRunFieldTransformationRules(
       currentFormTemplate.routes,
       reportPeriod,
       reportYear,
       workPlanFieldData
     );
+  }
+
+  const stringifiedTemplate = JSON.stringify(currentFormTemplate);
+
+  const currentTemplateHash = createHash("md5")
+    .update(stringifiedTemplate)
+    .digest("hex");
+
+  const matchTemplateVersion = await getTemplateVersionByHash(
+    reportType,
+    currentTemplateHash
+  );
+
+  //if a template of this hash already exist
+  if (matchTemplateVersion) {
+    return {
+      formTemplate: await getTemplate(
+        reportBucket,
+        getFormTemplateKey(matchTemplateVersion?.id)
+      ),
+      formTemplateVersion: matchTemplateVersion,
+    };
+  } else {
+    const newFormTemplateId = KSUID.randomSync().string;
 
     const formTemplateWithValidationJson = {
       ...currentFormTemplate,
       validationJson: getValidationFromFormTemplate(currentFormTemplate),
     };
+
+    //saving new version of the formTemplate to the database
     try {
       await s3Lib.put({
         Key: getFormTemplateKey(newFormTemplateId),
@@ -431,6 +457,11 @@ export async function getOrCreateFormTemplate(
       logger.error(err, "Error uploading new form template to S3");
       throw err;
     }
+
+    //getting the latest version so that if there isn't a match, we can use this to save to the next iteration
+    const mostRecentTemplateVersion = await getNewestTemplateVersion(
+      reportType
+    );
 
     // If we didn't find any form templates, start version at 1.
     const newFormTemplateVersionItem: FormTemplate = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Using hash to determine which version of the formTemplate to return to the user.

When a user creates a form, the system will get the base WP/SAR json, make a copy of it and then run the scan and transformation rules on the form copy. Once it finishes modifying that form, it will generate a hash out of that data and then check the database to see if a formTemplate with the same hash exist. If that hash exist, we retrieve that saved formTemplate and return it to the user, if not, we save the form copy we just created to the database. 

This is a temporary fix for the bug in prod until we can fully implement @benmartin-coforma FormTemplate version.

![Screenshot 2024-01-09 at 4 44 58 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/b7b05607-f4dd-4ffa-a402-cf3d0a078cd1)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3161

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Run local dynamodb to be able to see if the versions are updating correctly

1) Sign into MFP as a state user.
2) Create, fill out and submit a WP.
3) Sign out and sign in as an Admin. Approve the submitted WP
4) Sign out and sign back in as the previous state user.
5) Create a WP copy.
6) Do the previous steps as many times as deserved. Each WP copied should be its own version in the database.
7) Sign in as a different state user and go through the same process
8) This state user should be using the previous created forms instead of creating a new form.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
