### PR TITLE
WP PDF - Copyover WP Incorrect Statusing

### DIFF
--- a/services/ui-src/src/components/tables/EntityStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/EntityStatusIcon.tsx
@@ -31,7 +31,7 @@ export const EntityStatusIcon = ({ entityStatus, isPdf }: Props) => {
         return {
           src: isPdf ? closedIcon : closedIcon,
           alt: isPdf ? "" : "close icon",
-          style: sx.successText,
+          style: sx.closeText,
           text: "Close",
         };
       case EntityStatuses.NO_STATUS:
@@ -87,6 +87,10 @@ const sx = {
   },
   successText: {
     color: "palette.success_darker",
+    fontSize: "0.667rem",
+  },
+  closeText: {
+    color: "palette.gray",
     fontSize: "0.667rem",
   },
   errorText: {

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -142,9 +142,9 @@ export const getInitiativeStatus = (
     /**
      * Currently, on exporting a PDF of the Work Plan does not take into consideration the Close-out initiatives entity step,
      * but the status is always returning "incomplete" because that step is used to calculate the initiative status.
-     * This removes the Close-out initiative step status from the PDF statusing calculation if this is not a copy-over.
+     * This removes the Close-out initiative step status from the PDF statusing calculation if it has not been closed out.
      */
-    if (isPdf && !entity.isCopied) {
+    if (isPdf && !entity.isInitiativeClosed && report.reportType === "WP") {
       stepStatuses.splice(-1);
     }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The PDF for WP copyover was showing false for the initiative statusing even when it was completed. The issue stems from the fact that the statusing code is tracking close out even when there was no close out selected. We did have tracking for that but it didn't take into account copyover. This branch fixes that conditional.

This should say "Complete": 
![Screenshot 2024-02-22 at 10 02 49 AM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/127151429/01c56a5c-86df-424b-8bd6-402c615c4fa7)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3304

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into MFP
2) Fill out WP & submit
3) Sign out and sign into admin
4) Approve the submitted WP
5) Sign out and sign back into user
6) Copyover WP
7) Fill out copy WP until everything is completed
8) Go to "Review & Submit" section and click "Review PDF"
9) Review the PDF to make sure the statuses are accurate.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
