### PR TITLE
fix edit icon error

### DIFF
--- a/services/ui-src/src/types/formFields.ts
+++ b/services/ui-src/src/types/formFields.ts
@@ -126,6 +126,7 @@ export interface ChoiceFieldProps {
 export interface Choice {
   key: string; // choice.name
   value: string; // choice.value
+  id?: string; // choice.id
 }
 
 export interface DropdownChoice {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -83,7 +83,7 @@ export const initializeChoiceListFields = (
           ? choice.label[0]
           : choice.label;
         // if choice id has not already had parent field id appended, do so now
-        if (!choice.id.includes("-")) {
+        if (!choice.id?.includes("-")) {
           choice.id = field.id + "-" + choice.id;
         }
         choice.name = choice.id;

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -295,7 +295,7 @@ export const convertEntityToTargetPopulationChoice = (
 export const convertChoiceToEntity = (choices: Choice[]) => {
   return choices?.map((field: Choice) => {
     return {
-      id: field.id,
+      id: field.key ?? field.id,
       label: field.value,
       name: field.value,
       value: field.value,

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -83,7 +83,7 @@ export const initializeChoiceListFields = (
           ? choice.label[0]
           : choice.label;
         // if choice id has not already had parent field id appended, do so now
-        if (!choice.id?.includes("-")) {
+        if (!choice.id.includes("-")) {
           choice.id = field.id + "-" + choice.id;
         }
         choice.name = choice.id;
@@ -295,7 +295,7 @@ export const convertEntityToTargetPopulationChoice = (
 export const convertChoiceToEntity = (choices: Choice[]) => {
   return choices?.map((field: Choice) => {
     return {
-      id: field.key,
+      id: field.key ? field.key : field.id,
       label: field.value,
       name: field.value,
       value: field.value,

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -295,7 +295,7 @@ export const convertEntityToTargetPopulationChoice = (
 export const convertChoiceToEntity = (choices: Choice[]) => {
   return choices?.map((field: Choice) => {
     return {
-      id: field.key ? field.key : field.id,
+      id: field.id,
       label: field.value,
       name: field.value,
       value: field.value,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
updated the `convertChoiceToEntity` function to only assign `field.key` if it exists, otherwise assign the field.id. Hopefully this fixes the targetPopulation issue where the id was showing as undefined and breaking the addEditModal

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3244

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- create a SAR off of a work plan that has Target Populations
- click the edit icon from the dashboard view
- the modal should appear with no errors

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
