### PR TITLE
Add check for repeated work plan creation

### DIFF
--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -115,6 +115,9 @@ describe("Test createReport API method", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+    jest
+      .spyOn(helperFunctions, "eligibleToCreateNewWP")
+      .mockResolvedValueOnce(true);
   });
   test("Test unauthorized report creation throws 403 error", async () => {
     jest.spyOn(authFunctions, "isAuthorized").mockResolvedValueOnce(false);
@@ -208,7 +211,7 @@ describe("Test createReport API method", () => {
 
   test("Test successful run of sar report creation, not copied", async () => {
     jest
-      .spyOn(helperFunctions, "getLastCreatedWorkPlan")
+      .spyOn(helperFunctions, "getLatestSarEligibleWorkPlan")
       .mockResolvedValueOnce({
         workPlanMetadata: mockWPMetadata,
         workPlanFieldData: mockWPFieldData,
@@ -253,5 +256,18 @@ describe("Test createReport API method", () => {
 
     expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
     expect(res.body).toContain(error.NO_KEY);
+  });
+});
+
+describe("Test create WP not allowed", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+  test("Cannot create WP if previous WP not approved", async () => {
+    jest
+      .spyOn(helperFunctions, "eligibleToCreateNewWP")
+      .mockResolvedValueOnce(false);
+    const res = await createReport(wpCreationEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
   });
 });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -24,7 +24,8 @@ import {
 } from "../../utils/time/time";
 import {
   createReportName,
-  getLastCreatedWorkPlan,
+  eligibleToCreateNewWP,
+  getLatestSarEligibleWorkPlan,
 } from "../../utils/other/other";
 // types
 import {
@@ -99,10 +100,10 @@ export const createReport = handler(
       workPlanFieldData?: AnyObject;
     } =
       reportType === ReportType.SAR
-        ? await getLastCreatedWorkPlan(event, _context, state)
+        ? await getLatestSarEligibleWorkPlan(event, _context, state)
         : { workPlanMetadata: undefined, workPlanFieldData: undefined };
 
-    // If we recieved no work plan information and we're trying to create a SAR, return NO_WORKPLANS_FOUND
+    // If we received no work plan information and we're trying to create a SAR, return NO_WORKPLANS_FOUND
     if (
       !workPlanFieldData &&
       !workPlanMetadata &&
@@ -111,6 +112,17 @@ export const createReport = handler(
       return {
         status: StatusCodes.NOT_FOUND,
         body: error.NO_WORKPLANS_FOUND,
+      };
+    }
+
+    // If reportType is WP and there is an existing unapproved report, don't create another
+    if (
+      !(await eligibleToCreateNewWP(event, _context)) &&
+      reportType === ReportType.WP
+    ) {
+      return {
+        status: StatusCodes.BAD_REQUEST,
+        body: error.CREATE_NOT_PERMITTED,
       };
     }
 
@@ -279,7 +291,7 @@ export const createReport = handler(
       };
     }
 
-    // Begin Section - Create DyanmoDB record
+    // Begin Section - Create DynamoDB record
     const reportMetadataParams: DynamoWrite = {
       TableName: reportTable,
       Item: {

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -5,7 +5,9 @@ export const error = {
   MISSING_DATA: "Missing required data.",
   INVALID_DATA: "Provided data is not valid.",
   NO_MATCHING_RECORD: "No matching record found.",
-  SERVER_ERROR: "An unspecified server error occured.",
+  SERVER_ERROR: "An unspecified server error occurred.",
+  // form errors
+  CREATE_NOT_PERMITTED: "Cannot create new report at this time.",
   // bucket errors
   S3_OBJECT_CREATION_ERROR: "Report could not be created due to an S3 error.",
   S3_OBJECT_UPDATE_ERROR: "Report could not be updated due to an S3 error.",

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -24,7 +24,7 @@ export const createReportName = (
   return `${fullStateName} MFP ${reportName} ${reportYear} - Period ${period}`;
 };
 
-export const lastCreatedWorkPlan = (
+export const latestSarEligibleWorkPlan = (
   currentWorkPlans: ReportMetadataShape[]
 ): ReportMetadataShape | undefined => {
   let lastCreatedWorkPlan: ReportMetadataShape | undefined = undefined;
@@ -59,7 +59,7 @@ export const lastCreatedWorkPlan = (
   return lastCreatedWorkPlan;
 };
 
-export const getLastCreatedWorkPlan = async (
+export const getLatestSarEligibleWorkPlan = async (
   event: APIGatewayProxyEvent,
   _context: any,
   state: string
@@ -77,15 +77,15 @@ export const getLastCreatedWorkPlan = async (
   const currentWorkPlans = JSON.parse(workPlanSubmissions.body);
 
   // Get last created Work Plan
-  const eligbleWorkPlan = lastCreatedWorkPlan(currentWorkPlans);
+  const eligibleWorkPlan = latestSarEligibleWorkPlan(currentWorkPlans);
 
   // And assuming we have one we want to get the data from.
-  if (eligbleWorkPlan) {
+  if (eligibleWorkPlan) {
     const fetchWPReportEvent = event;
     fetchWPReportEvent.pathParameters = {
       reportType: ReportType.WP,
       state: state,
-      id: eligbleWorkPlan["id"],
+      id: eligibleWorkPlan["id"],
     };
     // Get the data of the eligble work plan
     const workPlan = await fetchReport(fetchWPReportEvent, _context);
@@ -101,4 +101,30 @@ export const getLastCreatedWorkPlan = async (
   }
   // If there wasn't an eligble work plan to copy from, return undefined
   return { workPlanMetadata: undefined, workPlanFieldData: undefined };
+};
+
+export const eligibleToCreateNewWP = async (
+  event: APIGatewayProxyEvent,
+  _context: any
+): Promise<boolean> => {
+  // Fetch all Work Plans for the state
+  const workPlanEvent = event;
+  workPlanEvent.pathParameters = {
+    ...workPlanEvent.pathParameters,
+    reportType: ReportType.WP,
+  };
+  const workPlanSubmissions = await fetchReportsByState(event, _context);
+  const currentWorkPlans = JSON.parse(workPlanSubmissions.body);
+
+  // Get most recently created Work Plan
+  const lastCreatedWorkPlan = currentWorkPlans.reduce(
+    (nextReport: ReportMetadataShape, latestReport: ReportMetadataShape) =>
+      nextReport.createdAt > latestReport.createdAt ? nextReport : latestReport
+  );
+
+  // Allow new create if no previous WP or previous WP is approved
+  return (
+    !lastCreatedWorkPlan ||
+    lastCreatedWorkPlan?.status === ReportStatus.APPROVED
+  );
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently our UI disabled a button when we don't want to allow the user to create multiple work plans. The API does not prevent this action, so you can circumvent the UI and create as many as you want 😱 

Open to feedback on status codes and error messaging for this situation!


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3251

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Using either your browser or the MFP Postman collection, attempt to create multiple Work Plans
  - In browser you can just try resending the network call multiple times
- Ensure the first one gets created. Any after that return 400.
  - If you complete a WP you can then create another. Then the pattern repeats.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---

### Notes
I tried adding a test file: `other.test.ts` and it gave many errors when I only tried to test the name formatting function. Maybe I need to mock the fetch calls even though they weren't in my test? Idk but if coverage is low I may need someone to look at that with me.