### PR TITLE
3194 Export Coverage Continued

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -1,93 +1,144 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  EntityDetailsStepTypes,
+  ModalOverlayReportPageVerbiage,
+  OverlayModalPageShape,
+  OverlayModalTypes,
+  OverlayModalStepTypes,
+} from "types";
+import {
+  ExportedModalOverlayReportSection,
+  Props,
+} from "./ExportedModalOverlayReportSection";
 
-import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
-
-import { renderStatusIcon } from "./ExportedModalOverlayReportSection";
-
-import { EntityShape, FormField, OverlayModalPageShape } from "types";
-
-jest.mock("./ExportedModalOverlayReportSection", () => ({
-  ...jest.requireActual("./ExportedModalOverlayReportSection"),
-  renderStatusIcon: jest.fn(),
-}));
-
-const section: OverlayModalPageShape = {
-  entityType: "",
-  stepType: "",
-  stepName: "",
-  stepInfo: [],
-  hint: "",
-  verbiage: {
-    addEntityButtonText: "",
-    dashboardTitle: "",
-    countEntitiesInTitle: false,
-    tableHeader: "",
-    addEditModalHint: "",
-    intro: {
-      section: "",
-      subsection: undefined,
-      hint: undefined,
-      info: undefined,
-      title: undefined,
-      subtitle: undefined,
-      spreadsheet: undefined,
-      exportSectionHeader: undefined,
-    },
+const defaultMockProps = {
+  section: {
+    entityType: OverlayModalTypes.INITIATIVE,
+    verbiage: {
+      intro: {
+        section: "",
+        subsection: "State- or Territory-Specific Initiatives",
+        info: [
+          {
+            type: "html",
+            content: "See ",
+          },
+          {
+            type: "internalLink",
+            content: "previous page",
+            props: {
+              to: "/wp/state-and-territory-specific-initiatives/instructions",
+              style: {
+                textDecoration: "underline",
+              },
+            },
+          },
+          {
+            type: "html",
+            content: " for detailed instructions.",
+          },
+        ],
+      },
+      addEntityButtonText: "Add initiative",
+      editEntityHint: 'Select "Edit" to complete the details.',
+      editEntityButtonText: "Edit name/topic",
+      readOnlyEntityButtonText: "View name/topic",
+      addEditModalAddTitle: "Add initiative",
+      addEditModalEditTitle: "Edit initiative",
+      deleteModalTitle: "Are you sure you want to delete this initiative?",
+      deleteModalConfirmButtonText: "Yes, delete initiative",
+      deleteModalWarning:
+        "Are you sure you want to proceed? You will lose all information entered for this initiative in the Work Plan.",
+      enterEntityDetailsButtonText: "Edit",
+      readOnlyEntityDetailsButtonText: "View",
+      dashboardTitle: "Initiative total count:",
+      countEntitiesInTitle: true,
+      tableHeader: "Initiative name <br/> Work Plan topic",
+      addEditModalHint:
+        "Provide the name of one initiative. You will be then be asked to complete details for this initiative including a description, evaluation plan and funding sources.",
+    } as ModalOverlayReportPageVerbiage,
+    entitySteps: [
+      {
+        stepType: EntityDetailsStepTypes.DEFINE_INITIATIVE,
+        stepName: "mock step name",
+        hint: "mock step hint",
+        entityType: "initiative",
+        modalForm: {
+          fields: [
+            {
+              id: "mock field id",
+              validation: "number",
+            },
+          ],
+        },
+      },
+      {
+        stepType: OverlayModalStepTypes.EVALUATION_PLAN,
+        stepName: "mock step name",
+        hint: "mock step hint",
+        entityType: "initiative",
+        modalForm: {
+          fields: [
+            {
+              id: "mock field id",
+              validation: "number",
+            },
+          ],
+        },
+      },
+      {
+        stepType: OverlayModalStepTypes.FUNDING_SOURCES,
+        stepName: "mock step name",
+        hint: "mock step hint",
+        entityType: "initiative",
+        modalForm: {
+          fields: [
+            {
+              id: "mock field id",
+              validation: "number",
+            },
+          ],
+        },
+      },
+      {
+        stepType: EntityDetailsStepTypes.CLOSE_OUT_INFORMATION,
+        stepName: "mock step name",
+        hint: "mock step hint",
+        entityType: "initiative",
+        modalForm: {
+          fields: [
+            {
+              id: "mock field id",
+              validation: "number",
+            },
+          ],
+        },
+      },
+    ] as OverlayModalPageShape[],
   },
-  modalForm: {
-    id: "",
-    fields: [],
-  },
-  name: "",
-  path: "",
-};
-
-const entityStep: (string | FormField)[] = [
-  "mockType",
-  "mock plan name",
-  "mock hint",
-  { id: "mock-id", props: { label: "mock field 1" }, type: "", validation: "" },
-];
-
-const entity: EntityShape = {
-  id: "entity-id",
-  type: "initiative",
-  "mock-id": "mock value",
-  mockType: [
-    {
-      id: "step-entity-id",
-    },
-  ],
-};
+} as Props;
 
 const testComponent = (
   <RouterWrappedComponent>
-    <ExportedOverlayModalReportSection
-      section={section}
-      entityStep={entityStep}
-      entity={entity}
-    />
+    <ExportedModalOverlayReportSection {...defaultMockProps} />
   </RouterWrappedComponent>
 );
 
-describe("Test ExportedOverlayModalReportSection Component", () => {
-  beforeEach(() => {
+describe("ExportedModalOverlayReportSection rendering", () => {
+  test("should render modal overlay report section", async () => {
     render(testComponent);
-  });
-  test("Test ExportRETTable render", () => {
-    screen.debug();
+    expect(
+      screen.getAllByTestId("exportedOverlayModalPage")[0]
+    ).toBeInTheDocument();
   });
 
-  test("should render status icon", async () => {
-    render(testComponent);
-    (renderStatusIcon as jest.Mock).mockReturnValue(HTMLElement);
-    expect(renderStatusIcon(true)).toEqual(HTMLElement);
+  test("should show success status icon", () => {
+    const { container } = render(testComponent);
+    screen.debug(container);
   });
-});
 
-describe("Test ExportedModalOverlayReportSection accessibility", () => {
   test("should not have basic accessibility issues", async () => {
     const { container } = render(testComponent);
     const results = await axe(container);

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -1,138 +1,93 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { useStore } from "utils";
-import {
-  mockReportStore,
-  RouterWrappedComponent,
-} from "utils/testing/setupJest";
-import { mockWPFullReport } from "utils/testing/mockReport";
-import {
-  EntityDetailsStepTypes,
-  ModalOverlayReportPageVerbiage,
-  OverlayModalPageShape,
-  OverlayModalTypes,
-  ReportRoute,
-} from "types";
-import {
-  ExportedModalOverlayReportSection,
-  Props,
-} from "./ExportedModalOverlayReportSection";
+import { RouterWrappedComponent } from "utils/testing/setupJest";
 
-jest.mock("utils/state/useStore");
-const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-const mockReport = {
-  ...mockWPFullReport,
-  fieldData: {
-    ...mockWPFullReport.fieldData,
-    [OverlayModalTypes.INITIATIVE]: [
-      {
-        ...mockWPFullReport.fieldData.entityType[0],
-        type: OverlayModalTypes.INITIATIVE,
-        id: "mock wip id", // this is both our search filter and our search target in renderFieldRow
-        initiative_wpTopic: [
-          {
-            value: "mock WP topic",
-          },
-        ],
-      },
-    ],
+import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
+
+import { renderStatusIcon } from "./ExportedModalOverlayReportSection";
+
+import { EntityShape, FormField, OverlayModalPageShape } from "types";
+
+jest.mock("./ExportedModalOverlayReportSection", () => ({
+  ...jest.requireActual("./ExportedModalOverlayReportSection"),
+  renderStatusIcon: jest.fn(),
+}));
+
+const section: OverlayModalPageShape = {
+  entityType: "",
+  stepType: "",
+  stepName: "",
+  stepInfo: [],
+  hint: "",
+  verbiage: {
+    addEntityButtonText: "",
+    dashboardTitle: "",
+    countEntitiesInTitle: false,
+    tableHeader: "",
+    addEditModalHint: "",
+    intro: {
+      section: "",
+      subsection: undefined,
+      hint: undefined,
+      info: undefined,
+      title: undefined,
+      subtitle: undefined,
+      spreadsheet: undefined,
+      exportSectionHeader: undefined,
+    },
   },
-  formTemplate: {
-    ...mockWPFullReport.formTemplate,
-    routes: [
-      /*
-       * We need the 3th route to have a child with entityType initiative,
-       * to avoid a null reference in getInitiativeStatus()
-       */
-      ...mockWPFullReport.formTemplate.routes.slice(0, 3),
-      {
-        name: "mock-route-4",
-        path: "/mock/mock-route-4",
-        children: [
-          {
-            entityType: OverlayModalTypes.INITIATIVE,
-          },
-        ],
-      } as ReportRoute,
-      ...mockWPFullReport.formTemplate.routes.slice(3),
-    ],
+  modalForm: {
+    id: "",
+    fields: [],
   },
+  name: "",
+  path: "",
 };
-mockReportStore.report = mockReport;
-mockedUseStore.mockReturnValue(mockReportStore);
 
-const defaultMockProps = {
-  section: {
-    entityType: OverlayModalTypes.INITIATIVE,
-    verbiage: {
-      intro: {
-        section: "",
-        subsection: "State- or Territory-Specific Initiatives",
-        info: [
-          {
-            type: "html",
-            content: "See ",
-          },
-          {
-            type: "internalLink",
-            content: "previous page",
-            props: {
-              to: "/wp/state-and-territory-specific-initiatives/instructions",
-              style: {
-                textDecoration: "underline",
-              },
-            },
-          },
-          {
-            type: "html",
-            content: " for detailed instructions.",
-          },
-        ],
-      },
-      addEntityButtonText: "Add initiative",
-      editEntityHint: 'Select "Edit" to complete the details.',
-      editEntityButtonText: "Edit name/topic",
-      readOnlyEntityButtonText: "View name/topic",
-      addEditModalAddTitle: "Add initiative",
-      addEditModalEditTitle: "Edit initiative",
-      deleteModalTitle: "Are you sure you want to delete this initiative?",
-      deleteModalConfirmButtonText: "Yes, delete initiative",
-      deleteModalWarning:
-        "Are you sure you want to proceed? You will lose all information entered for this initiative in the Work Plan.",
-      enterEntityDetailsButtonText: "Edit",
-      readOnlyEntityDetailsButtonText: "View",
-      dashboardTitle: "Initiative total count:",
-      countEntitiesInTitle: true,
-      tableHeader: "Initiative name <br/> Work Plan topic",
-      addEditModalHint:
-        "Provide the name of one initiative. You will be then be asked to complete details for this initiative including a description, evaluation plan and funding sources.",
-    } as ModalOverlayReportPageVerbiage,
-    entitySteps: [
-      {
-        stepType: EntityDetailsStepTypes.DEFINE_INITIATIVE,
-        stepName: "mock step name",
-        hint: "mock step hint",
-        entityType: "initiative",
-        modalForm: {
-          fields: [
-            {
-              id: "mock field id",
-              validation: "number",
-            },
-          ],
-        },
-      },
-    ] as OverlayModalPageShape[],
-  },
-} as Props;
+const entityStep: (string | FormField)[] = [
+  "mockType",
+  "mock plan name",
+  "mock hint",
+  { id: "mock-id", props: { label: "mock field 1" }, type: "", validation: "" },
+];
+
+const entity: EntityShape = {
+  id: "entity-id",
+  type: "initiative",
+  "mock-id": "mock value",
+  mockType: [
+    {
+      id: "step-entity-id",
+    },
+  ],
+};
 
 const testComponent = (
   <RouterWrappedComponent>
-    <ExportedModalOverlayReportSection {...defaultMockProps} />
+    <ExportedOverlayModalReportSection
+      section={section}
+      entityStep={entityStep}
+      entity={entity}
+    />
   </RouterWrappedComponent>
 );
 
-describe("ExportedModalOverlayReportSection", () => {
+describe("Test ExportedOverlayModalReportSection Component", () => {
+  beforeEach(() => {
+    render(testComponent);
+  });
+  test("Test ExportRETTable render", () => {
+    screen.debug();
+  });
+
+  test("should render status icon", async () => {
+    render(testComponent);
+    (renderStatusIcon as jest.Mock).mockReturnValue(HTMLElement);
+    expect(renderStatusIcon(true)).toEqual(HTMLElement);
+  });
+});
+
+describe("Test ExportedModalOverlayReportSection accessibility", () => {
   test("should not have basic accessibility issues", async () => {
     const { container } = render(testComponent);
     const results = await axe(container);

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -112,6 +112,7 @@ const defaultMockProps = {
         stepType: EntityDetailsStepTypes.DEFINE_INITIATIVE,
         stepName: "mock step name",
         hint: "mock step hint",
+        entityType: "initiative",
         modalForm: {
           fields: [
             {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -44,7 +44,6 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
     report && (alertVerbiage as AlertVerbiage)[entityType]
       ? getWPAlertStatus(report, entityType)
       : false;
-
   return (
     <Box>
       {showAlert && (

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
@@ -1,92 +1,83 @@
 import { render, screen } from "@testing-library/react";
-// components
-import { ReportContext } from "components";
-// utils
-import { useStore } from "../../utils";
-import { mockUseStore } from "../../utils/testing/setupJest";
+import { axe } from "jest-axe";
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+
 import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
-import { mockWpReportContext } from "../../utils/testing/mockReport";
-import { entityTypes } from "types";
-import { mockOverlayModalPageJson } from "utils/testing/setupJest";
 
-jest.mock("utils/state/useStore");
+import { EntityShape, FormField, OverlayModalPageShape } from "types";
 
-const mockEntity = {
-  id: "mock-id-1",
-  type: entityTypes[0],
-  "mock-modal-text-field": "mock input 1",
+const section: OverlayModalPageShape = {
+  entityType: "",
+  stepType: "",
+  stepName: "",
+  stepInfo: [],
+  hint: "",
+  verbiage: {
+    addEntityButtonText: "",
+    dashboardTitle: "",
+    countEntitiesInTitle: false,
+    tableHeader: "",
+    addEditModalHint: "",
+    intro: {
+      section: "",
+      subsection: undefined,
+      hint: undefined,
+      info: undefined,
+      title: undefined,
+      subtitle: undefined,
+      spreadsheet: undefined,
+      exportSectionHeader: undefined,
+    },
+  },
+  modalForm: {
+    id: "",
+    fields: [],
+  },
+  name: "",
+  path: "",
 };
 
-const mockEntity2 = {
-  id: "mock-id-2",
-  type: entityTypes[0],
-  "mock-modal-text-field": "mock input 1",
-  fundingSources: [
+const entityStep: (string | FormField)[] = [
+  "mockType",
+  "mock plan name",
+  "mock hint",
+  { id: "mock-id", props: { label: "mock field 1" }, type: "", validation: "" },
+];
+
+const entity: EntityShape = {
+  id: "entity-id",
+  type: "initiative",
+  "mock-id": "mock value",
+  mockType: [
     {
-      fundingSources_quarters2024Q1: "7.00",
-      fundingSources_quarters2024Q2: "7.00",
+      id: "step-entity-id",
     },
   ],
 };
 
-const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue(mockUseStore);
-
-const entityMockStep = [
-  "fundingSources",
-  "III. Funding sources",
-  "Add funding sources with projected quarterly expenditures",
-  {
-    id: "fundingSources_wpTopic",
-    props: {
-      label: "2024 1",
-      mask: "currency",
-    },
-    transformation: { rule: "" },
-    type: "number",
-    validation: "number",
-  },
-  {
-    id: "fundingSources_quarters2024Q1",
-    props: {
-      label: "2024 1",
-      mask: "currency",
-    },
-    transformation: { rule: "" },
-    type: "number",
-    validation: "number",
-  },
-];
-
-const exportedOverlayModalReportComponent = (
-  <ReportContext.Provider value={mockWpReportContext}>
+const testComponent = (
+  <RouterWrappedComponent>
     <ExportedOverlayModalReportSection
-      entity={mockEntity}
-      entityStep={entityMockStep}
-      section={mockOverlayModalPageJson}
+      section={section}
+      entityStep={entityStep}
+      entity={entity}
     />
-  </ReportContext.Provider>
+  </RouterWrappedComponent>
 );
 
-const exportedOverlayModalReportComponentEntityStep = (
-  <ReportContext.Provider value={mockWpReportContext}>
-    <ExportedOverlayModalReportSection
-      entity={mockEntity2}
-      entityStep={entityMockStep}
-      section={mockOverlayModalPageJson}
-    />
-  </ReportContext.Provider>
-);
-
-describe("ExportedReportWrapper rendering", () => {
-  test("ExportedOverlayModalReportComponent renders", () => {
-    render(exportedOverlayModalReportComponent);
-    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
+describe("Test ExportedOverlayModalReportSection Component", () => {
+  beforeEach(() => {
+    render(testComponent);
   });
+  test("Test ExportRETTable render", () => {
+    screen.debug();
+  });
+});
 
-  test("ExportedOverlayModalReportComponent returns entity step card", () => {
-    render(exportedOverlayModalReportComponentEntityStep);
-
-    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
+describe("Test ExportedModalOverlayReportSection accessibility", () => {
+  test("should not have basic accessibility issues", async () => {
+    const { container } = render(testComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+// components
+import { ReportContext } from "components";
+// utils
+import { useStore } from "../../utils";
+import { mockUseStore } from "../../utils/testing/setupJest";
+import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
+import { mockWpReportContext } from "../../utils/testing/mockReport";
+import { entityTypes } from "types";
+import { mockOverlayModalPageJson } from "utils/testing/setupJest";
+
+jest.mock("utils/state/useStore");
+
+const mockEntity = {
+  id: "mock-id-1",
+  type: entityTypes[0],
+  "mock-modal-text-field": "mock input 1",
+};
+
+const mockEntity2 = {
+  id: "mock-id-2",
+  type: entityTypes[0],
+  "mock-modal-text-field": "mock input 1",
+  fundingSources: [
+    {
+      fundingSources_quarters2024Q1: "7.00",
+      fundingSources_quarters2024Q2: "7.00",
+    },
+  ],
+};
+
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseStore);
+
+const entityMockStep = [
+  "fundingSources",
+  "III. Funding sources",
+  "Add funding sources with projected quarterly expenditures",
+  {
+    id: "fundingSources_wpTopic",
+    props: {
+      label: "2024 1",
+      mask: "currency",
+    },
+    transformation: { rule: "" },
+    type: "number",
+    validation: "number",
+  },
+  {
+    id: "fundingSources_quarters2024Q1",
+    props: {
+      label: "2024 1",
+      mask: "currency",
+    },
+    transformation: { rule: "" },
+    type: "number",
+    validation: "number",
+  },
+];
+
+const exportedOverlayModalReportComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedOverlayModalReportSection
+      entity={mockEntity}
+      entityStep={entityMockStep}
+      section={mockOverlayModalPageJson}
+    />
+  </ReportContext.Provider>
+);
+
+const exportedOverlayModalReportComponentEntityStep = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedOverlayModalReportSection
+      entity={mockEntity2}
+      entityStep={entityMockStep}
+      section={mockOverlayModalPageJson}
+    />
+  </ReportContext.Provider>
+);
+
+describe("ExportedReportWrapper rendering", () => {
+  test("ExportedOverlayModalReportComponent renders", () => {
+    render(exportedOverlayModalReportComponent);
+    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
+  });
+
+  test("ExportedOverlayModalReportComponent returns entity step card", () => {
+    render(exportedOverlayModalReportComponentEntityStep);
+
+    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.test.tsx
@@ -1,83 +1,92 @@
 import { render, screen } from "@testing-library/react";
-import { axe } from "jest-axe";
-import { RouterWrappedComponent } from "utils/testing/setupJest";
-
+// components
+import { ReportContext } from "components";
+// utils
+import { useStore } from "../../utils";
+import { mockUseStore } from "../../utils/testing/setupJest";
 import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
+import { mockWpReportContext } from "../../utils/testing/mockReport";
+import { entityTypes } from "types";
+import { mockOverlayModalPageJson } from "utils/testing/setupJest";
 
-import { EntityShape, FormField, OverlayModalPageShape } from "types";
+jest.mock("utils/state/useStore");
 
-const section: OverlayModalPageShape = {
-  entityType: "",
-  stepType: "",
-  stepName: "",
-  stepInfo: [],
-  hint: "",
-  verbiage: {
-    addEntityButtonText: "",
-    dashboardTitle: "",
-    countEntitiesInTitle: false,
-    tableHeader: "",
-    addEditModalHint: "",
-    intro: {
-      section: "",
-      subsection: undefined,
-      hint: undefined,
-      info: undefined,
-      title: undefined,
-      subtitle: undefined,
-      spreadsheet: undefined,
-      exportSectionHeader: undefined,
-    },
-  },
-  modalForm: {
-    id: "",
-    fields: [],
-  },
-  name: "",
-  path: "",
+const mockEntity = {
+  id: "mock-id-1",
+  type: entityTypes[0],
+  "mock-modal-text-field": "mock input 1",
 };
 
-const entityStep: (string | FormField)[] = [
-  "mockType",
-  "mock plan name",
-  "mock hint",
-  { id: "mock-id", props: { label: "mock field 1" }, type: "", validation: "" },
-];
-
-const entity: EntityShape = {
-  id: "entity-id",
-  type: "initiative",
-  "mock-id": "mock value",
-  mockType: [
+const mockEntity2 = {
+  id: "mock-id-2",
+  type: entityTypes[0],
+  "mock-modal-text-field": "mock input 1",
+  fundingSources: [
     {
-      id: "step-entity-id",
+      fundingSources_quarters2024Q1: "7.00",
+      fundingSources_quarters2024Q2: "7.00",
     },
   ],
 };
 
-const testComponent = (
-  <RouterWrappedComponent>
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseStore);
+
+const entityMockStep = [
+  "fundingSources",
+  "III. Funding sources",
+  "Add funding sources with projected quarterly expenditures",
+  {
+    id: "fundingSources_wpTopic",
+    props: {
+      label: "2024 1",
+      mask: "currency",
+    },
+    transformation: { rule: "" },
+    type: "number",
+    validation: "number",
+  },
+  {
+    id: "fundingSources_quarters2024Q1",
+    props: {
+      label: "2024 1",
+      mask: "currency",
+    },
+    transformation: { rule: "" },
+    type: "number",
+    validation: "number",
+  },
+];
+
+const exportedOverlayModalReportComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
     <ExportedOverlayModalReportSection
-      section={section}
-      entityStep={entityStep}
-      entity={entity}
+      entity={mockEntity}
+      entityStep={entityMockStep}
+      section={mockOverlayModalPageJson}
     />
-  </RouterWrappedComponent>
+  </ReportContext.Provider>
 );
 
-describe("Test ExportedOverlayModalReportSection Component", () => {
-  beforeEach(() => {
-    render(testComponent);
-  });
-  test("Test ExportRETTable render", () => {
-    screen.debug();
-  });
-});
+const exportedOverlayModalReportComponentEntityStep = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedOverlayModalReportSection
+      entity={mockEntity2}
+      entityStep={entityMockStep}
+      section={mockOverlayModalPageJson}
+    />
+  </ReportContext.Provider>
+);
 
-describe("Test ExportedModalOverlayReportSection accessibility", () => {
-  test("should not have basic accessibility issues", async () => {
-    const { container } = render(testComponent);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+describe("ExportedReportWrapper rendering", () => {
+  test("ExportedOverlayModalReportComponent renders", () => {
+    render(exportedOverlayModalReportComponent);
+    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
+  });
+
+  test("ExportedOverlayModalReportComponent returns entity step card", () => {
+    render(exportedOverlayModalReportComponentEntityStep);
+
+    expect(screen.getByTestId("exportedOverlayModalPage")).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
@@ -18,10 +18,8 @@ export const ExportedOverlayModalReportSection = ({
   entityStep,
 }: Props) => {
   const { emptyEntityMessage, dashboardTitle } = exportVerbiage;
-
   const stepType = entityStep![0] as string;
   const entityCount = entity?.[stepType]?.length;
-
   return (
     <Box mt="2rem" data-testid="exportedOverlayModalPage" sx={sx.container}>
       <Heading as="h4">

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -5,8 +5,8 @@ import {
   mockFormField,
   mockNestedFormField,
   mockWpReportContext,
-  mockSARReportContext,
   mockStandardReportPageJson,
+  mockSARReportContext,
 } from "utils/testing/setupJest";
 import { ReportContext } from "components";
 import { ExportedReportFieldTable } from "./ExportedReportFieldTable";
@@ -43,7 +43,6 @@ const mockStandardPageJson = {
     fields: reportJsonFields,
   },
 };
-
 const mockDrawerPageJson = {
   ...mockDrawerReportPageJson,
   drawerForm: { id: "drawer", fields: reportJsonFields },
@@ -60,6 +59,31 @@ const hintJson = {
   ...mockStandardReportPageJson,
   form: {
     id: "not-apoc",
+    fields: [
+      {
+        ...mockFormField,
+        props: {
+          label: "X. Mock Field label",
+          hint: "Mock Hint Text",
+        },
+      },
+    ],
+  },
+};
+
+const generalInformationJson = {
+  name: "General Information",
+  path: "/sar/general-information",
+  pageType: "standard",
+  verbiage: {
+    intro: {
+      section: "",
+      subsection: "General Information",
+      hint: "",
+    },
+  },
+  form: {
+    id: "ga",
     fields: [
       {
         ...mockFormField,
@@ -96,16 +120,11 @@ const hintComponent = (
   </ReportContext.Provider>
 );
 
-const exportedStandardSarTableComponent = (
+const generalInformationComponent = (
   <ReportContext.Provider value={mockSARReportContext}>
-    <ExportedReportFieldTable section={mockStandardPageJson} />
+    <ExportedReportFieldTable section={generalInformationJson} />
   </ReportContext.Provider>
 );
-
-jest.mock("./ExportedReportFieldTable", () => ({
-  ...jest.requireActual("./ExportedReportFieldTable"), // Use the actual implementation for other functions
-  getSectionFormFields: jest.fn(),
-}));
 
 describe("ExportedReportFieldRow", () => {
   test("Is present", async () => {
@@ -132,8 +151,8 @@ describe("ExportedReportFieldRow", () => {
     expect(hint).toBeVisible();
   });
 
-  test("Is SAR component present", async () => {
-    render(exportedStandardSarTableComponent);
+  test("shows the correct section form fields based on heading", async () => {
+    render(generalInformationComponent);
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -151,8 +151,9 @@ describe("ExportedReportFieldRow", () => {
     expect(hint).toBeVisible();
   });
 
-  test("shows the correct section form fields based on heading", async () => {
+  test("shows that general information renders correctly", async () => {
     render(generalInformationComponent);
+    expect(screen.getByText("Resubmission Information")).toBeInTheDocument();
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.test.tsx
@@ -5,6 +5,7 @@ import {
   mockFormField,
   mockNestedFormField,
   mockWpReportContext,
+  mockSARReportContext,
   mockStandardReportPageJson,
 } from "utils/testing/setupJest";
 import { ReportContext } from "components";
@@ -42,6 +43,7 @@ const mockStandardPageJson = {
     fields: reportJsonFields,
   },
 };
+
 const mockDrawerPageJson = {
   ...mockDrawerReportPageJson,
   drawerForm: { id: "drawer", fields: reportJsonFields },
@@ -94,6 +96,17 @@ const hintComponent = (
   </ReportContext.Provider>
 );
 
+const exportedStandardSarTableComponent = (
+  <ReportContext.Provider value={mockSARReportContext}>
+    <ExportedReportFieldTable section={mockStandardPageJson} />
+  </ReportContext.Provider>
+);
+
+jest.mock("./ExportedReportFieldTable", () => ({
+  ...jest.requireActual("./ExportedReportFieldTable"), // Use the actual implementation for other functions
+  getSectionFormFields: jest.fn(),
+}));
+
 describe("ExportedReportFieldRow", () => {
   test("Is present", async () => {
     render(exportedStandardTableComponent);
@@ -117,6 +130,10 @@ describe("ExportedReportFieldRow", () => {
     render(hintComponent);
     const hint = screen.queryByText(/Mock Hint Text/);
     expect(hint).toBeVisible();
+  });
+
+  test("Is SAR component present", async () => {
+    render(exportedStandardSarTableComponent);
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportFieldTable.tsx
@@ -19,8 +19,8 @@ import sarVerbiage from "verbiage/pages/sar/sar-export";
 
 export const ExportedReportFieldTable = ({ section }: Props) => {
   const { report } = useStore() ?? {};
-  const { tableHeaders } = wpVerbiage;
 
+  const { tableHeaders } = wpVerbiage;
   const pageType = section.pageType;
   const formFields =
     pageType === "drawer" ? section.drawerForm?.fields : section.form?.fields;
@@ -65,14 +65,13 @@ export const ExportedReportFieldTable = ({ section }: Props) => {
   );
 };
 
-const renderGeneralInformation = (
+export const renderGeneralInformation = (
   verbiage: any,
   formFields: (FormField | FormLayoutElement)[],
   pageType: string,
   entityType?: string
 ) => {
   const headings = verbiage.generalInformationTable.headings;
-
   // get the range of form fields for a particular section
   const getSectionFormFields = (
     heading: number,

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -70,11 +70,6 @@ describe("ExportedReportWrapper rendering", () => {
     expect(screen.getByTestId("exportTable")).toBeInTheDocument();
   });
 
-  test("ExportedModalOverlayReportSection renders", () => {
-    render(exportedModalOverlayReportWrapperComponent);
-    expect(screen.getByTestId("exportTable")).toBeInTheDocument();
-  });
-
   it("renders default logic block correctly", () => {
     const { container } = render(UnknownComponent);
     expect(container).toBeEmptyDOMElement();

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -6,6 +6,8 @@ import {
   mockModalDrawerReportPageJson,
   mockStandardReportPageJson,
   mockDrawerReportPageJson,
+  mockUnknownPageJson,
+  mockModalOverlayReportPageJson,
 } from "utils/testing/setupJest";
 import { mockWpReportContext } from "../../utils/testing/mockReport";
 
@@ -31,6 +33,18 @@ const exportedModalDrawerReportWrapperComponent = (
   </ReportContext.Provider>
 );
 
+const exportedModalOverlayReportWrapperComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockModalOverlayReportPageJson} />
+  </ReportContext.Provider>
+);
+
+const UnknownComponent = (
+  <ReportContext.Provider value={mockWpReportContext}>
+    <ExportedReportWrapper section={mockUnknownPageJson} />
+  </ReportContext.Provider>
+);
+
 describe("ExportedReportWrapper rendering", () => {
   test("exportedStandardReportWrapperComponent renders", () => {
     render(exportedStandardReportWrapperComponent);
@@ -49,6 +63,21 @@ describe("ExportedReportWrapper rendering", () => {
     expect(
       screen.getByTestId("exportedModalDrawerReportSection")
     ).toBeInTheDocument();
+  });
+
+  test("ExportedModalOverlayReportSection renders", () => {
+    render(exportedModalOverlayReportWrapperComponent);
+    expect(screen.getByTestId("exportTable")).toBeInTheDocument();
+  });
+
+  test("ExportedModalOverlayReportSection renders", () => {
+    render(exportedModalOverlayReportWrapperComponent);
+    expect(screen.getByTestId("exportTable")).toBeInTheDocument();
+  });
+
+  it("renders default logic block correctly", () => {
+    const { container } = render(UnknownComponent);
+    expect(container).toBeEmptyDOMElement();
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -18,7 +18,6 @@ import {
   StandardReportPageShape,
 } from "types";
 import { ExportedOverlayModalReportSection } from "./ExportedOverlayModalReportSection";
-
 export const ExportedReportWrapper = ({ section }: Props) => {
   switch (section.pageType) {
     case PageTypes.STANDARD:

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -344,11 +344,6 @@ export const mockOptionalFormField = {
   },
 };
 
-export const mockModalOverlayForm = {
-  id: "mock-modal-overlay-form-id",
-  fields: [mockFormField, mockNumberField, mockOptionalFormField],
-};
-
 export const mockModalOverlayReportPageVerbiage = {
   intro: mockVerbiageIntro,
   dashboardTitle: "Mock dashboard title",
@@ -366,6 +361,50 @@ export const mockModalOverlayReportPageVerbiage = {
   enterEntityDetailsButtonText: "Mock enter entity details button text",
 };
 
+export const mockModalOverlayForm = {
+  id: "mock-modal-overlay-form-id",
+  fields: [mockFormField, mockNumberField, mockOptionalFormField],
+};
+
+export const mockOverlayModalPageJson2 = {
+  name: "mock-route-2d",
+  path: "/mock/mock-route-2d",
+  pageType: "overlayModal",
+  entityType: "entityType",
+  entitySteps: [
+    {
+      entityType: "initiative",
+      hint: "Provide initiative description, including target populations and timeframe",
+      isRequired: true,
+      name: "State- or Territory Specific Initiatives: I. Define initiative",
+      pageType: "entityOverlay",
+      path: "/wp/state-and-territory-specific-initiatives/define-initiative",
+      stepInfo: ["stepName", "hint"],
+      stepName: "I. Define initiative",
+      stepType: "defineInitiative",
+      verbiage: mockModalOverlayReportPageVerbiage,
+      modalForm: mockModalForm,
+    },
+    {
+      entityType: "initiative",
+      hint: "Provide initiative description, including target populations and timeframe",
+      isRequired: true,
+      name: "State- or Territory Specific Initiatives: I. Define initiative",
+      pageType: "entityOverlay",
+      path: "/wp/state-and-territory-specific-initiatives/define-initiative",
+      stepInfo: ["stepName", "hint"],
+      stepName: "I. Define initiative",
+      stepType: "defineInitiative",
+      verbiage: mockModalOverlayReportPageVerbiage,
+      modalForm: mockModalForm,
+    },
+  ],
+  verbiage: mockModalOverlayReportPageVerbiage,
+  modalForm: mockModalForm,
+  entityInfo: ["initiative_name", "initiative_wpTopic"],
+  overlayForm: mockModalOverlayForm,
+};
+
 export const mockOverlayModalPageJson = {
   name: "mock-route-2d",
   path: "/mock/mock-route-2d",
@@ -379,6 +418,19 @@ export const mockOverlayModalPageJson = {
   hint: "Mock hint",
 };
 
+export const mockUnknownPageJson = {
+  name: "mock-route-2d",
+  path: "/mock/mock-route-2d",
+  pageType: "UNKNOWN_PAGE_TYPE",
+  entityType: "entityType",
+  verbiage: mockModalOverlayReportPageVerbiage,
+  modalForm: mockModalForm,
+  stepType: "mock-step",
+  stepName: "Mock step name",
+  stepInfo: ["name, hint"],
+  hint: "Mock hint",
+};
+
 export const mockModalOverlayReportPageJson = {
   name: "mock-route-2c",
   path: "/mock/mock-route-2c",
@@ -386,6 +438,19 @@ export const mockModalOverlayReportPageJson = {
   entityType: "entityType",
   verbiage: mockModalOverlayReportPageVerbiage,
   modalForm: mockModalOverlayForm,
+  overlayForm: mockModalOverlayForm,
+  entity: {},
+};
+
+export const mockOverlayModalReportPageJson = {
+  name: "mock-route-2c",
+  path: "/mock/mock-route-2c",
+  pageType: "overlayModal",
+  entityType: "entityType",
+  verbiage: mockModalOverlayReportPageVerbiage,
+  modalForm: mockModalOverlayForm,
+  overlayForm: mockModalOverlayForm,
+  entity: {},
 };
 
 export const mockDynamicModalOverlayReportPageJson = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -46,6 +46,12 @@ export const mockReportFieldData = {
   entityType: [
     {
       id: "mock-entity-id",
+      initiative_wpTopic: [
+        {
+          key: "initiative_wpTopic",
+          value: "Transitions and transition coordination services ",
+        },
+      ],
       name: "entity-name",
       entityType_one: "hello",
       transitionBenchmarks_targetPopulationName: "mock benchmark name",
@@ -233,7 +239,7 @@ export const mockSARReportContext = {
   ...mockReportMethods,
   report: mockSARFullReport,
   reportsByState: mockSARReportsByState,
-  copyEligibleReportsByState: mockSARReportsByState,
+  copyEligibleReportsByState: mockReportsByState,
   errorMessage: "",
   lastSavedTime: "2:00 PM",
 };


### PR DESCRIPTION
### Description
Tests for the following export files. (update to ExportedReportFieldTable.tsx which also increases coverage)

1. ExportedModalOverlayReportSection.tsx
2. ExportedReportFieldTable.tsx

<img width="1494" alt="Screenshot 2024-01-30 at 12 32 04 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/2ba4ec82-2f71-42a8-bef1-edc35fbe056b">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-[MDCT-3194](https://qmacbis.atlassian.net/browse/MDCT-3194]

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
