### PR TITLE
Update PDF display logic for quarters

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
@@ -114,14 +114,17 @@ const tableComponent = (
 
 describe("ExportedModalDrawerReportSection table", () => {
   test("renders correct twelve quarters in table", async () => {
-    const mock2024Q1Report = {...mockReportStore, report: {
-      ...mockReportStore.report,
-      reportPeriod: 1,
-      reportYear: 2024,
-    }}
+    const mock2024Q1Report = {
+      ...mockReportStore,
+      report: {
+        ...mockReportStore.report,
+        reportPeriod: 1,
+        reportYear: 2024,
+      },
+    };
     mockedUseStore.mockReturnValue(mock2024Q1Report);
     render(tableComponent);
-    
+
     // should display 12 quarters starting from 2024 Q1
     expect(screen.getByText("2024 Q1")).toBeVisible();
     expect(screen.getByText("2024 Q2")).toBeVisible();

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { useStore } from "utils";
 import {
@@ -13,7 +13,6 @@ import {
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue(mockReportStore);
 
 const defaultMockProps = {
   section: {
@@ -107,8 +106,50 @@ const testComponent = (
   </RouterWrappedComponent>
 );
 
+const tableComponent = (
+  <RouterWrappedComponent>
+    <ExportedModalDrawerReportSection {...defaultMockProps} />
+  </RouterWrappedComponent>
+);
+
+describe("ExportedModalDrawerReportSection table", () => {
+  test("renders correct twelve quarters in table", async () => {
+    const mock2024Q1Report = {...mockReportStore, report: {
+      ...mockReportStore.report,
+      reportPeriod: 1,
+      reportYear: 2024,
+    }}
+    mockedUseStore.mockReturnValue(mock2024Q1Report);
+    render(tableComponent);
+    
+    // should display 12 quarters starting from 2024 Q1
+    expect(screen.getByText("2024 Q1")).toBeVisible();
+    expect(screen.getByText("2024 Q2")).toBeVisible();
+    expect(screen.getByText("2024 Q3")).toBeVisible();
+    expect(screen.getByText("2024 Q4")).toBeVisible();
+    expect(screen.getByText("2025 Q1")).toBeVisible();
+    expect(screen.getByText("2025 Q2")).toBeVisible();
+    expect(screen.getByText("2025 Q3")).toBeVisible();
+    expect(screen.getByText("2025 Q4")).toBeVisible();
+    expect(screen.getByText("2026 Q1")).toBeVisible();
+    expect(screen.getByText("2026 Q2")).toBeVisible();
+    expect(screen.getByText("2026 Q3")).toBeVisible();
+    expect(screen.getByText("2026 Q4")).toBeVisible();
+
+    // should not display quarters before or after those 12
+    expect(screen.queryByText("2023 Q3")).not.toBeInTheDocument();
+    expect(screen.queryByText("2023 Q4")).not.toBeInTheDocument();
+    expect(screen.queryByText("2027 Q1")).not.toBeInTheDocument();
+    expect(screen.queryByText("2027 Q2")).not.toBeInTheDocument();
+
+    // renders "Not answered" for each quarter given no entity data
+    expect(screen.queryAllByText("Not answered").length).toBe(12);
+  });
+});
+
 describe("ExportedModalDrawerReportSection", () => {
   test("should not have basic accessibility issues", async () => {
+    mockedUseStore.mockReturnValue(mockReportStore);
     const { container } = render(testComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -14,6 +14,7 @@ export const ExportedModalDrawerReportSection = ({
   const [overflow, setOverflow] = useState(false);
   const report = useStore().report;
   const entities = report?.fieldData?.[entityType];
+  const { reportPeriod, reportYear } = report!;
 
   // if Transition Benchmark Header title has an abbrev. just display that
   const getTableHeaders = () => {
@@ -45,7 +46,21 @@ export const ExportedModalDrawerReportSection = ({
   };
 
   const ariaLabelledAsterisk = `<span aria-label="sum of incomplete fields">*</span>`;
-  const quarterArraySeedData = Array(12).fill(notAnsweredText);
+
+  // applicable quarters for report; populates left table column
+  const generateQuarterLabels = () => {
+    // The first quarter will be Q1 for period 1, or Q3 for period 2.
+    const firstQuarterIndex = reportPeriod === 1 ? 0 : 2;
+
+    // returns array of labels like ["2024 Q1", "2024 Q2", ...]
+    return [...new Array(12)]
+      .map((_, index) => ({
+        year: reportYear + Math.floor((firstQuarterIndex + index) / 4),
+        quarter: `Q${1 + ((firstQuarterIndex + index) % 4)}`,
+      }))
+      .map(({ year, quarter }) => `${year} ${quarter}`);
+  };
+  const quarterLabels = generateQuarterLabels();
 
   // creates arrays of 'only' quarterly values
   const quarterValueArray = entities.map((entity: EntityShape) => {
@@ -53,30 +68,22 @@ export const ExportedModalDrawerReportSection = ({
       entity?.transitionBenchmarks_applicableToMfpDemonstration?.[0].value ===
       "No";
 
+    // if not applicable we populate the column with 12 "N/A" cells
+    if (isNotApplicableToMfp) {
+      return Array(12).fill("N/A");
+    }
+
     const quarterArray = Object.keys(entity)
       .filter((key) => key.includes("quarterly"))
-      .map((key) => (isNotApplicableToMfp ? "N/A" : entity[key]));
+      .map((key) => entity[key]);
 
-    return quarterArray.length === 0 ? [...quarterArraySeedData] : quarterArray;
+    // if length of filled in data is not 12, show "Not answered" in remaining cells
+    while (quarterArray.length < 12) {
+      quarterArray.push(notAnsweredText);
+    }
+
+    return quarterArray;
   });
-
-  // list of quarters to be added to the table (left column)
-  const extractQuarterLabels = () => {
-    const newEntities = new Array(...entities);
-    let quarterLabelArray: any = [];
-    newEntities.map((entity: EntityShape) => {
-      for (const key in entity) {
-        // push key values into quarterArray that are quarters
-
-        if (key.includes("quarterly")) {
-          const id = key.replace("quarterlyProjections", "").split("Q");
-          quarterLabelArray.push(`${id[0]} Q${id[1]}`);
-        }
-      }
-    });
-    return quarterLabelArray;
-  };
-  const quarterLabels = [...extractQuarterLabels()];
 
   const generateFootRow = () => {
     // creates an array that totals up each each quarter column

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -186,9 +186,7 @@ export const ExportedModalDrawerReportSection = ({
     };
 
     const updateFooterRow = overflow
-      ? generateFootRow().filter(
-          (arr: any) => generateFootRow().indexOf(arr) <= 6
-        )
+      ? generateFootRow().filter((item, index) => index <= 6)
       : generateFootRow();
 
     const table = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The PDF Transition Benchmarks table for copied reports was not showing the new quarters unless you filled some in. Once you did, it did not populate new cells in N/A columns.

This PR updates the table logic such that:
- Quarter labels are generated based on report year and period (instead of pulled from form data) to ensure we get 12 correct quarters
- Number of table cell values for a given column must be 12
  - N/A columns now populate with 12 immediately if the Target population is not applicable
  - Columns where the user has not yet filled in new quarters will populate remaining with "Not answered"

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3285

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create a WP
  - Select "Yes" on at least one target population
  - Try a mix of numbers and N/A values for fun!
- Submit and Approve the WP
- Create a new WP that copies from the first
- View the PDF of the second work plan and verify the target populations table:
  - shows twelve quarters
  - shows the correct quarters for this period and year (should start Q3 2024 and end Q2 2027)
  - shows all of the copied values
  - shows "not answered" for cells in Q1 and Q2 2027 belonging to columns where other values are provided
  - shows "N/A" for cells in Q1 and Q2 2027 belonging to columns where the Target pop is not applicable
  - row calculations and whatnot work


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---