### PR TITLE
Add SMART goals instructions accordion to Objectives Progress page

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -990,7 +990,7 @@
             "isRequired": true,
             "verbiage": {
               "intro": {
-                "section": "State- or Territory-Specific Initiatives",
+                "section": "State or Territory-Specific Initiatives",
                 "info": [
                   {
                     "type": "html",
@@ -1002,6 +1002,37 @@
                   }
                 ],
                 "dashboardTitle": "Objectives progress"
+              },
+              "accordion": {
+                "buttonLabel": "About SMART goals",
+                "intro": [
+                  {
+                    "type": "html",
+                    "content": "The evaluation plan in your MFP Work Plan captured expected results for each state or territory-specific initiative. You identified one or more objectives per initiative and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. In the Semi-Annual Progress Report, you must articulate how you will achieve targets and meet milestones. For more information on objectives and identifying appropriate performance measures, see "
+                  },
+                  {
+                    "type": "externalLink",
+                    "content": "\"Using Data to Improve Money Follows the Person Program Performance.\"",
+                    "props": {
+                      "href": "https://www.medicaid.gov/sites/default/files/2023-01/MFP-Technical-Assistance-Brief.pdf",
+                      "target": "_blank",
+                      "aria-label": "Using Data to Improve Money Follows the Person Program Performance (Link opens in new tab)"
+                    }
+                  },
+                  {
+                    "type": "html",
+                    "content": "<br/><br/>As a reminder, SMART stands for:"
+                  }
+                ],
+                "list": [
+                  [
+                    "<b>Specific:</b> Specifies the activities, actors, and beneficiaries",
+                    "<b>Measurable:</b> Defines how a change will be measured",
+                    "<b>Achievable:</b> Confirms the feasibility of implementing the intervention as planned",
+                    "<b>Realistic/relevant</b>: Ensures the intervention relates to the goal",
+                    "<b>Time-bound</b>: Specifies when the results are expected"
+                  ]
+                ]
               },
               "editEntityButtonText": "Edit objective progress",
               "reportProgressButtonText": "Report objective progress",

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -124,7 +124,6 @@ export const OverlayModalPage = ({
           text={verbiage.intro}
           accordion={verbiage.accordion}
           initiativeName={selectedEntity!.initiative_name}
-          stepType={stepType}
         />
       )}
       <Box>

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -3,7 +3,7 @@ import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
 import { parseCustomHtml } from "utils";
-import { AnyObject } from "types";
+import { AnyObject, OverlayModalStepTypes } from "types";
 import { ReportPeriod } from "./ReportPeriod";
 
 export const ReportPageIntro = ({
@@ -12,7 +12,6 @@ export const ReportPageIntro = ({
   initiativeName,
   reportPeriod,
   reportYear,
-  stepType,
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
@@ -26,16 +25,16 @@ export const ReportPageIntro = ({
         {initiativeName ? initiativeName : subsection}
       </Heading>
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
-      {accordion && stepType !== "objectiveProgress" && (
+      {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
         <InstructionsAccordion verbiage={accordion} />
       )}
-      {stepType === "objectiveProgress" && (
+      {OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
         <Heading as="h3" sx={sx.subTitle}>
-          Objectives progress
+          {text.dashboardTitle}
         </Heading>
       )}
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-      {accordion && stepType === "objectiveProgress" && (
+      {accordion && OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
         <InstructionsAccordion verbiage={accordion} />
       )}
       <ReportPeriod
@@ -54,7 +53,6 @@ interface Props {
   [key: string]: any;
   reportPeriod?: number;
   reportYear?: number;
-  stepType?: string;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -28,7 +28,7 @@ export const ReportPageIntro = ({
       {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
         <InstructionsAccordion verbiage={accordion} />
       )}
-      {OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
+      {OverlayModalStepTypes.OBJECTIVE_PROGRESS && text.dashboardTitle && (
         <Heading as="h3" sx={sx.subTitle}>
           {text.dashboardTitle}
         </Heading>

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -2,8 +2,8 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
-import { parseCustomHtml, useStore } from "utils";
-import { AnyObject, ReportType } from "types";
+import { parseCustomHtml } from "utils";
+import { AnyObject } from "types";
 import { ReportPeriod } from "./ReportPeriod";
 
 export const ReportPageIntro = ({
@@ -16,7 +16,6 @@ export const ReportPageIntro = ({
   ...props
 }: Props) => {
   const { section, subsection, hint, info } = text;
-  const { report } = useStore() ?? {};
 
   return (
     <Box sx={sx.introBox} {...props}>
@@ -27,13 +26,18 @@ export const ReportPageIntro = ({
         {initiativeName ? initiativeName : subsection}
       </Heading>
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
-      {accordion && <InstructionsAccordion verbiage={accordion} />}
-      {stepType === "evaluationPlan" && report?.reportType === ReportType.SAR && (
+      {accordion && stepType !== "objectiveProgress" && (
+        <InstructionsAccordion verbiage={accordion} />
+      )}
+      {stepType === "objectiveProgress" && (
         <Heading as="h3" sx={sx.subTitle}>
           Objectives progress
         </Heading>
       )}
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
+      {accordion && stepType === "objectiveProgress" && (
+        <InstructionsAccordion verbiage={accordion} />
+      )}
       <ReportPeriod
         text={text}
         reportPeriod={reportPeriod}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add SMART goals instructions accordion to Objectives Progress page
![Screenshot 2024-02-09 at 4 25 35 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/10237149/750cca1e-571c-4c29-9aeb-7fb452e21935)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3280

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
go to the Objectives Page of the SAR and see that the Instructions Accordion matches the figma design


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
