### PR TITLE
Always display default target populations in initiatives

### DIFF
--- a/services/app-api/utils/data/data.test.ts
+++ b/services/app-api/utils/data/data.test.ts
@@ -2,6 +2,18 @@ import { removeNotApplicablePopsFromInitiatives } from "./data";
 
 const targetPopulationNotApplicable = {
   id: "123",
+  transitionBenchmarks_targetPopulationName: "Not applicable",
+  isRequired: true,
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "123-abc",
+      value: "No",
+    },
+  ],
+};
+
+const targetPopulationDefaultNotApplicable = {
+  id: "123",
   transitionBenchmarks_targetPopulationName: "Older adults",
   isRequired: true,
   transitionBenchmarks_applicableToMfpDemonstration: [
@@ -14,7 +26,7 @@ const targetPopulationNotApplicable = {
 
 const targetPopulationApplicable = {
   id: "123",
-  transitionBenchmarks_targetPopulationName: "Older adults",
+  transitionBenchmarks_targetPopulationName: "Applicable",
   isRequired: true,
   transitionBenchmarks_applicableToMfpDemonstration: [
     {
@@ -88,7 +100,10 @@ describe("Test removeNotApplicablePopsFromInitiatives", () => {
 
   it("should remove a target population from an initiative if that population does not apply", async () => {
     const fieldData = {
-      targetPopulations: [targetPopulationNotApplicable],
+      targetPopulations: [
+        targetPopulationNotApplicable,
+        targetPopulationDefaultNotApplicable,
+      ],
       initiative: [
         {
           ...initiative,
@@ -101,11 +116,17 @@ describe("Test removeNotApplicablePopsFromInitiatives", () => {
     };
 
     const expectedOutput = {
-      targetPopulations: [targetPopulationNotApplicable],
+      targetPopulations: [
+        targetPopulationNotApplicable,
+        targetPopulationDefaultNotApplicable,
+      ],
       initiative: [
         {
           ...initiative,
-          defineInitiative_targetPopulations: [initiativePD],
+          defineInitiative_targetPopulations: [
+            initiativeOlderAdults,
+            initiativePD,
+          ],
         },
       ],
     };
@@ -116,7 +137,10 @@ describe("Test removeNotApplicablePopsFromInitiatives", () => {
 
   it("should NOT remove a target population from an initiative if that population applies", async () => {
     const fieldData = {
-      targetPopulations: [targetPopulationApplicable],
+      targetPopulations: [
+        targetPopulationDefaultNotApplicable,
+        targetPopulationApplicable,
+      ],
       initiative: [
         {
           ...initiative,
@@ -129,7 +153,10 @@ describe("Test removeNotApplicablePopsFromInitiatives", () => {
     };
 
     const expectedOutput = {
-      targetPopulations: [targetPopulationApplicable],
+      targetPopulations: [
+        targetPopulationDefaultNotApplicable,
+        targetPopulationApplicable,
+      ],
       initiative: [
         {
           ...initiative,

--- a/services/app-api/utils/data/data.ts
+++ b/services/app-api/utils/data/data.ts
@@ -38,6 +38,14 @@ export const removeNotApplicablePopsFromInitiatives = (
     .filter(isNotApplicable)
     .map(getPopulationName);
 
+  const defaultTargetPopulationNames = [
+    "Older adults",
+    "Individuals with physical disabilities (PD)",
+    "Individuals with intellectual and developmental disabilities (I/DD)",
+    "Individuals with mental health and substance use disorders (MH/SUD)",
+    "HCBS infrastructure/system-level development",
+  ];
+
   if (notApplicablePopulationNames.length === 0) return fieldData;
 
   /*
@@ -49,7 +57,8 @@ export const removeNotApplicablePopsFromInitiatives = (
     initiative.defineInitiative_targetPopulations =
       initiative.defineInitiative_targetPopulations?.filter(
         (initiativePopulation: AnyObject) =>
-          !notApplicablePopulationNames.includes(initiativePopulation.value)
+          !notApplicablePopulationNames.includes(initiativePopulation.value) ||
+          defaultTargetPopulationNames.includes(initiativePopulation.value)
       );
   }
 

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -23,6 +23,8 @@ import {
   mockTargetPopReqButApplicable,
   mockTargetPopReqButApplicableIsUndefined,
   mockTargetPopReqButNotApplicable,
+  mockTargetPopDefaultAndApplicable,
+  mockTargetPopDefaultButNotApplicable,
 } from "utils/testing/setupJest";
 import { AnyObject } from "yup/lib/types";
 
@@ -64,18 +66,22 @@ describe("form utilities", () => {
       mockTargetPopButOtherApplicable,
       mockTargetPopButOtherNotApplicable,
       mockTargetPopByOtherNotDefined,
+      mockTargetPopDefaultButNotApplicable,
+      mockTargetPopDefaultAndApplicable,
     ];
 
     it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration", async () => {
       const filteredPopulations = removeNotApplicablePopulations(
         exampleTargetPopulations
       );
-      expect(filteredPopulations.length).toBe(4);
+      expect(filteredPopulations.length).toBe(6);
       expect(filteredPopulations).toEqual([
         mockTargetPopReqButApplicable,
         mockTargetPopReqButApplicableIsUndefined,
         mockTargetPopButOtherApplicable,
         mockTargetPopByOtherNotDefined,
+        mockTargetPopDefaultButNotApplicable,
+        mockTargetPopDefaultAndApplicable,
       ]);
     });
   });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -328,7 +328,7 @@ export const updateRenderFields = (
 ) => {
   const targetPopulations = report?.fieldData?.targetPopulations;
 
-  const notApplicableOption = {
+  const hcbsPopulation = {
     id: "3Nc13O5GHA6Hc4KheO5FMSD2",
     transitionBenchmarks_targetPopulationName:
       "HCBS infrastructure/system-level development",
@@ -339,7 +339,8 @@ export const updateRenderFields = (
   const filteredTargetPopulations =
     removeNotApplicablePopulations(targetPopulations);
 
-  filteredTargetPopulations?.push(notApplicableOption);
+  // This one always has to be at the end for...reasons
+  filteredTargetPopulations?.push(hcbsPopulation);
 
   const formatChoiceList = convertTargetPopulationsFromWPToSAREntity(
     filteredTargetPopulations
@@ -392,7 +393,8 @@ export const injectFormWithTargetPopulations = (
 
 /**
  * This function takes the target populations given from the form data and then filters out
- * any population that a user has answered "No". It does this by looking for a child object
+ * any population that a user has answered "No" UNLESS that population
+ * is included in the default population list. It does this by looking for a child object
  * called transitionBenchmarks_applicableToMfpDemonstration and seeing if it has a value of "No"
  * @param {AnyObject[]} targetPopulations - targetPopulations that are in the formData
  * @return {AnyObject[]} Target populations filtered to no long has No answers from
@@ -401,10 +403,21 @@ export const injectFormWithTargetPopulations = (
 export const removeNotApplicablePopulations = (
   targetPopulations: AnyObject[]
 ) => {
+  const defaultPopulationNames = [
+    "Older adults",
+    "Individuals with physical disabilities (PD)",
+    "Individuals with intellectual and developmental disabilities (I/DD)",
+    "Individuals with mental health and substance use disorders (MH/SUD)",
+  ];
+
   const filteredPopulations = targetPopulations?.filter((population) => {
+    const isDefault = defaultPopulationNames.includes(
+      population.transitionBenchmarks_targetPopulationName
+    );
+
     const isApplicable =
       population?.transitionBenchmarks_applicableToMfpDemonstration?.[0]?.value;
-    return isApplicable !== "No";
+    return isDefault || isApplicable !== "No";
   });
   return filteredPopulations;
 };

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -128,3 +128,29 @@ export const mockTargetPopByOtherNotDefined = {
   type: "targetPopulations",
   transitionBenchmarks_targetPopulationName: "Other-Undefined",
 };
+
+export const mockTargetPopDefaultButNotApplicable = {
+  id: "7",
+  transitionBenchmarks_targetPopulationName: "Older adults",
+  isRequired: true,
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "a",
+      value: "No",
+    },
+  ],
+  quarterlyProjections2023Q3: "",
+};
+
+export const mockTargetPopDefaultAndApplicable = {
+  id: "7",
+  transitionBenchmarks_targetPopulationName: "Older adults",
+  isRequired: true,
+  transitionBenchmarks_applicableToMfpDemonstration: [
+    {
+      key: "a",
+      value: "Yes",
+    },
+  ],
+  quarterlyProjections2023Q3: "",
+};


### PR DESCRIPTION
### Description
When creating a work plan, the user should always see default target populations in the Define Initiatives view, regardless of whether they are applicable to the MFP as defined in the Transition Benchmarks view. 

### Related ticket(s)
CMDCT-3228

---
### How to test

There are ~4~ 5 user flows. For the first 4 user flows, the steps are the same:

1. Log in as a state user
2. Create a work plan
3. On the Transition Benchmarks section, either create or edit existing target populations according to the details for each flow.
4. On the State or Territory Specific Initiatives section, create a new initiative.
5. Click the Edit button, and on the next screen, in the Define Initiative row, click the Edit button.
6. The expected view for target populations are detailed in each flow below.

#### 1. No user defined populations, none of the default populations are applicable
- Skip the Transition Benchmarks section (or make sure only the default populations are present and they are all marked "No")
- Expected list of population checkboxes in the Define Initiatives view:
    - Older adults
    - Individuals with physical disabilities (PD)
    - Individuals with intellectual and developmental disabilities (I/DD)
    - Individuals with mental health and substance use disorders (MH/SUD)
    - HCBS infrastructure/system-level development

#### 2. No user defined populations, at least one default population is applicable
- In the Transition Benchmarks section, check "Yes" for at least one of the default populations. Do not create any custom populations.
- Expected list of population checkboxes in the Define Initiatives view:
    - Older adults
    - Individuals with physical disabilities (PD)
    - Individuals with intellectual and developmental disabilities (I/DD)
    - Individuals with mental health and substance use disorders (MH/SUD)
    - HCBS infrastructure/system-level development

#### 3. At least one user defined population, marked applicable
- In the Transition Benchmarks section, create a custom population. Check "Yes" for the custom population.
- Expected list of population checkboxes in the Define Initiatives view:
    - Older adults
    - Individuals with physical disabilities (PD)
    - Individuals with intellectual and developmental disabilities (I/DD)
    - Individuals with mental health and substance use disorders (MH/SUD)
    - Other: _whatever you named the applicable initiative_
    - HCBS infrastructure/system-level development

#### 4. At least one user defined population, marked NOT applicable
- In the Transition Benchmarks section, create another custom population. Check "No" for the custom population.
- Expected list of population checkboxes in the Define Initiatives view:
    - Older adults
    - Individuals with physical disabilities (PD)
    - Individuals with intellectual and developmental disabilities (I/DD)
    - Individuals with mental health and substance use disorders (MH/SUD)
    - Other: _whatever you named the applicable initiative_
    - HCBS infrastructure/system-level development
**Note:** you should not see the _not applicable_ custom initiative

#### 5. Create a new SAR
TBD! I am checking how this is supposed to work.

### Important updates
I had to change the data file in the API to get the checkbox selections to save in the Define Initiative view. Would love extra 👀  on that.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
