### PR TITLE
display quarters in quantitative progress

### DIFF
--- a/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
@@ -1,6 +1,6 @@
 // utils
 import { AnyObject, OverlayModalStepTypes } from "types";
-import { Text, Box } from "@chakra-ui/react";
+import { Text, Box, Grid, GridItem, Flex } from "@chakra-ui/react";
 import { notAnsweredText } from "../../constants";
 
 const wereTargetsMetForObjectiveProgress = (
@@ -97,8 +97,43 @@ export const EntityStepCardBottomSection = ({
                 : undefined
             }
           >
-            {formattedEntityData?.quarterProjections?.length > 0 ? (
+            {formattedEntityData?.targetsMet &&
+            formattedEntityData?.quarterProjections?.length > 0 ? (
               <>
+                <Text sx={sx.subtitle} data-testid="sar-grid">
+                  Quantitative targets for this reporting period
+                </Text>
+
+                <Grid sx={sx.sarGrid}>
+                  {formattedEntityData?.quarterProjections
+                    .slice(0, 2)
+                    .map((quarter: any) => {
+                      return (
+                        <GridItem key={quarter.id}>
+                          <Flex sx={sx.gridItems}>
+                            <Text sx={sx.sarGridSubtitle}>
+                              {quarter.id} Target:
+                            </Text>
+                            <Text sx={sx.gridItems}>{quarter.value}</Text>
+                          </Flex>
+                        </GridItem>
+                      );
+                    })}
+                  {formattedEntityData?.quarterActuals
+                    .slice(0, 2)
+                    .map((quarter: any) => {
+                      return (
+                        <GridItem key={quarter.id}>
+                          <Flex sx={sx.gridItems}>
+                            <Text sx={sx.sarGridSubtitle}>
+                              {quarter.id} Actual:
+                            </Text>
+                            <Text sx={sx.gridItems}>{quarter.value}</Text>
+                          </Flex>
+                        </GridItem>
+                      );
+                    })}
+                </Grid>
                 {(formattedEntityData?.targetsMet || printVersion) &&
                   wereTargetsMetForObjectiveProgress(
                     formattedEntityData,

--- a/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardBottomSection.tsx
@@ -1,6 +1,6 @@
 // utils
 import { AnyObject, OverlayModalStepTypes } from "types";
-import { Text, Box, Grid, GridItem, Flex } from "@chakra-ui/react";
+import { Text, Box } from "@chakra-ui/react";
 import { notAnsweredText } from "../../constants";
 
 const wereTargetsMetForObjectiveProgress = (
@@ -99,40 +99,6 @@ export const EntityStepCardBottomSection = ({
           >
             {formattedEntityData?.quarterProjections?.length > 0 ? (
               <>
-                <Text sx={sx.subtitle} data-testid="sar-grid">
-                  Quantitative targets for this reporting period
-                </Text>
-
-                <Grid sx={sx.sarGrid}>
-                  {formattedEntityData?.quarterProjections
-                    .slice(0, 2)
-                    .map((quarter: any) => {
-                      return (
-                        <GridItem key={quarter.id}>
-                          <Flex sx={sx.gridItems}>
-                            <Text sx={sx.sarGridSubtitle}>
-                              {quarter.id} Target:
-                            </Text>
-                            <Text sx={sx.gridItems}>{quarter.value}</Text>
-                          </Flex>
-                        </GridItem>
-                      );
-                    })}
-                  {formattedEntityData?.quarterActuals
-                    .slice(0, 2)
-                    .map((quarter: any) => {
-                      return (
-                        <GridItem key={quarter.id}>
-                          <Flex sx={sx.gridItems}>
-                            <Text sx={sx.sarGridSubtitle}>
-                              {quarter.id} Actual:
-                            </Text>
-                            <Text sx={sx.gridItems}>{quarter.value}</Text>
-                          </Flex>
-                        </GridItem>
-                      );
-                    })}
-                </Grid>
                 {(formattedEntityData?.targetsMet || printVersion) &&
                   wereTargetsMetForObjectiveProgress(
                     formattedEntityData,

--- a/services/ui-src/src/components/cards/EntityCardTopSection.test.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.test.tsx
@@ -116,5 +116,15 @@ describe("Test EntityStepCardTopSection renders correctly for SAR", () => {
     expect(
       topOfCard.getByText(mockFullyCompletedObjectiveProgress.targets)
     ).toBeVisible();
+    expect(
+      topOfCard.getByText(
+        `${mockFullyCompletedObjectiveProgress.quarterProjections[0].id} Target:`
+      )
+    ).toBeVisible();
+    expect(
+      topOfCard.getByText(
+        `${mockFullyCompletedObjectiveProgress.quarterProjections[1].id} Target:`
+      )
+    ).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -8,6 +8,7 @@ import { useStore } from "utils";
 export const EntityStepCardTopSection = ({
   stepType,
   formattedEntityData,
+  entityCompleted,
 }: Props) => {
   const { report } = useStore() ?? {};
   switch (stepType) {
@@ -24,25 +25,30 @@ export const EntityStepCardTopSection = ({
           <Text sx={sx.description}>{formattedEntityData.description}</Text>
           <Text sx={sx.subtitle}>Performance measure targets</Text>
           <Text sx={sx.description}>{formattedEntityData.targets}</Text>
-          {formattedEntityData.quarterProjections.length > 0 && (
-            <>
-              <Text sx={sx.subtitle}>
-                Quantitative targets for this reporting period
-              </Text>
-              <Grid sx={sx.sarGrid}>
-                {formattedEntityData?.quarterProjections.map((quarter: any) => {
-                  return (
-                    <GridItem key={quarter.id}>
-                      <Flex sx={sx.gridItems}>
-                        <Text sx={sx.gridSubtitle}>{quarter.id} Target:</Text>
-                        <Text sx={sx.subtext}>{quarter.value}</Text>
-                      </Flex>
-                    </GridItem>
-                  );
-                })}
-              </Grid>
-            </>
-          )}
+          {formattedEntityData.quarterProjections.length > 0 &&
+            !entityCompleted && (
+              <>
+                <Text sx={sx.subtitle}>
+                  Quantitative targets for this reporting period
+                </Text>
+                <Grid sx={sx.sarGrid}>
+                  {formattedEntityData?.quarterProjections.map(
+                    (quarter: any) => {
+                      return (
+                        <GridItem key={quarter.id}>
+                          <Flex sx={sx.gridItems}>
+                            <Text sx={sx.gridSubtitle}>
+                              {quarter.id} Target:
+                            </Text>
+                            <Text sx={sx.subtext}>{quarter.value}</Text>
+                          </Flex>
+                        </GridItem>
+                      );
+                    }
+                  )}
+                </Grid>
+              </>
+            )}
         </>
       );
     case OverlayModalStepTypes.EVALUATION_PLAN:
@@ -144,6 +150,7 @@ interface Props {
   stepType: string;
   formattedEntityData: AnyObject;
   printVersion?: boolean;
+  entityCompleted?: boolean;
 }
 
 const sx = {

--- a/services/ui-src/src/components/cards/EntityCardTopSection.tsx
+++ b/services/ui-src/src/components/cards/EntityCardTopSection.tsx
@@ -24,6 +24,25 @@ export const EntityStepCardTopSection = ({
           <Text sx={sx.description}>{formattedEntityData.description}</Text>
           <Text sx={sx.subtitle}>Performance measure targets</Text>
           <Text sx={sx.description}>{formattedEntityData.targets}</Text>
+          {formattedEntityData.quarterProjections.length > 0 && (
+            <>
+              <Text sx={sx.subtitle}>
+                Quantitative targets for this reporting period
+              </Text>
+              <Grid sx={sx.sarGrid}>
+                {formattedEntityData?.quarterProjections.map((quarter: any) => {
+                  return (
+                    <GridItem key={quarter.id}>
+                      <Flex sx={sx.gridItems}>
+                        <Text sx={sx.gridSubtitle}>{quarter.id} Target:</Text>
+                        <Text sx={sx.subtext}>{quarter.value}</Text>
+                      </Flex>
+                    </GridItem>
+                  );
+                })}
+              </Grid>
+            </>
+          )}
         </>
       );
     case OverlayModalStepTypes.EVALUATION_PLAN:
@@ -145,6 +164,13 @@ const sx = {
     gridAutoFlow: "column",
     gridGap: ".5rem",
     marginBottom: "1.25rem",
+  },
+  sarGrid: {
+    display: "grid",
+    gridTemplateRows: "1fr",
+    gridAutoFlow: "column",
+    marginBottom: "1.25rem",
+    width: "50%",
   },
   gridSubtitle: {
     fontWeight: "bold",

--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -170,6 +170,7 @@ export const EntityStepCard = ({
           stepType={stepType}
           printVersion={!!printVersion}
           formattedEntityData={formattedEntityData}
+          entityCompleted={entityCompleted}
         />
         {entityCompleted || printVersion ? (
           <EntityStepCardBottomSection


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
display the 2 first quarters in the reporting period for Quantitative Objective Progress in the SAR

<img width="690" alt="Screenshot 2024-02-08 at 12 10 15 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/732ff218-b31e-48fb-bc4d-f2b1408fb8ad">

upon completing the entity, the display of quantitative info moves to the blue section
<img width="691" alt="Screenshot 2024-02-08 at 12 21 12 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/5274c3b3-848c-4b3e-9dfb-8f8fccf91910">

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3233

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- create a WP with an objective that contains quantitative info
- create a SAR off of that WP, go to State Initiatives -> Objectives progress and you should see the 1st two quarters displaying in the quantitative objective progress card


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
