### PR TITLE
[Bugfix] SAR - Objectives Progress Copyover Hydration

### DIFF
--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -426,11 +426,8 @@ export const quantitativeQuarters = (
     //depending on the period, the quarter starts at  Q1 or Q3
     const currentQuarter = reportPeriod === 1 ? 1 : 3;
     // have to loop twice for both periods
-    for (
-      let quarterNumber = currentQuarter;
-      quarterNumber <= currentQuarter + 1;
-      quarterNumber += 1
-    ) {
+    const quartersInPeriod = reportPeriod === 1 ? [1, 2] : [3, 4];
+    for (let quarterNumber of quartersInPeriod) {
       const formFieldHeading: FormField = {
         id: `objectiveTargetsHeader_Q${quarterNumber}_${fieldToRepeat.id}`,
         type: "sectionHeader",

--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -423,8 +423,14 @@ export const quantitativeQuarters = (
         ? "Second quarter (April 1 - June 30)"
         : "Fourth quarter (October 1 - December 31)";
 
+    //depending on the period, the quarter starts at  Q1 or Q3
+    const currentQuarter = reportPeriod === 1 ? 1 : 3;
     // have to loop twice for both periods
-    for (let quarterNumber = 1; quarterNumber <= 2; quarterNumber += 1) {
+    for (
+      let quarterNumber = currentQuarter;
+      quarterNumber <= currentQuarter + 1;
+      quarterNumber += 1
+    ) {
       const formFieldHeading: FormField = {
         id: `objectiveTargetsHeader_Q${quarterNumber}_${fieldToRepeat.id}`,
         type: "sectionHeader",

--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -436,11 +436,11 @@ export const quantitativeQuarters = (
         type: "sectionHeader",
         props: {
           content:
-            quarterNumber == 1
+            quarterNumber == currentQuarter
               ? headingStringFirstQuarter
               : headingStringSecondQuarter,
           label:
-            quarterNumber == 1
+            quarterNumber == currentQuarter
               ? "Complete the following for quantitative targets:"
               : "",
         },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There's an issue with SAR reports that are created from a copied over WP. The SAR Objective Progress is not auto-hydrating the Target Value textboxes. What's causing this is not because of the copy over but because of the target transformation not generating the correctly ids & labels by quarters. 

**IMPORTANT**: This issue affected the objectives of reporting period 2 only. So when testing the SAR and WP reporting, check that it is for reporting period 2.

![Screenshot 2024-02-05 at 12 21 04 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/7d86401c-2cd8-418d-bfb4-ae7d47478867)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3208

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP, any state user
2) Fill out and submit a WP
    - When filling out evalution plan, make sure to select yes and fill out the target quantitative targets.
3) Signout of state user and sign in as admin
4) Approve the previously made WP
5) Sign back into the state user, and copy the approve WP
7) Fill out the copied WP, go through the approval process again
8) Create a SAR from the copied WP
9) Go to the SAR - State- or Territory-Specific Initiatives - Objective Progress and see if the target value is populated

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
