### PR TITLE
[Bugfix] SAR PDF Not Rendering with Transition Benchmarks

### DIFF
--- a/services/ui-src/src/components/export/ExportedRETTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedRETTable.test.tsx
@@ -88,9 +88,9 @@ const section = {
 };
 
 const emptySection = {
-  id:"mock-empty",
-  fields: []
-}
+  id: "mock-empty",
+  fields: [],
+};
 
 const mockSARReport = {
   report: {
@@ -209,16 +209,20 @@ describe("Test ExportedRETTable Component", () => {
     expect(screen.queryAllByRole("row")).toHaveLength(9);
   });
 });
-describe("Test ExportedRETTable Component with empty section", () =>{
+describe("Test ExportedRETTable Component with empty section", () => {
   it("Test ExportRETTable render if section is empty", () => {
     //an empty section means no transition benchmark had been selected
     mockedUseStore.mockReturnValue(mockSARReport);
     render(<ExportRETTable section={emptySection as any} />);
     const table = screen.queryByRole("table");
     expect(table).toBe(null);
-    expect(screen.getByText("Your associated MFP Work Plan does not contain any target populations.")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Your associated MFP Work Plan does not contain any target populations."
+      )
+    ).toBeVisible();
   });
-})
+});
 describe("Test ExportedReportWrapper accessibility", () => {
   it("ExportedReportWrapper should not have basic accessibility issues", async () => {
     const { container } = render(<ExportRETTable section={section as any} />);

--- a/services/ui-src/src/components/export/ExportedRETTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedRETTable.test.tsx
@@ -87,6 +87,11 @@ const section = {
   name: "mock table name",
 };
 
+const emptySection = {
+  id:"mock-empty",
+  fields: []
+}
+
 const mockSARReport = {
   report: {
     fieldData: {
@@ -204,6 +209,16 @@ describe("Test ExportedRETTable Component", () => {
     expect(screen.queryAllByRole("row")).toHaveLength(9);
   });
 });
+describe("Test ExportedRETTable Component with empty section", () =>{
+  it("Test ExportRETTable render if section is empty", () => {
+    //an empty section means no transition benchmark had been selected
+    mockedUseStore.mockReturnValue(mockSARReport);
+    render(<ExportRETTable section={emptySection as any} />);
+    const table = screen.queryByRole("table");
+    expect(table).toBe(null);
+    expect(screen.getByText("Your associated MFP Work Plan does not contain any target populations.")).toBeVisible();
+  });
+})
 describe("Test ExportedReportWrapper accessibility", () => {
   it("ExportedReportWrapper should not have basic accessibility issues", async () => {
     const { container } = render(<ExportRETTable section={section as any} />);

--- a/services/ui-src/src/components/export/ExportedRETTable.tsx
+++ b/services/ui-src/src/components/export/ExportedRETTable.tsx
@@ -6,7 +6,7 @@ import {
 } from "types";
 
 // components
-import { Box } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import { Table } from "components";
 
 // utils
@@ -325,24 +325,28 @@ export const ExportRETTable = ({ section }: Props) => {
   });
 
   const formattedFieldData = { ...report?.fieldData, formId: form?.id };
-  //generate the table
-  let table = generateMainTable(rows, formattedFieldData, section.name);
-  formatFooterForRET(form?.id, report!, table.footRow!, table.headRow!);
-  //copying the current table before label truncating; these are the desired aria-labels
-  const ariaOverride = structuredClone(table);
-  //truncating the table labels
-  table.headRow = table.headRow.map((label) => formatHeaderForRET(label));
-  table.bodyRows = table.bodyRows.map((rows) => {
-    rows[0] = formatLabelForRET(form?.id, rows[0], report!);
-    return rows;
-  });
+  // //generate the table
+  let table: TableContentShape = {};
+  let ariaOverride: TableContentShape = {};
+  if (Object.keys(rows).length > 0) {
+    table = generateMainTable(rows, formattedFieldData, section.name);
+    formatFooterForRET(form?.id, report!, table.footRow!, table.headRow!);
+    //copying the current table before label truncating; these are the desired aria-labels
+    ariaOverride = structuredClone(table);
+    //truncating the table labels
+    table.headRow = table.headRow?.map((label) => formatHeaderForRET(label));
+    table.bodyRows = table.bodyRows?.map((rows) => {
+      rows[0] = formatLabelForRET(form?.id, rows[0], report!);
+      return rows;
+    });
+  }
   //split the table if there are >= 3 Other columns
-  const tables = truncateTable(table, 7);
+  const tables: TableContentShape[] = truncateTable(table, 7);
 
   return (
     <Box mt="2rem" data-testid="exportRETTable" sx={sx.container}>
-      {tables &&
-        tables.map((table, index) => {
+      {tables.length > 0 ? (
+        tables?.map((table, index) => {
           return (
             <Table
               sx={sx.table}
@@ -351,7 +355,12 @@ export const ExportRETTable = ({ section }: Props) => {
               ariaOverride={ariaOverride}
             ></Table>
           );
-        })}
+        })
+      ) : (
+        <Text>
+          Your associated MFP Work Plan does not contain any target populations.
+        </Text>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The R, E & T section in SAR pdf renders a bunch of charts based on the transition benchmarks that were selected. When there was no transition benchmark being utilized, the pdf was erroring out. This PR will fix the render issue and display a message saying, "Your associated MFP Work Plan does not contain any target populations.", if no chart is rendered.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3214

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Sign into MFP, any state user
2. Fill out a WP, say no to all transition benchmark and submit
3. Sign out and login as admin user
4. Approve the previously submitted WP
5. Signout and sign back in as the state user
6. Create a SAR
7. Go to Review & Submit section, click Review PDF
8. The page should rendered and each R, E & T section should show a message saying "Your associated MFP Work Plan does not contain any target populations.". EXCEPT if you are in period 2. In period 2, section 9 will still make a chart as it doesn't use Transition Benchmark for its data.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
