### PR TITLE
CMDCT-3227: [WP] Mask Values w/ Comma for Qualitative Objective Cards

### DIFF
--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,4 +1,5 @@
 import { EntityShape, OverlayModalStepTypes, AnyObject } from "types";
+import { convertToThousandsSeparatedString } from "utils";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
   const radioLabelValue = entity?.[label]?.[0].value;
@@ -17,7 +18,10 @@ const getRepeatedField = (
     for (const [key, value] of Object.entries(entity)) {
       if (key.includes(repeatedKey) && value) {
         const id = key.replace(repeatedKey, "").split("Q");
-        quarters.push({ id: `${id[0]} Q${id[1]}`, value: value });
+        quarters.push({
+          id: `${id[0]} Q${id[1]}`,
+          value: convertToThousandsSeparatedString(value).maskedValue,
+        });
       }
     }
   }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adding a comma-separated mask to qualitative target values on the `II. Evaluation plan` step for an initiative.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3227

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a WP
- Navigate to the initiatives dashboard
- Create an initiative

Go to step `II. Evaluation plans` and enter a bunch of really long numbers for the `Qualitative targets` question, they should display as comma-separated numbers in the card.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
