### PR TITLE
#3377 Review & Submit page console errors

### DIFF
--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
@@ -81,6 +81,17 @@ describe("MFP WP Review and Submit Page Functionality", () => {
       const { adminInfo } = review;
       expect(screen.getByText(adminInfo.submitLink.text)).toBeEnabled();
     });
+
+    test("should not show console errors", () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        user: mockAdminUserStore,
+      });
+      render(ReviewSubmitPage(WPReviewVerbiage));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -132,6 +143,20 @@ describe("MFP SAR Review and Submit Page Functionality", () => {
       const { review } = SARReviewVerbiage;
       const { adminInfo } = review;
       expect(screen.getByText(adminInfo.unlockLink.text)).toBeEnabled();
+    });
+
+    test("should not show console errors", () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        report: {
+          reportType: "SAR",
+        },
+        user: mockAdminUserStore,
+      });
+      render(ReviewSubmitPage(SARReviewVerbiage));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.tsx
@@ -10,6 +10,8 @@ import {
   Input,
   ModalFooter,
   Link,
+  UnorderedList,
+  ListItem,
 } from "@chakra-ui/react";
 import { Modal } from "components";
 // utils
@@ -79,7 +81,13 @@ export const AdminReview = ({
       <Box sx={sx.adminLeadTextBox}>
         <Box sx={sx.infoTextBox}>
           <Text sx={sx.infoHeading}>{adminInfo.header}</Text>
-          <Text>{parseCustomHtml(adminInfo.info)}</Text>
+          {adminInfo.list && (
+            <UnorderedList sx={sx.list}>
+              {adminInfo.list.map((item: any, index: number) => (
+                <ListItem key={index}>{parseCustomHtml(item.content)}</ListItem>
+              ))}
+            </UnorderedList>
+          )}
         </Box>
       </Box>
       <Flex sx={sx.adminSubmitContainer}>
@@ -211,6 +219,13 @@ const sx = {
   infoHeading: {
     fontWeight: "bold",
     marginBottom: ".5rem",
+  },
+  list: {
+    paddingLeft: "1rem",
+    margin: "1.5rem",
+    li: {
+      marginBottom: "0.5rem",
+    },
   },
   adminApprove: {
     display: "flex",

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -193,6 +193,19 @@ describe("Review and Submit Page Functionality", () => {
       expect(unfilledPageImg).toBe(null);
     });
   });
+
+  describe("Console errors", () => {
+    test("should not show console errors", () => {
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+      mockedUseStore.mockReturnValue({
+        ...mockUseStore,
+        report: mockFilledReport,
+      });
+      render(WpReviewSubmitPage);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("When loading a sucessfully submitted report (Success Message Generator)", () => {

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -158,9 +158,11 @@ const ReadyToSubmit = ({
           {intro.header}
         </Heading>
         <Box sx={sx.infoTextBox}>
-          {intro.info.map((item: AnyObject) => (
-            <React.Fragment key={item.sectionHeader}>
-              <Text sx={sx.infoHeading}>{item.sectionHeader}</Text>
+          {intro.info.map((item: any, index: number) => (
+            <React.Fragment key={index}>
+              {item.sectionHeader && (
+                <Text sx={sx.infoHeading}>{item.sectionHeader}</Text>
+              )}
               <Text sx={sx.infoParagraph}>{item.content}</Text>
             </React.Fragment>
           ))}

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -1,4 +1,9 @@
-import { MouseEventHandler, useContext, useEffect, useState } from "react";
+import React, {
+  MouseEventHandler,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { AdminReview } from "./AdminReview";
 // components
 import {
@@ -153,8 +158,12 @@ const ReadyToSubmit = ({
           {intro.header}
         </Heading>
         <Box sx={sx.infoTextBox}>
-          <Text sx={sx.infoHeading}>{intro.infoHeader}</Text>
-          <Text>{parseCustomHtml(intro.info)}</Text>
+          {intro.info.map((item: AnyObject) => (
+            <React.Fragment key={item.sectionHeader}>
+              <Text sx={sx.infoHeading}>{item.sectionHeader}</Text>
+              <Text sx={sx.infoParagraph}>{item.content}</Text>
+            </React.Fragment>
+          ))}
         </Box>
 
         <Box>
@@ -326,6 +335,9 @@ const sx = {
   infoHeading: {
     fontWeight: "bold",
     marginBottom: ".5rem",
+  },
+  infoParagraph: {
+    marginBottom: "1rem",
   },
   headerImage: {
     display: "inline-block",

--- a/services/ui-src/src/verbiage/pages/sar/sar-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-review-and-submit.ts
@@ -10,16 +10,16 @@ export default {
       infoHeader: "Ready to Submit?",
       info: [
         {
+          sectionHeader: "Ready to Submit?",
           type: "text",
-          as: "span",
           content:
             "Double check that everything in your MFP SAR submission is accurate. You will be able to make edits after submitting if you contact your CMS MFP Project Officer to unlock your report while it is in “Submitted” status.",
         },
         {
+          sectionHeader: "Compliance review",
           type: "text",
-          as: "div",
           content:
-            "<br><b>Compliance review</b><br>Your Project Officer will review your report and may contact you and unlock your report for editing if there are corrections to be made.",
+            "Your Project Officer will review your report and may contact you and unlock your report for editing if there are corrections to be made.",
         },
       ],
     },
@@ -39,12 +39,10 @@ export default {
     },
     adminInfo: {
       header: "Admin Review",
-      info: [
+      list: [
         {
-          type: "text",
-          as: "div",
           content:
-            "<ul><li>To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state contact and inform them. The status will change to “In revision”.</li><br/></ul>",
+            "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state contact and inform them. The status will change to “In revision”.",
         },
       ],
       modal: {

--- a/services/ui-src/src/verbiage/pages/wp/wp-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-review-and-submit.ts
@@ -10,16 +10,16 @@ export default {
       infoHeader: "Ready to Submit?",
       info: [
         {
+          sectionHeader: "Ready to Submit?",
           type: "text",
-          as: "span",
           content:
             "Double check that everything in your MFP Work Plan submission is accurate. You will only be able to make edits after submitting if you contact your CMS MFP Project Officer to unlock your report while it is still in “Submitted” status. ",
         },
         {
+          sectionHeader: "Compliance review",
           type: "text",
-          as: "div",
           content:
-            "<br><b>Compliance review</b><br>Your Project Officer will review your report and may contact you and unlock your report for editing if there are corrections to be made. If there are no corrections to be made, your Project Officer will approve the report by {x time before it’s due}, its status will change to “Approved” and it will no longer be editable because its information will be used in the MFP Semi-Annual Progress Report (SAR) for the same reporting period.",
+            "Your Project Officer will review your report and may contact you and unlock your report for editing if there are corrections to be made. If there are no corrections to be made, your Project Officer will approve the report by {x time before it’s due}, its status will change to “Approved” and it will no longer be editable because its information will be used in the MFP Semi-Annual Progress Report (SAR) for the same reporting period.",
         },
       ],
     },

--- a/services/ui-src/src/verbiage/pages/wp/wp-review-and-submit.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-review-and-submit.ts
@@ -25,12 +25,14 @@ export default {
     },
     adminInfo: {
       header: "Admin Review",
-      info: [
+      list: [
         {
-          type: "text",
-          as: "div",
           content:
-            "<ul><li>To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state or territory contact and inform them. The status will change to “In revision”.</li><br/><li>To approve a submission, review the submission and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the MFP SAR. <strong>You will not be able to unapprove or unlock it.</strong></li></ul>",
+            "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission, then email the state or territory contact and inform them. The status will change to “In revision”.",
+        },
+        {
+          content:
+            "To approve a submission, review the submission and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the MFP SAR. <strong>You will not be able to unapprove or unlock it.</strong>",
         },
       ],
       modal: {


### PR DESCRIPTION
### Description
Refactoring verbiage for Review & Submit content so we don't get console errors about improperly nested content.

This PR changes the structure of the verbiage, so we can utilize existing Chakra components and make rendering intentions more clear, instead of relying on parsing HTML strings. I am hoping this is more developer-friendly as well.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3377

---
### How to test
1. Log in as a state user and create a new work plan or edit an existing one. 
2. Navigate to the Review & Submit section.
3. Check the console and make sure there are no errors about:
    - nested `<div>` inside of `<p>` tags. _(Note: there may be other console errors that are unrelated to this specific issue)_

4. Log in as an admin user and view the WP Review & Submit section.
5. Check the console and make sure there are no errors about:
    - nested `<div>` inside of `<p>` tags.
    - nested `<ul>` inside of `<p>` tags.
6. Follow the same steps to verify for the SAR (both state user and admin, same errors)

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
