### PR TITLE
[CMDCT-3193] Update EntityDetailsDashboardOverlay tests

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { RouterWrappedComponent } from "../../utils/testing/mockRouter";
+import {
+  mockUseEntityStore,
+  mockEntityDetailsDashboardOverlayJson,
+  mockFormField,
+  mockVerbiageIntro,
+} from "../../utils/testing/setupJest";
+import { EntityDetailsDashboardOverlay } from "./EntityDetailsDashboardOverlay";
+import { useStore } from "utils";
+import { axe } from "jest-axe";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseEntityStore);
+
+const mockDashboard = {
+  id: "mock id",
+  fields: [mockFormField],
+  name: "mock dashboard",
+  pageType: "entityDetailsDashboardOverlay",
+  verbiage: {
+    intro: mockVerbiageIntro,
+  },
+};
+
+const entityDetailsDashboardOverlayComponent = (
+  <RouterWrappedComponent>
+    <EntityDetailsDashboardOverlay
+      route={mockEntityDetailsDashboardOverlayJson}
+      dashboard={mockDashboard}
+    />
+  </RouterWrappedComponent>
+);
+
+describe("Test EntityDetailsDashboardOverlay", () => {
+  test("EntityDetailsDashboardOverlay view renders", () => {
+    render(entityDetailsDashboardOverlayComponent);
+    // Check that the header rendered
+    expect(
+      screen.getByText(
+        mockEntityDetailsDashboardOverlayJson.verbiage.intro.section
+      )
+    ).toBeVisible();
+
+    expect(
+      screen.getByText(
+        mockEntityDetailsDashboardOverlayJson.verbiage.intro.subsection
+      )
+    ).toBeVisible();
+  });
+});
+
+describe("Test EntityDetailsDashboardOverlay accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(entityDetailsDashboardOverlayComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsDashboardOverlay.tsx
@@ -127,7 +127,11 @@ export const EntityDetailsDashboardOverlay = ({
           </Table>
           <Box>
             <Flex sx={sx.buttonFlex}>
-              <Button onClick={closeEntityDetailsOverlay as MouseEventHandler}>
+              <Button
+                onClick={closeEntityDetailsOverlay as MouseEventHandler}
+                variant="none"
+                aria-label="Return to all initiatives"
+              >
                 Return to all initiatives
               </Button>
             </Flex>

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -155,6 +155,7 @@ export const EntityRow = ({
               sx={sx.editNameButton}
               variant="none"
               onClick={() => openAddEditEntityModal(entity)}
+              aria-label="edit button"
             >
               {!editable || isInitiativeClosed
                 ? verbiage.readOnlyEntityButtonText
@@ -170,6 +171,7 @@ export const EntityRow = ({
             onClick={() => openOverlayOrDrawer(entity)}
             variant="outline"
             disabled={entityStatus === EntityStatuses.DISABLED}
+            aria-label="edit button"
           >
             {!editable || isInitiativeClosed
               ? verbiage.readOnlyEntityDetailsButtonText
@@ -180,6 +182,7 @@ export const EntityRow = ({
               sx={sx.deleteButton}
               data-testid="delete-entity"
               onClick={() => openDeleteEntityModal(entity)}
+              aria-label="delete button"
             >
               <Image src={deleteIcon} alt="delete icon" boxSize="3x3" />
             </Button>

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -305,6 +305,28 @@ export const mockEntityDetailsOverlayJson = {
   entityType: "mock-entity-type",
 };
 
+export const mockEntityDetailsDashboardOverlayJson = {
+  verbiage: mockEntityDetailsOverlayVerbiage,
+  name: "mock name",
+  path: "/mock/mock-route-entity-dashboard-overlay",
+  entitySteps: [
+    {
+      name: "mock-route-entity-dashboard-overlay",
+      path: "/mock/mock-route-entity-dasboard-overlay",
+      pageType: "entityOverlay",
+      entityType: "mock entity type",
+      stepType: "mock step type",
+      stepName: "mock step name",
+      stepInfo: ["mock step info"],
+      hint: "Mock hint",
+      isRequired: "false",
+      verbiage: mockEntityDetailsOverlayVerbiage,
+      form: mockForm,
+      entities: [],
+    },
+  ],
+};
+
 export const mockOptionalFormField = {
   id: "mock-optional-text-field",
   type: "text",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This change updates the EntityDetailsDashboardOverlay tests. The coverage is not at 100. This is because we need to mock a component in which the `stepIsOpen`, which is set by the react state, is to `true` (I haven't figured out how to do this yet :D)

Coverage: 
| File                                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|--------|--------|--------|--------|--------|------|
|  EntityDetailsDashboardOverlay.tsx   |   66.66 |       25 |   45.45 |   66.66 | ...,67-68,118-123 |

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3193

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. yarn test coverage

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [X] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
