### PR TITLE
Resubmission Field Bugfix

### DIFF
--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -75,17 +75,16 @@ export const StandardReportPage = ({ route, validateOnRender }: Props) => {
     };
 
     if (
-      report?.reportType === "SAR" &&
-      (report?.submissionCount! === 0 ||
-        (report?.status === ReportStatus.SUBMITTED &&
-          report?.submissionCount! === 1))
+      (report?.reportType === "SAR" && !report?.submissionCount) ||
+      (report?.status === ReportStatus.SUBMITTED &&
+        report?.submissionCount! === 1 &&
+        report.locked)
     ) {
       return hideResubmissionField();
     } else {
       return formDataCopy;
     }
   };
-
   return (
     <Box>
       {route.verbiage?.intro && (


### PR DESCRIPTION
When a SAR report is started the resubmission field was showing up. I added to the conditional to properly hide it until a report is being resubmitted.

new logic:

1. if report is a SAR AND submissionCount isn't there - hide the resubmission field. ( submissionCount doesn't show until a 
submission is complete)

OR

2.  if report is Submitted AND submissionCount is 1 AND report is locked - hide the resubmission field ( this is the first time a user submits a report then decides to refresh the page. The resubmissionCount property shows up and has a value as 1 and the report is locked). 


### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3200

