### PR TITLE
CMDCT-3303 - Add Cypress tests for homepage, profile, and dashboard

### DIFF
--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -1,6 +1,15 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  experimentalStudio: true,
+  redirectionLimit: 20,
+  retries: 1,
+  watchForFileChanges: true,
+  fixturesFolder: "fixtures",
+  screenshotsFolder: "screenshots",
+  videosFolder: "videos",
+  downloadsFolder: "downloads",
+  types: ["cypress", "cypress-axe"],
   video: true,
   env: {
     STATE_USER_EMAIL: "cypressstateuser@test.com",
@@ -8,6 +17,7 @@ module.exports = defineConfig({
   },
   e2e: {
     baseUrl: "http://127.0.0.1:3000/",
+    testIsolation: false,
     setupNodeEvents(on, _config) {
       on("task", {
         log(message) {

--- a/tests/cypress/e2e/footer.cy.js
+++ b/tests/cypress/e2e/footer.cy.js
@@ -1,0 +1,28 @@
+// element selectors
+const helpLinkText = "Contact Us";
+const accessibilityStatementLinkText = "Accessibility Statement";
+
+beforeEach(() => {
+  cy.authenticate("stateUser");
+});
+
+afterEach(() => {
+  cy.navigateToHomePage();
+});
+
+describe("Footer integration tests", () => {
+  it("Footer help link navigates to /help", () => {
+    cy.contains(helpLinkText).click();
+    cy.location("pathname").should("match", /help/);
+  });
+
+  it("Footer accessibility statement link navigates to the right external URL", () => {
+    cy.get(
+      'a[href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/CMSNondiscriminationNotice"]'
+    ).contains(accessibilityStatementLinkText);
+
+    cy.contains(accessibilityStatementLinkText).then((link) => {
+      cy.request(link.prop("href")).its("status").should("eq", 200);
+    });
+  });
+});

--- a/tests/cypress/e2e/home.cy.js
+++ b/tests/cypress/e2e/home.cy.js
@@ -1,0 +1,18 @@
+// element selectors
+const templateCardAccordionVerbiage = "When is the MFP Work Plan due?";
+const templateCardAccordionContent = "The MFP Work Plan will be created";
+
+beforeEach(() => {
+  cy.authenticate("stateUser");
+});
+
+afterEach(() => {
+  cy.navigateToHomePage();
+});
+
+describe("Homepage integration tests", () => {
+  it("Clicking accordion expander opens accordion", () => {
+    cy.contains(templateCardAccordionVerbiage).first().click();
+    cy.contains(templateCardAccordionContent).should("be.visible");
+  });
+});

--- a/tests/cypress/e2e/profile.cy.js
+++ b/tests/cypress/e2e/profile.cy.js
@@ -1,0 +1,30 @@
+// element selectors
+const menuButton = '[aria-label="my account"';
+const menuOptionManageAccount =
+  '[data-testid="header-menu-option-manage-account"]';
+const adminButton = 'button:contains("Banner Editor")';
+
+describe("Profile integration tests", () => {
+  it("Allows admin user to navigate to /admin", () => {
+    cy.authenticate("adminUser");
+
+    cy.get(menuButton).click();
+    cy.get(menuOptionManageAccount).click();
+    cy.location("pathname").should("match", /profile/);
+
+    cy.get(adminButton).click();
+    cy.location("pathname").should("match", /admin/);
+  });
+
+  it("Disallows state user to navigate to /admin (redirects to /profile)", () => {
+    cy.authenticate("stateUser");
+
+    cy.get(menuButton).click();
+    cy.get(menuOptionManageAccount).click();
+    cy.location("pathname").should("match", /profile/);
+    cy.get(adminButton).should("not.exist");
+
+    cy.visit("/admin");
+    cy.location("pathname").should("match", /profile/);
+  });
+});

--- a/tests/cypress/e2e/wp/dashboard.cy.js
+++ b/tests/cypress/e2e/wp/dashboard.cy.js
@@ -1,0 +1,50 @@
+describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
+  describe("MFP Work Plan Dashboard Page - State User Report Creation", () => {
+    it("State users can create Work Plans", () => {
+      cy.authenticate("stateUser");
+
+      //Given I've logged in
+      cy.url().should("include", "/");
+
+      //And I enter the Work Plan Dashboard
+      cy.contains("Enter Work Plan online").click();
+      cy.url().should("include", "/wp");
+
+      //When I click the create Work Plan Button and create a WP
+      cy.contains("Start MFP Work Plan").click();
+      cy.contains("Start new").click();
+
+      //Then there is a new Workplan with the title
+      cy.contains("MFP Work Plan", { matchCase: true }).should("be.visible");
+    });
+  });
+
+  describe("MFP Work Plan Dashboard Page - Admin Archiving", () => {
+    it("Admin users can archive/unarchive Work Plans", () => {
+      cy.authenticate("adminUser");
+
+      //Given I've logged in
+      cy.url().should("include", "/");
+
+      //When an admin selects the state and report type to look at
+      cy.fillOutForm([
+        ["state", "dropdown", "District of Columbia"],
+        ["report", "radio", "MFP Work Plan (WP)"],
+      ]);
+      cy.contains("Go to Report Dashboard").click();
+      cy.url().should("include", "/wp");
+
+      //Then there is a new Workplan with the title
+      cy.contains("District of Columbia MFP Work Plan", {
+        matchCase: true,
+      }).should("be.visible");
+
+      //And when the admin clicks archive/unarchive it should do that to the report
+      cy.contains("Archive").click();
+      cy.contains("Unarchive").should("be.visible");
+
+      cy.contains("Unarchive").click();
+      cy.contains("Archive").should("be.visible");
+    });
+  });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -32,6 +32,56 @@ const adminUser = {
   password: adminUserPassword,
 };
 
+Cypress.Commands.add("navigateToHomePage", () => {
+  if (cy.location("pathname") !== "/") cy.visit("/");
+});
+
+Cypress.Commands.add("fillOutForm", (formInputs) => {
+  formInputs.forEach((row) => {
+    /*
+     * Repeated inputs have the same name, so it comes back as an array. Thus we need to grab
+     * which input in the array we need. Otherwise we can just query the name of the input
+     */
+    const repeatedInput = row?.[3];
+    const input = repeatedInput
+      ? cy.get(`input[name^="${row[0]}"]`)
+      : cy.get(`[name='${row[0]}']`);
+    const inputType = row[1];
+    const inputValue = row[2];
+    switch (inputType) {
+      case "singleCheckbox":
+        if (inputValue == "true") {
+          input.check();
+          input.blur();
+        } else input.uncheck();
+        break;
+      case "radio":
+        input.check(inputValue);
+        input.blur();
+        break;
+      case "checkbox":
+        input.check(inputValue);
+        input.blur();
+        break;
+      case "dropdown":
+        input.select(inputValue);
+        input.blur();
+        break;
+      case "repeated":
+        input.eq(repeatedInput);
+        input.clear();
+        input.type(inputValue);
+        input.blur();
+        break;
+      default:
+        input.clear();
+        input.type(inputValue);
+        input.blur();
+        break;
+    }
+  });
+});
+
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
   cy.session([userType, userCredentials], () => {
     cy.visit("/");


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Adds cypress tests for the homepage, profile and dashboard

The password is pin to the top of the devs channel, if you are missing it.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3303

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Navigate to tests/cypress
- Run `CYPRESS_ADMIN_USER_PASSWORD='insertpasswordhere!' CYPRESS_STATE_USER_PASSWORD='Insertpasswordhere!' yarn test`
- Click e2e configuration
- Run the new tests! 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Cypress config was updated.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary