### PR TITLE
MDCT-3194 - Test Coverage

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.test.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.test.tsx
@@ -64,4 +64,22 @@ describe("Test AppRoutes", () => {
     });
     expect(screen.getByTestId("404-view")).toBeVisible();
   });
+
+  test("export SAR report page", async () => {
+    const history = createMemoryHistory();
+    history.push("/sar/export");
+    await act(async () => {
+      await render(appRoutesComponent(history));
+    });
+    expect(screen.getByTestId("exportedReportMetadataTable")).toBeVisible();
+  });
+
+  test("export WP report page", async () => {
+    const history = createMemoryHistory();
+    history.push("/wp/export");
+    await act(async () => {
+      await render(appRoutesComponent(history));
+    });
+    expect(screen.getByTestId("exportedReportMetadataTable")).toBeVisible();
+  });
 });

--- a/services/ui-src/src/components/app/AppRoutes.test.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.test.tsx
@@ -2,8 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
+
 // components
-import { AppRoutes } from "components";
+import { AppRoutes, PostLogoutRedirect } from "components";
 // utils
 import { useStore, UserProvider } from "utils";
 import {
@@ -31,6 +32,7 @@ const appRoutesComponent = (history: any) => (
   <Router location={history.location} navigator={history}>
     <UserProvider>
       <AppRoutes />
+      <PostLogoutRedirect />
     </UserProvider>
   </Router>
 );
@@ -48,6 +50,15 @@ describe("Test AppRoutes", () => {
   test("not-found routes redirect to 404", async () => {
     const history = createMemoryHistory();
     history.push("/obviously-fake-route");
+    await act(async () => {
+      await render(appRoutesComponent(history));
+    });
+    expect(screen.getByTestId("404-view")).toBeVisible();
+  });
+
+  test("redirect when hitting postLogout endpoint", async () => {
+    const history = createMemoryHistory();
+    history.push("/postLogout");
     await act(async () => {
       await render(appRoutesComponent(history));
     });

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
@@ -1,0 +1,86 @@
+import { render } from "@testing-library/react";
+import { ReportContext } from "components";
+import { ExportedReportPage, reportTitle } from "./ExportedReportPage";
+import {
+  mockStandardReportPageJson,
+  mockReportJson,
+  mockWpReportContext,
+  mockSARReportContext,
+} from "utils/testing/setupJest";
+import { ReportType, ReportShape } from "types";
+
+const exportedReportPage = (context: any) => (
+  <ReportContext.Provider value={context}>
+    <ExportedReportPage />
+  </ReportContext.Provider>
+);
+
+describe("reportTitle", () => {
+  it("should generate the correct title for WP report type", () => {
+    const reportType = ReportType.WP;
+    const reportPage = { heading: "Report Heading" };
+    const report: ReportShape = {
+      fieldData: { stateName: "State", otherFields: "...otherFields" },
+      reportYear: 2022,
+      reportPeriod: "Q1",
+    };
+
+    const result = reportTitle(reportType, reportPage, report);
+
+    expect(result).toBe("State Report Heading 2022 - Period Q1");
+  });
+
+  it("should generate the correct title for SAR report type", () => {
+    const reportType = ReportType.SAR;
+    const reportPage = { heading: "Report Heading" };
+    const report: ReportShape = {
+      fieldData: { stateName: "State", otherFields: "...otherFields" },
+      reportYear: 2022,
+      reportPeriod: "Q1",
+    };
+
+    const result = reportTitle(reportType, reportPage, report);
+
+    expect(result).toBe("State Report Heading 2022 - Period Q1");
+  });
+
+  it("should throw an error for an unknown report type", () => {
+    const unknownReportType = "UnknownType";
+    const reportPage = { heading: "Report Heading" };
+    const report: ReportShape = {
+      fieldData: { stateName: "State", otherFields: "...otherFields" },
+      reportYear: 2022,
+      reportPeriod: "Q1",
+    };
+
+    expect(() =>
+      reportTitle(unknownReportType, reportPage, report)
+    ).toThrowError(
+      `The title for report type ${unknownReportType} has not been implemented.`
+    );
+  });
+});
+
+describe("Test ExportedReportPage Functionality", () => {
+  test("Is the export page visible for WP Reports", async () => {
+    localStorage.setItem("selectedReportType", "WP");
+
+    mockWpReportContext.report.formTemplate.routes = [
+      mockStandardReportPageJson,
+    ];
+    const page = render(exportedReportPage(mockReportJson));
+    const loadingText = page.getByText("Loading...");
+    expect(loadingText).toBeVisible();
+  });
+
+  test("Is the export page visible for SAR Reports", async () => {
+    localStorage.setItem("selectedReportType", "SAR");
+    localStorage.getItem("selectedReportType");
+    mockSARReportContext.report.formTemplate.routes = [
+      mockStandardReportPageJson,
+    ];
+    const page = render(exportedReportPage(mockReportJson));
+    const loadingText = page.getByText("Loading...");
+    expect(loadingText).toBeVisible();
+  });
+});

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -36,7 +36,6 @@ export const ExportedReportPage = () => {
 
   const exportVerbiage = exportVerbiageMap[reportType];
   const { metadata, reportPage } = exportVerbiage;
-
   return (
     <Box sx={sx.container}>
       {(report && routesToRender && (

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -194,6 +194,12 @@ export const mockReportsByState = [
   { ...mockWPFullReport, id: "mock-report-id-3" },
 ];
 
+export const mockSARReportsByState = [
+  { ...mockSARFullReport, id: "mock-report-id-1" },
+  { ...mockSARFullReport, id: "mock-report-id-2" },
+  { ...mockSARFullReport, id: "mock-report-id-3" },
+];
+
 export const mockReportMethods = {
   archiveReport: jest.fn(),
   releaseReport: jest.fn(),
@@ -218,6 +224,15 @@ export const mockWpReportContext = {
   report: mockWPFullReport,
   reportsByState: mockReportsByState,
   copyEligibleReportsByState: mockReportsByState,
+  errorMessage: "",
+  lastSavedTime: "2:00 PM",
+};
+
+export const mockSARReportContext = {
+  ...mockReportMethods,
+  report: mockSARFullReport,
+  reportsByState: mockSARReportsByState,
+  copyEligibleReportsByState: mockSARReportsByState,
   errorMessage: "",
   lastSavedTime: "2:00 PM",
 };


### PR DESCRIPTION
### Description
1. Increased components/PostLogoutRedirect to 100% test/branch coverage
2. Increased components/pages/Export to 100% statement coverage

<img width="1495" alt="Screenshot 2024-01-18 at 2 08 36 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/4f8b7938-3ee8-47c1-a6ca-6bb8cad8432b">

<img width="1490" alt="Screenshot 2024-01-18 at 2 09 08 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/a07dcc54-1950-4bfa-a22e-2b144f1b6912">


### Related ticket(s)
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3194


<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
