### PR TITLE
Remove date-fns and date-fns-tz from app-api

### DIFF
--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -33,8 +33,6 @@
   "dependencies": {
     "aws-jwt-verify": "^3.1.0",
     "aws-sdk": "^2.1525.0",
-    "date-fns": "^2.26.0",
-    "date-fns-tz": "^1.2.2",
     "dompurify": "^2.4.0",
     "jsdom": "^20.0.0",
     "jwt-decode": "^3.1.2",

--- a/services/app-api/tsconfig.json
+++ b/services/app-api/tsconfig.json
@@ -10,8 +10,6 @@
     "outDir": ".build",
     "rootDir": "./",
     "resolveJsonModule": true,
-    // This module resolution strategy avoids issues with the types of date-fns-tz
-    "moduleResolution": "node",
     "lib": ["ES2022"],
     "module": "node16",
     "target": "ES2022"

--- a/services/app-api/utils/time/time.test.ts
+++ b/services/app-api/utils/time/time.test.ts
@@ -1,5 +1,26 @@
 import { ReportType } from "../types";
-import { calculateDueDate, calculatePeriod, isLeapYear } from "./time";
+import {
+  calculateDueDate,
+  calculatePeriod,
+  convertDateUtcToEt,
+  isLeapYear,
+} from "./time";
+
+describe("Test convertDateUtcToEt", () => {
+  it("Converts to Eastern Time correctly just before midnight", () => {
+    // 2024-12-31 11:59:59pm in New York
+    const date = 1735707599000;
+
+    expect(convertDateUtcToEt(date)).toBe("12/31/2024");
+  });
+
+  it("Converts to Eastern Time correctly just after midnight", () => {
+    // 2025-01-01 12:00:01am in New York
+    const date = 1735707601000;
+
+    expect(convertDateUtcToEt(date)).toBe("01/01/2025");
+  });
+});
 
 describe("Test calculatePeriod", () => {
   it("calculatePeriod given due date of 01/01/2022", () => {

--- a/services/app-api/utils/time/time.ts
+++ b/services/app-api/utils/time/time.ts
@@ -1,23 +1,16 @@
-import { utcToZonedTime } from "date-fns-tz";
 import { ReportMetadataShape, ReportType } from "../types";
 
-/*
- * Converts passed UTC datetime to ET date
- * returns -> ET date in format mm/dd/yyyy
+/**
+ * @param date A UTC timestamp, as from `Date.now()`
+ * @returns A MM/dd/yyyy string, for that date on the US East Coast.
  */
-export const convertDateUtcToEt = (date: number): string => {
-  const convertedDate = date;
-  const easternDatetime = utcToZonedTime(
-    new Date(convertedDate),
-    "America/New_York"
-  );
-
-  const month = twoDigitCalendarDate(new Date(easternDatetime).getMonth() + 1);
-  const day = twoDigitCalendarDate(new Date(easternDatetime).getDate());
-  const year = new Date(easternDatetime).getFullYear();
-
-  // month + 1 because Date object months are zero-indexed
-  return `${month}/${day}/${year}`;
+export const convertDateUtcToEt = (date: number) => {
+  return Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(date));
 };
 
 /*
@@ -48,16 +41,12 @@ export const isLeapYear = (year: number) => {
 /**
  * This method returns a date in ISO format to a date in mm/dd/yyyy format.
  * @param date The given date in ISO format
- * @returns a date in mm/dd/yyyy format
+ * @returns a date in MM/dd/yyyy format
  */
 export const convertToFormattedDate = (date: Date) => {
-  let year = date.getFullYear();
-
-  let month = (1 + date.getMonth()).toString();
-  month = month.length > 1 ? month : "0" + month;
-
-  let day = date.getDate().toString();
-  day = day.length > 1 ? day : "0" + day;
+  const year = date.getFullYear();
+  const month = (1 + date.getMonth()).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
 
   return `${month}/${day}/${year}`;
 };
@@ -93,14 +82,6 @@ export const calculateDueDate = (
     }
   }
   return convertToFormattedDate(date);
-};
-
-/*
- * This code ensures the date has a preceeding 0 if the month/day is a single digit.
- * Ex: 7 becomes 07 while 10 stays 10
- */
-export const twoDigitCalendarDate = (date: number) => {
-  return ("0" + date).slice(-2);
 };
 
 export const calculateCurrentQuarter = () => {

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -314,13 +314,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.21.0":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
-  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -1286,18 +1279,6 @@ data-urls@^3.0.2:
     abab "^2.0.6"
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
-
-date-fns-tz@^1.2.2:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.8.tgz#083e3a4e1f19b7857fa0c18deea6c2bc46ded7b9"
-  integrity sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==
-
-date-fns@^2.26.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
 
 debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
@@ -2877,11 +2858,6 @@ regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### Description
We can skip a package import (and all of the resulting Snyk/dependabot noise) by invoking the built-in `Intl.DateTimeFormat` functions. This function has been fully supported in NodeJS since 13.0.

This upgrade should be safe because we are only changing the API - therefore we are not relying on browser versions or users' machine configurations. If the unit tests pass in Github's runner, and reports are created with the correct date format in this branch's ephemeral environment, we will know we are regression-free.

### Related ticket(s)
n/a

---
### How to test
* Log in to this branch's cloudfront environment as a state user
* Create a Work Plan
* Examine the payload in the network tab when you fetch this work plan. The top-level `reportYear` property should be 2024.
* For bonus points, fill out & submit that Work Plan, then examine the fieldData in the DB or in the network tab. The top-level `reportSubmissionDate` property should be properly formatted with MM/dd/yyyy.

### Important updates


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
