### PR TITLE
Restrict requests by assigned state for state users

### DIFF
--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -41,18 +41,12 @@ const archiveEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test archiveReport method", () => {
-  beforeEach(() => {
-    // fail state and pass admin auth checks
-    mockAuthUtil.hasPermissions
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
-  });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("Test archive report passes with valid data", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {
@@ -68,6 +62,7 @@ describe("Test archiveReport method", () => {
   });
 
   test("Test archive report with no existing record throws 404", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {
@@ -82,6 +77,7 @@ describe("Test archiveReport method", () => {
   });
 
   test("Test archive report without admin permissions throws 403", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(false);
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -17,6 +17,7 @@ import { StatusCodes } from "../../utils/types";
 
 jest.mock("../../utils/auth/authorization", () => ({
   isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthorizedToFetchState: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
   hasReportAccess: jest.fn().mockReturnValue(true),
 }));

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -46,16 +46,9 @@ import { extractWorkPlanData } from "../../utils/transformations/transformations
 
 export const createReport = handler(
   async (event: APIGatewayProxyEvent, _context) => {
-    if (!hasPermissions(event, [UserRoles.STATE_USER])) {
-      return {
-        status: StatusCodes.UNAUTHORIZED,
-        body: error.UNAUTHORIZED,
-      };
-    }
-
     const requiredParams = ["reportType", "state"];
 
-    // Return No_Key when not given a state and reportType as a paramater
+    // Return No_Key when not given a state and reportType as a parameter
     if (
       !event.pathParameters ||
       !hasReportPathParams(event.pathParameters, requiredParams)
@@ -72,6 +65,12 @@ export const createReport = handler(
       return {
         status: StatusCodes.BAD_REQUEST,
         body: error.NO_KEY,
+      };
+    }
+    if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
+      return {
+        status: StatusCodes.UNAUTHORIZED,
+        body: error.UNAUTHORIZED,
       };
     }
 

--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -36,19 +36,12 @@ const releaseEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test releaseReport method", () => {
-  beforeEach(() => {
-    // fail state and pass admin auth checks
-    mockAuthUtil.hasPermissions
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
-  });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("Test release report passes with valid data", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     mockDocumentClient.get.promise.mockReturnValueOnce({
       Item: mockDynamoDataWPLocked,
     });
@@ -63,6 +56,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report passes with valid data, but it's been more than the first submission", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     const newPreviousId = KSUID.randomSync().string;
     mockDocumentClient.get.promise.mockReturnValueOnce({
       Item: {
@@ -85,6 +79,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report with no existing record throws 404", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     mockDocumentClient.get.promise.mockReturnValueOnce({
       Item: undefined,
     });
@@ -94,6 +89,7 @@ describe("Test releaseReport method", () => {
   });
 
   test("Test release report without admin permissions throws 403", async () => {
+    mockAuthUtil.hasPermissions.mockReturnValueOnce(false);
     mockDocumentClient.get.promise.mockReturnValueOnce({
       Item: mockDynamoDataWPLocked,
     });

--- a/services/app-api/handlers/reports/submit.ts
+++ b/services/app-api/handlers/reports/submit.ts
@@ -14,6 +14,7 @@ import s3Lib, {
   getFormTemplateKey,
 } from "../../utils/s3/s3-lib";
 import { convertDateUtcToEt } from "../../utils/time/time";
+import { hasReportPathParams } from "../../utils/dynamo/hasReportPathParams";
 // types
 import {
   isState,
@@ -23,21 +24,14 @@ import {
 } from "../../utils/types";
 
 export const submitReport = handler(async (event, _context) => {
+  const requiredParams = ["id", "reportType", "state"];
   if (
-    !event.pathParameters?.id ||
-    !event.pathParameters?.state ||
-    !event.pathParameters.reportType
+    !event.pathParameters ||
+    !hasReportPathParams(event.pathParameters!, requiredParams)
   ) {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
-    };
-  }
-
-  if (!hasPermissions(event, [UserRoles.STATE_USER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
     };
   }
 
@@ -47,6 +41,12 @@ export const submitReport = handler(async (event, _context) => {
     return {
       status: StatusCodes.BAD_REQUEST,
       body: error.NO_KEY,
+    };
+  }
+  if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
+    return {
+      status: StatusCodes.UNAUTHORIZED,
+      body: error.UNAUTHORIZED,
     };
   }
 

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -90,7 +90,7 @@ export const updateReport = handler(async (event, context) => {
   }
 
   // Ensure user has correct permissions to update a report.
-  if (!hasPermissions(event, [UserRoles.STATE_USER])) {
+  if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
     return {
       status: StatusCodes.UNAUTHORIZED,
       body: error.UNAUTHORIZED,

--- a/services/app-api/utils/auth/authorization.test.ts
+++ b/services/app-api/utils/auth/authorization.test.ts
@@ -1,5 +1,9 @@
 import { proxyEvent } from "../testing/proxyEvent";
-import { hasPermissions, isAuthorized } from "./authorization";
+import {
+  hasPermissions,
+  isAuthorized,
+  isAuthorizedToFetchState,
+} from "./authorization";
 import { UserRoles } from "../types";
 
 const mockVerifier = jest.fn();
@@ -99,5 +103,36 @@ describe("Check user has permissions", () => {
   });
   test("has permissions should fail when the api token is missing", () => {
     expect(hasPermissions(noApiKeyEvent, [UserRoles.ADMIN])).toBeFalsy();
+  });
+});
+
+describe("Test isAuthorizedToFetchState", () => {
+  test("isAuthorizedToFetchState should pass when requested role and state match user role and state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "AL",
+    });
+    expect(isAuthorizedToFetchState(apiKeyEvent, "AL")).toBeTruthy();
+  });
+  test("isAuthorizedToFetchState should fail if state requested does not match role", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+      "custom:cms_state": "AL",
+    });
+    expect(isAuthorizedToFetchState(apiKeyEvent, "TX")).toBeFalsy();
+  });
+  test("isAuthorizedToFetchState should fail if state is not specified in state user role", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.STATE_USER,
+    });
+    expect(isAuthorizedToFetchState(apiKeyEvent, "AL")).toBeFalsy();
+  });
+  test("isAuthorizedToFetchState should pass for admin, regardless of state", () => {
+    mockedDecode.mockReturnValue({
+      "custom:cms_roles": UserRoles.ADMIN,
+    });
+    expect(isAuthorizedToFetchState(apiKeyEvent, "TX")).toBeTruthy();
+    expect(isAuthorizedToFetchState(apiKeyEvent, "AL")).toBeTruthy();
+    expect(isAuthorizedToFetchState(apiKeyEvent, "OR")).toBeTruthy();
   });
 });

--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -7,6 +7,7 @@ import { UserRoles } from "../types";
 
 interface DecodedToken {
   "custom:cms_roles": UserRoles;
+  "custom:cms_state": string | undefined;
 }
 
 const loadCognitoValues = async () => {
@@ -73,21 +74,40 @@ export const isAuthorized = async (event: APIGatewayProxyEvent) => {
 
 export const hasPermissions = (
   event: APIGatewayProxyEvent,
-  allowedRoles: UserRoles[]
+  allowedRoles: UserRoles[],
+  state?: string
 ) => {
   let isAllowed = false;
   // decode the idToken
   if (event?.headers["x-api-key"]) {
     const decoded = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
     const idmUserRoles = decoded["custom:cms_roles"];
+    const idmUserState = decoded["custom:cms_state"];
     const mfpUserRole = idmUserRoles
       ?.split(",")
       .find((role) => role.includes("mdctmfp")) as UserRoles;
 
-    if (allowedRoles.includes(mfpUserRole)) {
-      isAllowed = true;
-    }
+    isAllowed =
+      allowedRoles.includes(mfpUserRole) &&
+      (!state || idmUserState?.includes(state))!;
   }
 
   return isAllowed;
+};
+
+export const isAuthorizedToFetchState = (
+  event: APIGatewayProxyEvent,
+  state: string
+) => {
+  // If this is a state user for the matching state, authorize them.
+  if (hasPermissions(event, [UserRoles.STATE_USER], state)) {
+    return true;
+  }
+
+  const nonStateUserRoles = Object.values(UserRoles).filter(
+    (role) => role !== UserRoles.STATE_USER
+  );
+
+  // If they are any other user type, they don't need to belong to this state.
+  return hasPermissions(event, nonStateUserRoles);
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Copies work from [MCR](https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/11575)

We have an auth utility called `hasPermissions` that verifies the requesting user has the role expected for a given request (ex: ADMIN for create banner, STATE USER for submit report, etc.)

Key changes:
- `services/app-api/utils/auth/authorization.ts` the `hasPermissions()` method is updated to optionally accept `state`. It performs different verification logic as a result.
  - also added the `isAuthorizedToFetchState()` method to verify that if they are a state user, they are a state user for the requested state. Admins and other types can request any state.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3197

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
To verify the `create` updates (same logic as `update` and `submit`)
- Log in as a state user
- With the network tab open, create a WP report
- Manipulate the POST network request to send it to a different state
- Verify that request returns a 403 (on `main` it is a 201 😬 )

You can do a similar test to verify `fetch` permissions checks
- Log in as a state user
- With the network tab open, refresh the WP reports dashboard
- Manipulate the GET network request to request reports from a different state
- Verify that request returns a 403 (on `main` it is a 200 😬 )

You can also verify admin functions still work as expected (like create and delete banner)

On Chrome you can right-click the command and select "Copy as cURL or Copy as Fetch". The former you can paste in a terminal and edit. The latter you can paste in the browser's console and edit (I found this easier). Resend the command and verify the status code.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---