### PR TITLE
CMDCT-3202.II: Follow-Up Text Color Fix

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -880,7 +880,7 @@
                       "hint": [
                         {
                           "type": "html",
-                          "content": "Select all that apply. “Other” population(s) selected and defined in the"
+                          "content": "Select all that apply. “Other” population(s) selected and defined in the "
                         },
                         {
                           "type": "internalLink",
@@ -891,7 +891,7 @@
                         },
                         {
                           "type": "html",
-                          "content": "section automatically upload. Select “HCBS infrastructure/system-level development” for initiatives that strengthen or expand home and community-based services (HCBS)."
+                          "content": " section automatically upload. Select “HCBS infrastructure/system-level development” for initiatives that strengthen or expand home and community-based services (HCBS)."
                         }
                       ],
                       "choices": []

--- a/services/ui-src/src/components/export/ExportedRETTable.tsx
+++ b/services/ui-src/src/components/export/ExportedRETTable.tsx
@@ -357,7 +357,7 @@ export const ExportRETTable = ({ section }: Props) => {
           );
         })
       ) : (
-        <Text>
+        <Text sx={sx.retAlert}>
           Your associated MFP Work Plan does not contain any target populations.
         </Text>
       )}
@@ -421,5 +421,9 @@ const sx = {
       background: "palette.secondary_lightest",
       fontWeight: "bold",
     },
+  },
+  // RE&T warning message
+  retAlert: {
+    color: "palette.error_dark",
   },
 };

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -261,7 +261,7 @@ const sx = {
   },
   // RE&T warning message
   retAlert: {
-    color: "palette.error",
+    color: "palette.error_dark",
     paddingTop: "1rem",
   },
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Changing the text color for this error message to `error_dark` and updating the PDF to reflect that.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3202

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Same instructions as: 
https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/468

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
