### PR TITLE
Fix nested field validation

### DIFF
--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -197,7 +197,7 @@ export const nested = (
   return baseSchema.when(parentFieldName, {
     is: (value: Choice[]) =>
       // look for parentOptionId in checked choices
-      value?.find((option: Choice) => option.key === parentOptionId),
+      value?.find((option: Choice) => option.key.endsWith(parentOptionId)),
     then: () => fieldSchema(), // returns standard field schema (required)
     otherwise: () => baseSchema, // returns not-required Yup base schema
   });


### PR DESCRIPTION
### Description
In the field data, choice list option IDs start with the parent field ID, followed by the option ID. Therefore when we test to see if a choice is selected, we must match on the suffix of the option ID.

### Related ticket(s)
CMDCT-3277

---
### How to test
1. Create a WP with at least one applicable target population
2. Create a SAR based on that WP
3. Navigate to the RET disenrollment page
4. Confirm that patient counts disenrolled for "other" reasons must be numeric.

### Important updates
n/a

---
### Author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
