### PR TITLE
EntityDetailsOverlay Test Coverage

### DIFF
--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { RenderResult, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 // components
 import { EntityDetailsOverlay } from "components";
@@ -8,13 +8,16 @@ import {
   RouterWrappedComponent,
   mockUseEntityStore,
 } from "utils/testing/setupJest";
-import { useStore } from "utils";
+import { autosaveFieldData, useStore } from "utils";
+import userEvent from "@testing-library/user-event";
+import { UseFormReturn, FieldValues } from "react-hook-form";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue(mockUseEntityStore);
 
 const mockCloseEntityDetailsOverlay = jest.fn();
+const mockAutoSave = jest.fn();
 
 const { closeOutWarning, closeOutModal } =
   mockEntityDetailsOverlayJson.verbiage;
@@ -28,9 +31,12 @@ const entityDetailsOverlayComponent = (
   </RouterWrappedComponent>
 );
 
+let component: RenderResult;
 describe("Test EntityDetailsOverlayPage", () => {
+  beforeEach(() => {
+    component = render(entityDetailsOverlayComponent);
+  });
   test("EntityDetailsOverlayPage view renders", () => {
-    render(entityDetailsOverlayComponent);
     // Check that the header rendered
     expect(
       screen.getByText(mockEntityDetailsOverlayJson.verbiage.intro.section)
@@ -55,6 +61,16 @@ describe("Test EntityDetailsOverlayPage", () => {
     expect(
       screen.getByText(closeOutModal.closeOutModalButtonText)
     ).toBeVisible();
+  });
+  test("Test onChange Function", async () => {
+    const textbox = component.container.querySelector("#mock-text-field");
+    await userEvent.type(textbox!, "test");
+  });
+  test("Test onSubmit Function", async () => {
+    const saveButton = screen.getByText(
+      "Return to dashboard for this initiative"
+    );
+    await userEvent.click(saveButton);
   });
 });
 

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
@@ -28,6 +28,13 @@ jest.mock("utils/autosave/autosave", () => ({
   autosaveFieldData: jest.fn().mockImplementation(() => Promise.resolve("")),
 }));
 
+//mock closeout status to enable closeout button
+jest.mock("components/tables/getEntityStatus", () => ({
+  getCloseoutStatus: jest.fn().mockImplementation(() => {
+    return true;
+  }),
+}));
+
 const { closeOutWarning, closeOutModal } =
   mockEntityDetailsOverlayJson.verbiage;
 
@@ -93,6 +100,16 @@ describe("Test EntityDetailsOverlayPage", () => {
     const saveButton = screen.getByText("Save & return");
     await userEvent.click(saveButton);
     expect(mockCloseEntityDetailsOverlay).toHaveBeenCalled();
+  });
+  it("Test Closeout Modal", async () => {
+    const closeoutBtn = screen.getByText(closeOutModal.closeOutModalButtonText);
+    await userEvent.click(closeoutBtn);
+
+    const modal = screen.getByText("This is a modal");
+    expect(modal).toBeVisible();
+
+    const modalCloseBtn = screen.getByText("Cancel");
+    await userEvent.click(modalCloseBtn);
   });
 });
 

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.test.tsx
@@ -1,8 +1,4 @@
-import {
-  RenderResult,
-  render,
-  screen,
-} from "@testing-library/react";
+import { RenderResult, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 // components
 import { EntityDetailsOverlay, ReportContext } from "components";
@@ -21,6 +17,8 @@ const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue(mockUseEntityStore);
 
 const mockCloseEntityDetailsOverlay = jest.fn();
+
+let component: RenderResult;
 
 //bypass autosave call when simulating type inputs
 jest.mock("utils/autosave/autosave", () => ({
@@ -45,8 +43,10 @@ const entityDetailsOverlayComponent = (
 );
 
 describe("Test EntityDetailsOverlayPage", () => {
+  beforeEach(() => {
+    component = render(entityDetailsOverlayComponent);
+  });
   test("EntityDetailsOverlayPage view renders", () => {
-    render(entityDetailsOverlayComponent);
     // Check that the header rendered
     expect(
       screen.getByText(mockEntityDetailsOverlayJson.verbiage.intro.section)
@@ -74,18 +74,25 @@ describe("Test EntityDetailsOverlayPage", () => {
   });
 
   test("Test onSubmit Function", async () => {
-    let component = render(entityDetailsOverlayComponent);
     //fill out form
     const textbox = component.container.querySelector("#mock-text-field");
-    await userEvent.type(textbox!, "test");
-    const dateField = component.container.querySelector('[name="mock-date-field"]')
+    await userEvent.type(textbox!, "mock text");
+    expect(textbox).toHaveValue("mock text");
+
+    const dateField = component.container.querySelector(
+      '[name="mock-date-field"]'
+    );
     await userEvent.type(dateField!, "2/2/2022");
+    expect(dateField).toHaveValue("2/2/2022");
+
     const number = component.container.querySelector("#mock-number-field");
     await userEvent.type(number!, "3");
+    expect(number).toHaveValue("3");
 
     //trigger onSubmit
     const saveButton = screen.getByText("Save & return");
     await userEvent.click(saveButton);
+    expect(mockCloseEntityDetailsOverlay).toHaveBeenCalled();
   });
 });
 

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -162,7 +162,7 @@ export const EntityDetailsOverlay = ({
 
       dataToWrite.fieldData = { [entityType]: updatedEntities };
       const shouldSave = entityWasUpdated(
-        report?.fieldData?.[entityType][selectedEntityIndex],
+        report?.fieldData?.[entityType]?.[selectedEntityIndex],
         updatedEntities[selectedEntityIndex]
       );
       if (shouldSave) await updateReport(reportKeys, dataToWrite);

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -97,7 +97,7 @@ export const mockSectionHeaderField = {
 
 export const mockForm = {
   id: "mock-form-id",
-  fields: [mockFormField, mockDateField, mockDropdownField, mockNumberField],
+  fields: [mockFormField, mockDateField, mockNumberField],
 };
 
 export const mockModalForm = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -57,6 +57,12 @@ export const mockReportFieldData = {
       transitionBenchmarks_targetPopulationName: "mock benchmark name",
     },
   ],
+  initiative: [
+    {
+      id: "mock-initative-id",
+      name: "mock-name",
+    },
+  ],
 };
 
 export const mockWPReport = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Increasing code coverage from EntityDetailsOverlay. 

I removed one of the mock form field being a dropdown as I don't think we have any dropdowns in WP or SAR and it was preventing me from being able to to test onSubmit. We may have also removed some code with rendering dropdowns at one point too?

From 40% to 96% line coverage:
<img width="778" alt="Screenshot 2024-01-30 at 4 46 00 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/aca64590-324b-4bf5-b962-9cc67c288437">



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run **yarn coverage** in the **/ui-src/ folder**

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
