### PR TITLE
[Bugfix] WP Copy Initiative Status in Review & Submit

### DIFF
--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -189,7 +189,11 @@ export const calculateCompletionStatus = async (
                 ? stepForm.form
                 : stepForm.modalForm;
 
-              if (nestedFormTemplate?.initiativeId !== stepFields?.id) {
+              //WP uses modaloverlay so it doesn't have an initiativeId, only SAR does
+              if (
+                nestedFormTemplate?.initiativeId !== stepFields?.id &&
+                formTemplate.type === "SAR"
+              ) {
                 continue;
               }
               const isEntityComplete = await calculateFormCompletion(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The strangest case of this should have been broken the whole time but somehow managed to not be until the copy. 

WP Review and Submit status for State- or Territory Specific Initiatives status would show only complete when a WP copy was made. The issue was that the status did not actually run because it was trying to check for an initiativeId that only existed in dynamic modal overlay report pages. This PR adds a simple check to the conditional.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3250

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Sign into MFP, any state user
- Fill out and submit a WP
- Signout of state user and sign in as admin
- Approve the previously made WP
- Sign back into the state user, and copy the approve WP
- Go to into the copied WP, check Review and Submit.
- Check to make sure the status of State- or Territory Specific Initiatives is false
- Fill out State- or Territory Specific Initiatives and then check that the status is complete .

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
