### PR TITLE
CMDCT-3181: [Bug] WP - Define Initiative

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -945,7 +945,8 @@
                               "validation": {
                                 "type": "endDate",
                                 "dependentFieldName": "defineInitiative_projectedStartDate",
-                                "parentFieldName": "defineInitiative_projectedEndDate"
+                                "parentFieldName": "defineInitiative_projectedEndDate",
+                                "nested": true
                               },
                               "props": {
                                 "label": "Projected end date",

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -944,8 +944,9 @@
                               "type": "date",
                               "validation": {
                                 "type": "endDate",
-                                "dependentFieldName": "defineInitiative_projectedStartDate",
+                                "parentOptionId": "defineInitiative_projectedEndDate-WNsSaAHeDvRD2Pjkz6DcOE",
                                 "parentFieldName": "defineInitiative_projectedEndDate",
+                                "dependentFieldName": "defineInitiative_projectedStartDate",
                                 "nested": true
                               },
                               "props": {

--- a/services/app-api/utils/validation/completionValidation.ts
+++ b/services/app-api/utils/validation/completionValidation.ts
@@ -13,6 +13,7 @@ export const mapValidationTypesToSchema = (fieldValidationTypes: AnyObject) => {
   Object.entries(fieldValidationTypes).forEach(
     (fieldValidationType: [string, string | AnyObject]) => {
       const [key, fieldValidation] = fieldValidationType;
+
       // if standard validation type, set corresponding schema from map
       if (typeof fieldValidation === "string") {
         const correspondingSchema = schemaMap[fieldValidation];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, in the `WP Define Initiative` step, if a user selects `No` to the last question of the form, they are not able to submit using the `Save & return` button. 

![Screenshot 2024-01-11 at 1 54 36 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/99458559/d240e464-9726-48c5-896b-936c44097d05)

The issue was that the "Yes" option has a nested child input field, but it was not marked as `nested` in the `wp.json` and users weren't able to submit because the form was "incomplete" unless that field was filled.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3181

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
You should be able to select `No` and submit this form now.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
