### PR TITLE
[MFP] WP General Info heading missing - 508 remediation

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -16,13 +16,41 @@ export const ReportPageIntro = ({
 }: Props) => {
   const { section, subsection, hint, info } = text;
 
+  if (section && subsection) {
+    return (
+      <Box sx={sx.introBox} {...props}>
+        <Heading as="h1" sx={sx.smallHeading}>
+          {section}
+        </Heading>
+        <Heading as="h2" sx={sx.largeHeading}>
+          {initiativeName ? initiativeName : subsection}
+        </Heading>
+        {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
+        {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
+          <InstructionsAccordion verbiage={accordion} />
+        )}
+        {OverlayModalStepTypes.OBJECTIVE_PROGRESS && text.dashboardTitle && (
+          <Heading as="h3" sx={sx.subTitle}>
+            {text.dashboardTitle}
+          </Heading>
+        )}
+        {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
+        {accordion && OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
+          <InstructionsAccordion verbiage={accordion} />
+        )}
+        <ReportPeriod
+          text={text}
+          reportPeriod={reportPeriod}
+          reportYear={reportYear}
+        />
+      </Box>
+    );
+  }
+
   return (
     <Box sx={sx.introBox} {...props}>
-      <Heading as="h1" sx={sx.sectionHeading}>
-        {section}
-      </Heading>
-      <Heading as="h2" sx={sx.subsectionHeading}>
-        {initiativeName ? initiativeName : subsection}
+      <Heading as="h1" sx={sx.largeHeading}>
+        {subsection}
       </Heading>
       {hint && <Box sx={sx.hintTextBox}>{hint}</Box>}
       {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
@@ -59,11 +87,11 @@ const sx = {
   introBox: {
     marginBottom: "1rem",
   },
-  sectionHeading: {
+  smallHeading: {
     color: "palette.gray",
     fontSize: "md",
   },
-  subsectionHeading: {
+  largeHeading: {
     fontWeight: "normal",
     fontSize: "4xl",
     marginTop: "0.5rem",

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -16,7 +16,7 @@ export const ReportPageIntro = ({
 }: Props) => {
   const { section, subsection, hint, info } = text;
 
-  if (section && subsection) {
+  if (section && (subsection || initiativeName)) {
     return (
       <Box sx={sx.introBox} {...props}>
         <Heading as="h1" sx={sx.smallHeading}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3248

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Check headings on each page and confirm that there is an h1 heading on each page, and that the visual styling stayed the same

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
