### PR TITLE
fix tealium domain

### DIFF
--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -28,7 +28,7 @@
         production: "prod",
       };
       var tealiumEnv = tealiumEnvMap[nodeEnv] || "dev";
-      var tealiumUrl = `https://tags.tiqcdn.com/utag/cmsgov/cms-mfp/${tealiumEnv}/utag.sync.js`;
+      var tealiumUrl = `https://tags.tiqcdn.com/utag/cmsgov/cms-general/${tealiumEnv}/utag.sync.js`;
       document.write(`<script src="${tealiumUrl}" async><\/script>`);
     </script>
   </head>
@@ -40,7 +40,7 @@
     </script>
     <script>
       (function (t, e, a, l, i, u, m) {
-        t = "cmsgov/cms-mdctmfp";
+        t = "cmsgov/cms-general";
         e = tealiumEnv;
         a = "/" + t + "/" + e + "/utag.js";
         l = "//tags.tiqcdn.com/utag" + a;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Because CMS is shifting from Google Analytics to Adobe Analytics, we need to alter the domain specified in the tealium tag.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
n/a

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~~
- [x] ~~I have updated relevant documentation, if necessary~~
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
