### PR TITLE
CMDCT-3104: [PDF] SAR General Information Page + Metadata Table

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -212,9 +212,7 @@ export function renderModalOverlayTableBody(
         );
       });
     case ReportType.SAR:
-      throw new Error(
-        `The modal overlay table headers for report type '${reportType}' have not been implemented.`
-      );
+      return <></>;
     default:
       assertExhaustive(reportType);
       throw new Error(

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -1,11 +1,7 @@
 import { ReactElement } from "react";
 // components
-import { Box } from "@chakra-ui/react";
-import {
-  ExportedSectionHeading,
-  ExportedReportFieldRow,
-  Table,
-} from "components";
+import { Box, Heading } from "@chakra-ui/react";
+import { ExportedReportFieldRow, Table } from "components";
 // types, utils
 import { useStore } from "utils";
 import {
@@ -105,10 +101,11 @@ const renderGeneralInformation = (
   return headings.map((heading: string, idx: number) => {
     return (
       <Box key={idx}>
-        <ExportedSectionHeading heading={heading} />
+        <Heading as="h3" sx={sx.heading}>
+          {heading}
+        </Heading>
         <Table
           sx={sx.root}
-          className={"two-column"}
           content={{
             headRow: [
               verbiage.reportPage.sarDetailsTable.headers.indicator,
@@ -220,5 +217,9 @@ const sx = {
         },
       },
     },
+  },
+  heading: {
+    fontSize: "xl",
+    fontWeight: "bold",
   },
 };

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -188,6 +188,7 @@ const sx = {
       lineHeight: "base",
       borderBottom: "1px solid",
       borderColor: "palette.gray_lighter",
+      paddingLeft: "0",
     },
     thead: {
       //this will prevent generating a new header whenever the table spills over in another page

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -113,9 +113,4 @@ const sx = {
       paddingBottom: "0rem",
     },
   },
-  sarDetailsTable: {
-    td: {
-      fontWeight: "bold",
-    },
-  },
 };

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -11,8 +11,27 @@ export const ExportedReportMetadataTable = ({
 }: Props) => {
   const { report } = useStore() ?? {};
   return (
+    <>
+      <Table
+        data-testid="exportedReportMetadataTable"
+        sx={sx.metadataTable}
+        content={{
+          headRow: headerRowLabels(reportType, verbiage),
+          bodyRows: bodyRowContent(reportType, report),
+        }}
+      />
+      {reportType === ReportType.SAR && (
+        <ExportedSarDetailsTable reportType={reportType} verbiage={verbiage} />
+      )}
+    </>
+  );
+};
+
+export const ExportedSarDetailsTable = ({ reportType, verbiage }: Props) => {
+  const { report } = useStore() ?? {};
+  return (
     <Table
-      data-testid="exportedReportMetadataTable"
+      data-testid="exportedSarDetailsTable"
       sx={sx.metadataTable}
       content={{
         headRow: headerRowLabels(reportType, verbiage),
@@ -73,9 +92,10 @@ export const bodyRowContent = (
       return [
         [
           report?.submissionName ?? "",
-          convertDateUtcToEt(report?.lastAltered),
-          report?.lastAlteredBy,
-          report?.status,
+          convertDateUtcToEt(report.dueDate),
+          convertDateUtcToEt(report.lastAltered),
+          report.status,
+          report.lastAlteredBy,
         ],
       ];
     default:

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -1,5 +1,5 @@
 // components
-import { Table } from "components";
+import { ExportedSarDetailsTable, Table } from "components";
 // utils
 import { ReportShape, ReportType } from "types";
 import { convertDateUtcToEt, useStore } from "utils";
@@ -21,23 +21,9 @@ export const ExportedReportMetadataTable = ({
         }}
       />
       {reportType === ReportType.SAR && (
-        <ExportedSarDetailsTable reportType={reportType} verbiage={verbiage} />
+        <ExportedSarDetailsTable verbiage={verbiage} />
       )}
     </>
-  );
-};
-
-export const ExportedSarDetailsTable = ({ reportType, verbiage }: Props) => {
-  const { report } = useStore() ?? {};
-  return (
-    <Table
-      data-testid="exportedSarDetailsTable"
-      sx={sx.metadataTable}
-      content={{
-        headRow: headerRowLabels(reportType, verbiage),
-        bodyRows: bodyRowContent(reportType, report),
-      }}
-    />
   );
 };
 
@@ -125,6 +111,11 @@ const sx = {
       fontWeight: "bold",
       textAlign: "left",
       paddingBottom: "0rem",
+    },
+  },
+  sarDetailsTable: {
+    td: {
+      fontWeight: "bold",
     },
   },
 };

--- a/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
@@ -1,0 +1,63 @@
+// components
+import { Table } from "components";
+// types
+import { Choice, ReportShape } from "types";
+// utils
+import { useStore } from "utils";
+
+export const ExportedSarDetailsTable = ({ verbiage }: Props) => {
+  const { report } = useStore() ?? {};
+  return (
+    <Table
+      data-testid="exportedSarDetailsTable"
+      sx={sx.sarDetailsTable}
+      content={{
+        headRow: [
+          verbiage.sarDetailsTable.headers.indicator,
+          verbiage.sarDetailsTable.headers.response,
+        ],
+        bodyRows: bodyRowContent(verbiage.sarDetailsTable, report),
+      }}
+    />
+  );
+};
+
+const targetPopulations = (populations?: Choice[]): string => {
+  const selectedPopulations = populations?.map((population) => {
+    return " " + population["value"];
+  });
+  return selectedPopulations?.toString() ?? "";
+};
+
+const bodyRowContent = (verbiage: any, report?: ReportShape): string[][] => {
+  // TODO: add responses for first two (2) rows
+  return [
+    [verbiage.indicators[0]],
+    [verbiage.indicators[1]],
+    [verbiage.indicators[2], targetPopulations(report?.populations!)],
+  ];
+};
+
+export interface Props {
+  verbiage: any;
+}
+
+const sx = {
+  sarDetailsTable: {
+    margin: "3rem 0",
+    maxWidth: "reportPageWidth",
+    td: {
+      verticalAlign: "middle",
+      textAlign: "left",
+      padding: "8px",
+    },
+    "td:nth-of-type(1)": {
+      fontWeight: "bold",
+    },
+    th: {
+      fontWeight: "bold",
+      textAlign: "left",
+      paddingBottom: "0rem",
+    },
+  },
+};

--- a/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
@@ -33,7 +33,7 @@ const bodyRowContent = (verbiage: any, report?: ReportShape): string[][] => {
   const associatedWp = `${report?.fieldData.stateName} Work Plan ${report?.reportYear} - Period ${report?.reportPeriod}`;
   return [
     [verbiage.indicators[0], associatedWp],
-    [verbiage.indicators[1], report?.finalSar![0].value],
+    [verbiage.indicators[1], report?.finalSar?.[0].value],
     [verbiage.indicators[2], targetPopulations(report?.populations!)],
   ];
 };

--- a/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
@@ -30,10 +30,10 @@ const targetPopulations = (populations?: Choice[]): string => {
 };
 
 const bodyRowContent = (verbiage: any, report?: ReportShape): string[][] => {
-  // TODO: add responses for first two (2) rows
+  const associatedWp = `${report?.fieldData.stateName} Work Plan ${report?.reportYear} - Period ${report?.reportPeriod}`;
   return [
-    [verbiage.indicators[0]],
-    [verbiage.indicators[1]],
+    [verbiage.indicators[0], associatedWp],
+    [verbiage.indicators[1], report?.finalSar![0].value],
     [verbiage.indicators[2], targetPopulations(report?.populations!)],
   ];
 };

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -43,6 +43,7 @@ export { ExportedModalOverlayReportSection } from "./export/ExportedModalOverlay
 export { ExportedOverlayModalReportSection } from "./export/ExportedOverlayModalReportSection";
 export { ExportedReportBanner } from "./export/ExportedReportBanner";
 export { PrintButton } from "./export/PrintButton";
+export { ExportedSarDetailsTable } from "./export/ExportedSarDetailsTable";
 // fields
 export { CheckboxField } from "./fields/CheckboxField";
 export { ChoiceField } from "./fields/ChoiceField";

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -100,7 +100,6 @@ export const renderReportSections = (
         {childSections?.map((child: ReportRoute) => renderSection(child))}
         {/* if section does not have children and has content to render, render it */}
         {!childSections && (
-          // TODO: handle "General Information" use-case
           <Box>
             <ExportedSectionHeading
               heading={section.verbiage?.intro?.subsection || section.name}

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -33,8 +33,10 @@ export const ExportedReportPage = () => {
     WP: wpVerbiage,
     SAR: sarVerbiage,
   };
+
   const exportVerbiage = exportVerbiageMap[reportType];
   const { metadata, reportPage } = exportVerbiage;
+
   return (
     <Box sx={sx.container}>
       {(report && routesToRender && (
@@ -97,7 +99,8 @@ export const renderReportSections = (
         {/* if section has children, recurse */}
         {childSections?.map((child: ReportRoute) => renderSection(child))}
         {/* if section does not have children and has content to render, render it */}
-        {!childSections && section.name !== "General Information" && (
+        {!childSections && (
+          // TODO: handle "General Information" use-case
           <Box>
             <ExportedSectionHeading
               heading={section.verbiage?.intro?.subsection || section.name}

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -78,7 +78,7 @@ export const reportTitle = (
     case ReportType.WP:
       return `${report.fieldData.stateName} ${reportPage.heading} ${report.reportYear} - Period ${report.reportPeriod}`;
     case ReportType.SAR:
-      return `THIS IS A SARRRRRRRR`;
+      return report.submissionName;
     default:
       assertExhaustive(reportType);
       throw new Error(

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -9,11 +9,11 @@ export default {
   },
   metadata: {
     author: "CMS",
-    subject: "Managed Care Program Annual Report",
+    subject: "Semi-Annual Progress Report",
     language: "English",
   },
   reportPage: {
-    heading: "Managed Care Program Annual Report (SAR) for ",
+    heading: "Semi-Annual Progress Report (SAR) for ",
     metadataTableHeaders: {
       submissionName: "Submission Name",
       dueDate: "Due date",

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -21,14 +21,21 @@ export default {
       editedBy: "Edited by",
       status: "Status",
     },
-    detailsTableHeaders: {
-      indicator: "Indicator",
-      response: "Response",
-    },
     combinedDataTable: {
       title: "Exclusion of CHIP from SAR",
       subtitle:
         "Enrollees in separate CHIP programs funded under Title XXI should not be reported in the SAR. Please check this box if the state is unable to remove information about Separate CHIP enrollees from its reporting on this program.",
+    },
+    sarDetailsTable: {
+      headers: {
+        indicator: "Indicator",
+        response: "Response",
+      },
+      indicators: [
+        "Associated Work Plan",
+        "Is this SAR for a Close-out?",
+        "Select the target populations applicable to your state during this reporting period.",
+      ],
     },
   },
   tableHeaders: {

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -38,6 +38,15 @@ export default {
       ],
     },
   },
+  generalInformationTable: {
+    headings: [
+      "Resubmission Information",
+      "Organization Information",
+      "Authorized Organizational Representative (AOR)",
+      "Project Director",
+      "CMS Project Officer",
+    ],
+  },
   tableHeaders: {
     number: "Number",
     indicator: "Indicator",

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -33,7 +33,7 @@ export default {
       },
       indicators: [
         "Associated Work Plan",
-        "Is this SAR for a Close-out?",
+        "Is this your state/territory's final MFP SAR for your period of performance in the MFP demonstration?",
         "Select the target populations applicable to your state during this reporting period.",
       ],
     },

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -15,10 +15,15 @@ export default {
   reportPage: {
     heading: "Managed Care Program Annual Report (SAR) for ",
     metadataTableHeaders: {
+      submissionName: "Submission Name",
       dueDate: "Due date",
       lastEdited: "Last edited",
       editedBy: "Edited by",
       status: "Status",
+    },
+    detailsTableHeaders: {
+      indicator: "Indicator",
+      response: "Response",
     },
     combinedDataTable: {
       title: "Exclusion of CHIP from SAR",
@@ -31,6 +36,7 @@ export default {
     indicator: "Indicator",
     response: "Response",
   },
+  modalOverlayTableHeaders: {},
   emptyEntityMessage: {
     accessMeasures: "0  - No access measures entered",
     sanctions: "0 - No sanctions entered",

--- a/services/ui-src/src/verbiage/pages/wp/wp-export.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-export.ts
@@ -9,7 +9,7 @@ export default {
   },
   metadata: {
     author: "CMS",
-    subject: "Managed Care Program Annual Report",
+    subject: "MFP Program Work Plan",
     language: "English",
   },
   reportPage: {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Creating and styling the PDF for the `SAR General Information` page (and its internal sections), as well as pulling the metadata for the PDF.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3104

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
There's the _old_ way:
- Log in as a state user
- Create and submit a Work Plan
- Log in as an admin user
- Approve the Work Plan
- Log back in as state user
- - Create a new SAR
- Fill in the `General Information` page (the first page of this form)
- Navigate to `Review & submit` and click on `Review PDF`

And then there's the _coooool_ way:
- Use @gmrabian and @keeysnc 's handy dandy `MFP Postman Collection` to create, fill, submit, AND approve a WP 😎 
- Create a new SAR
- Fill in the `General Information` page (the first page of this form)
- Navigate to `Review & submit` and click on `Review PDF`

The metadata tables at the top of the PDF should have all the correct data populating and you should see the `General Information` section + its subsections with the appropriate data.

**Note:** I left the red border around these tables to avoid any confusion on which sections are done, but I could remove it if needed!

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
