### PR TITLE
Console Error Table Layout Fix

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -131,7 +131,7 @@ const sx = {
     "@media print": {
       pageBreakInside: "avoid",
     },
-    "table-layout": "fixed",
+    tableLayout: "fixed",
     marginBottom: "1rem",
     "tr, th": {
       verticalAlign: "top",

--- a/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportMetadataTable.tsx
@@ -101,7 +101,7 @@ const sx = {
   metadataTable: {
     margin: "3rem 0",
     maxWidth: "reportPageWidth",
-    "table-layout": "fixed",
+    tableLayout: "fixed",
     td: {
       verticalAlign: "middle",
       textAlign: "left",

--- a/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedSarDetailsTable.tsx
@@ -46,7 +46,7 @@ const sx = {
   sarDetailsTable: {
     margin: "3rem 0",
     maxWidth: "reportPageWidth",
-    "table-layout": "fixed",
+    tableLayout: "fixed",
     td: {
       verticalAlign: "middle",
       textAlign: "left",

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -179,7 +179,7 @@ export const sx = {
     fontSize: "4xl",
   },
   combinedDataTable: {
-    "table-layout": "fixed",
+    tableLayout: "fixed",
     ".combined-data-title": {
       display: "inline-block",
       marginBottom: "0.5rem",


### PR DESCRIPTION
`Using kebab-case for css properties in objects is not supported. Did you mean tableLayout? `

Updated css selector `"table-layout"` -> tableLayout to get rid of console warning. I also verified that the tables haven't been altered from the update. 



### Related ticket(s)
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3364

---
### How to test
1. Go to WP and SAR PDF's and verify no styling changes to the table layouts


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
