### PR TITLE
Bufgix SAR PDF page error

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -164,6 +164,7 @@
         "intro": {
           "info": [
             {
+              "type": "p",
               "content": "In this section, please provide information for the specified period. Transition targets are populated from your state’s current MFP Work Plan, where applicable. Blue-shaded cells are auto-calculated."
             }
           ]

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -12,7 +12,6 @@ const mockHtmlString = "<span><em>whatever</em></span>";
 const testElementArray = [
   {
     type: "text",
-    as: "span",
     content: "Mock text ",
   },
   {
@@ -24,7 +23,6 @@ const testElementArray = [
   },
   {
     type: "text",
-    as: "span",
     content: ".",
   },
   {
@@ -40,6 +38,31 @@ const testElementArray = [
 const mockElementsWithChildren: CustomHtmlElement[] = [
   {
     type: "ul",
+    content: "",
+    props: {
+      "data-test-id": "foo",
+    },
+    children: [
+      {
+        type: "li",
+        content: "",
+        props: {
+          "data-test-id": "bar",
+        },
+        children: [
+          {
+            type: "span",
+            content: "Foo",
+            props: {
+              "data-test-id": "biz",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "ol",
     content: "",
     props: {
       "data-test-id": "foo",
@@ -102,9 +125,17 @@ describe("Test labelTextWithOptional", () => {
 });
 
 describe("Test createElementWithChildren", () => {
-  test("should correctly create nested elements", async () => {
+  test("should correctly create ul elements", async () => {
     const { container } = render(testComponentWithChildren);
     expect(await container.querySelector("ul")).toBeVisible();
+    expect(await container.querySelector('[data-test-id="foo"]')).toBeVisible();
+    expect(await container.querySelector('[data-test-id="bar"]')).toBeVisible();
+    expect(await container.querySelector('[data-test-id="biz"]')).toBeVisible();
+  });
+
+  test("should correctly create ol elements", async () => {
+    const { container } = render(testComponentWithChildren);
+    expect(await container.querySelector("ol")).toBeVisible();
     expect(await container.querySelector('[data-test-id="foo"]')).toBeVisible();
     expect(await container.querySelector('[data-test-id="bar"]')).toBeVisible();
     expect(await container.querySelector('[data-test-id="biz"]')).toBeVisible();

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -37,6 +37,58 @@ const testElementArray = [
   },
 ];
 
+const undefinedElement: any = [
+  {
+    type: "ul",
+    content: "",
+    props: {
+      "data-test-id": "foo",
+    },
+    children: [
+      {
+        type: "li",
+        content: "",
+        props: {
+          "data-test-id": "bar",
+        },
+        children: [
+          {
+            type: "span",
+            content: "Foo",
+            props: {
+              "data-test-id": "biz",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "ol",
+    content: "",
+    props: {
+      "data-test-id": "foo",
+    },
+    children: [
+      {
+        type: "li",
+        content: "",
+        props: {
+          "data-test-id": "bar",
+        },
+        children: [
+          {
+            content: "Undefined element",
+            props: {
+              "data-test-id": "biz",
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
 const mockElementsWithChildren: CustomHtmlElement[] = [
   {
     type: "ul",
@@ -95,6 +147,9 @@ const testComponent = <div>{parseCustomHtml(testElementArray)}</div>;
 const testComponentWithChildren = (
   <div>{parseCustomHtml(mockElementsWithChildren)}</div>
 );
+
+const undefinedTypeComponent = <div>{parseCustomHtml(undefinedElement)}</div>;
+
 describe("Test parseCustomHtml", () => {
   const sanitizationSpy = jest.spyOn(DOMPurify, "sanitize");
   beforeEach(() => {
@@ -113,6 +168,17 @@ describe("Test parseCustomHtml", () => {
 
   test("Type 'html' is sanitized and parsed", () => {
     expect(sanitizationSpy).toHaveBeenCalled();
+  });
+});
+
+describe("Handling undefined elementType", () => {
+  beforeEach(() => {
+    render(undefinedTypeComponent);
+  });
+
+  test("Should handle and convert undefined element type to text", () => {
+    const element = screen.getByText("Undefined element");
+    expect(element).toBeVisible();
   });
 });
 

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -12,6 +12,7 @@ const mockHtmlString = "<span><em>whatever</em></span>";
 const testElementArray = [
   {
     type: "text",
+    as: "span",
     content: "Mock text ",
   },
   {
@@ -23,6 +24,7 @@ const testElementArray = [
   },
   {
     type: "text",
+    as: "span",
     content: ".",
   },
   {
@@ -31,6 +33,13 @@ const testElementArray = [
   },
   {
     type: "html",
+    content: mockHtmlString,
+  },
+];
+
+const notAnElementType = [
+  {
+    type: "",
     content: mockHtmlString,
   },
 ];
@@ -89,6 +98,9 @@ const mockElementsWithChildren: CustomHtmlElement[] = [
 ];
 
 const testComponent = <div>{parseCustomHtml(testElementArray)}</div>;
+const testComponentNotAnElementType = (
+  <div>{parseCustomHtml(notAnElementType)}</div>
+);
 const testComponentWithChildren = (
   <div>{parseCustomHtml(mockElementsWithChildren)}</div>
 );
@@ -110,6 +122,16 @@ describe("Test parseCustomHtml", () => {
 
   test("Type 'html' is sanitized and parsed", () => {
     expect(sanitizationSpy).toHaveBeenCalled();
+  });
+});
+
+describe("Not part of element type array", () => {
+  const sanitizationSpy = jest.spyOn(DOMPurify, "sanitize");
+  beforeEach(() => {
+    render(testComponentNotAnElementType);
+  });
+  test("Not an element type", () => {
+    expect(sanitizationSpy).toHaveErrorMessage;
   });
 });
 

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -37,13 +37,6 @@ const testElementArray = [
   },
 ];
 
-const notAnElementType = [
-  {
-    type: "",
-    content: mockHtmlString,
-  },
-];
-
 const mockElementsWithChildren: CustomHtmlElement[] = [
   {
     type: "ul",
@@ -98,9 +91,7 @@ const mockElementsWithChildren: CustomHtmlElement[] = [
 ];
 
 const testComponent = <div>{parseCustomHtml(testElementArray)}</div>;
-const testComponentNotAnElementType = (
-  <div>{parseCustomHtml(notAnElementType)}</div>
-);
+
 const testComponentWithChildren = (
   <div>{parseCustomHtml(mockElementsWithChildren)}</div>
 );
@@ -122,16 +113,6 @@ describe("Test parseCustomHtml", () => {
 
   test("Type 'html' is sanitized and parsed", () => {
     expect(sanitizationSpy).toHaveBeenCalled();
-  });
-});
-
-describe("Not part of element type array", () => {
-  const sanitizationSpy = jest.spyOn(DOMPurify, "sanitize");
-  beforeEach(() => {
-    render(testComponentNotAnElementType);
-  });
-  test("Not an element type", () => {
-    expect(sanitizationSpy).toHaveErrorMessage;
   });
 });
 

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -60,16 +60,18 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         ...props,
       };
 
-      if (type === "html") {
+      if (type === "ul" || type === "ol") {
+        return createElementWithChildren(element);
+      }
+
+      if (elementType) {
         // sanitize and parse html
         content = sanitizeAndParseHtml(content);
         // delete 'as' prop since React.Fragment can't accept it
         delete elementProps.as;
         return React.createElement(elementType, elementProps, content);
       }
-      if (type === "ul" || type === "ol") {
-        return createElementWithChildren(element);
-      }
+
       return;
     });
   }

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -60,11 +60,7 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         ...props,
       };
 
-      if (type === "ul" || type === "ol") {
-        return createElementWithChildren(element);
-      }
-
-      if (elementType) {
+      if (type === "html") {
         // sanitize and parse html
         content = sanitizeAndParseHtml(content);
         // delete 'as' prop since React.Fragment can't accept it
@@ -72,7 +68,7 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         return React.createElement(elementType, elementProps, content);
       }
 
-      return;
+      return createElementWithChildren(element);
     });
   }
 };
@@ -101,6 +97,15 @@ export function createElementWithChildren(
     );
   }
   const santizedContent = sanitizeAndParseHtml(content);
+
+  if (elementType === undefined) {
+    return React.createElement(
+      customElementMap["text"],
+      elementProps,
+      santizedContent
+    );
+  }
+
   return React.createElement(elementType, elementProps, santizedContent);
 }
 

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, FC } from "react";
 import { sanitize } from "dompurify";
 import parse from "html-react-parser";
 // components
@@ -59,6 +59,7 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         as,
         ...props,
       };
+
       if (type === "html") {
         // sanitize and parse html
         content = sanitizeAndParseHtml(content);
@@ -66,7 +67,10 @@ export const parseCustomHtml = (element: CustomHtmlElement[] | string) => {
         delete elementProps.as;
         return React.createElement(elementType, elementProps, content);
       }
-      return createElementWithChildren(element);
+      if (type === "ul" || type === "ol") {
+        return createElementWithChildren(element);
+      }
+      return;
     });
   }
 };
@@ -81,7 +85,7 @@ export function createElementWithChildren(
   element: CustomHtmlElement
 ): ReactElement {
   const { type, content, as, props } = element;
-  const elementType: string = customElementMap[type] || type;
+  const elementType: string | FC = customElementMap[type] || type;
   const elementProps = {
     key: type + uuid(),
     as,

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -1,4 +1,4 @@
-import React, { ReactElement, FC } from "react";
+import React, { ReactElement } from "react";
 import { sanitize } from "dompurify";
 import parse from "html-react-parser";
 // components
@@ -85,7 +85,7 @@ export function createElementWithChildren(
   element: CustomHtmlElement
 ): ReactElement {
   const { type, content, as, props } = element;
-  const elementType: string | FC = customElementMap[type] || type;
+  const elementType: string = customElementMap[type] || type;
   const elementProps = {
     key: type + uuid(),
     as,

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -22,7 +22,7 @@ import {
 import { CustomHtmlElement } from "types";
 import uuid from "react-uuid";
 
-const customElementMap: any = {
+export const customElementMap: any = {
   externalLink: Link,
   internalLink: RouterLink,
   text: Text,


### PR DESCRIPTION
### Description
Fix for SAR Pdf error showing up due to 'createElementWithChildren' not being called. Added a conditional to call createElementWithChildren' when an element has children (ordered or unordered list). 

Error:
![screenshot_2024-02-20_at_3 35 24___pm](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/fcccab7c-9895-451a-99c5-b7b178bf3326)

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
