### PR TITLE
Add missing text to sar.json

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -171,7 +171,7 @@
       },
       "children": [
         {
-          "name": "Number of people who signed an MFP informed consent form in the ",
+          "name": "Number of people who signed an MFP informed consent form in the reporting period",
           "path": "/sar/recruitment-enrollment-transitions/number-of-people-signed-informed-consent-form",
           "pageType": "standard",
           "verbiage": {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The sar.json file was missing two words to complete the sidebar text.

As of now no WP or SAR reports are created in prod, so there is no need to run a script to update existing forms. Existing Dev and Val reports will continue to have this typo. We can decide with product and design if we want to update those or not (the quickest way I would suggest is deleting existing dev and val reports).

Before:
![image-2024-02-06-19-16-14-687](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/577c9dd2-fc7c-4e38-a42b-363bb4ee6dcd)

After:
![Screenshot 2024-02-21 at 9 30 28 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/97bc0648-871e-474e-b118-811eff509b7e)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3276

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
I recommend using the postman collection to save time
- Log in as a state user 
- Create and submit a WP
- Log in as an admin user and approve that WP
- Log in as a state user and create a SAR
- Verify the first nested sidebar text shows a complete sentence (doesn't end with "in the") and matches the second screenshot above

---
### Author checklist
<!-- Complete the following steps before opening for review -->
- [x] I have performed a self-review of my code
---