### PR TITLE
Fix on TR Console Error

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -1,5 +1,5 @@
 // components
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Heading, Text, Td } from "@chakra-ui/react";
 import { Fragment } from "react";
 import uuid from "react-uuid";
 // components
@@ -31,7 +31,7 @@ export const ExportedEntityDetailsOverlaySection = ({
   const { report } = useStore() ?? {};
 
   return (
-    <Box sx={sx.sectionHeading} {...props}>
+    <Td sx={sx.sectionHeading} {...props}>
       {report &&
         renderEntityDetailTables(
           report,
@@ -41,7 +41,7 @@ export const ExportedEntityDetailsOverlaySection = ({
           closed,
           props.tableSection
         )}
-    </Box>
+    </Td>
   );
 };
 

--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -1,5 +1,5 @@
 // components
-import { Box, Heading, Text, Td } from "@chakra-ui/react";
+import { Box, Heading, Text } from "@chakra-ui/react";
 import { Fragment } from "react";
 import uuid from "react-uuid";
 // components
@@ -31,7 +31,7 @@ export const ExportedEntityDetailsOverlaySection = ({
   const { report } = useStore() ?? {};
 
   return (
-    <Td sx={sx.sectionHeading} {...props}>
+    <Box as="td" sx={sx.sectionHeading} {...props}>
       {report &&
         renderEntityDetailTables(
           report,
@@ -41,7 +41,7 @@ export const ExportedEntityDetailsOverlaySection = ({
           closed,
           props.tableSection
         )}
-    </Td>
+    </Box>
   );
 };
 

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -7,7 +7,7 @@ import {
   Alert,
   ExportedOverlayModalReportSection,
 } from "components";
-import { Box, Heading, Image, Td, Text, Tr } from "@chakra-ui/react";
+import { Heading, Image, Td, Text, Tr } from "@chakra-ui/react";
 // types
 import {
   AlertTypes,
@@ -46,7 +46,7 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
       ? getWPAlertStatus(report, entityType)
       : false;
   return (
-    <Box>
+    <>
       {showAlert && (
         <Alert
           title={(alertVerbiage as AlertVerbiage)[entityType].title}
@@ -54,7 +54,12 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
           description={(alertVerbiage as AlertVerbiage)[entityType].description}
         />
       )}
-      <Table sx={sx.root} content={{}} data-testid="exportTable">
+      <Table
+        sx={sx.root}
+        sxOverride={{ container: { ...sx.container } }}
+        content={{}}
+        data-testid="exportTable"
+      >
         {report?.fieldData[entityType] &&
           renderModalOverlayTableBody(
             section,
@@ -66,7 +71,7 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
         report?.fieldData[entityType].length === 0) && (
         <Text sx={sx.emptyState}> No entities found.</Text>
       )}
-    </Box>
+    </>
   );
 };
 
@@ -137,8 +142,8 @@ export function renderModalOverlayTableBody(
     case ReportType.WP:
       return entities.map((entity, idx) => {
         return (
-          <Box sx={sx.container} key={`${reportType}${idx}`}>
-            <Tr>
+          <>
+            <Tr key={`${reportType}${idx}`}>
               <Td sx={sx.statusIcon}>
                 <EntityStatusIcon
                   entity={entity}
@@ -162,34 +167,34 @@ export function renderModalOverlayTableBody(
               switch (type) {
                 case EntityDetailsStepTypes.DEFINE_INITIATIVE:
                   return (
-                    <Box key={`${type}${idx}${stepIdx}`}>
+                    <Tr key={`${type}${idx}${stepIdx}`}>
                       <ExportedEntityDetailsOverlaySection
                         section={section as ModalOverlayReportPageShape}
                         entity={entity}
                         entityStep={step}
                         showHintText={true}
                       />
-                    </Box>
+                    </Tr>
                   );
                 case OverlayModalStepTypes.EVALUATION_PLAN:
                   return (
-                    <Box key={`${type}${idx}${stepIdx}`}>
+                    <Tr key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
                         entityStep={step}
                       />
-                    </Box>
+                    </Tr>
                   );
                 case OverlayModalStepTypes.FUNDING_SOURCES:
                   return (
-                    <Box key={`${type}${idx}${stepIdx}`}>
+                    <Tr key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
                         entityStep={step}
                       />
-                    </Box>
+                    </Tr>
                   );
                 case EntityDetailsStepTypes.CLOSE_OUT_INFORMATION:
                   //clean up title
@@ -197,7 +202,7 @@ export function renderModalOverlayTableBody(
 
                   return (
                     entity?.isInitiativeClosed && (
-                      <Box key={`${type}${idx}${stepIdx}`}>
+                      <Tr key={`${type}${idx}${stepIdx}`}>
                         <ExportedEntityDetailsOverlaySection
                           section={section as ModalOverlayReportPageShape}
                           entity={entity}
@@ -205,21 +210,21 @@ export function renderModalOverlayTableBody(
                           showHintText={false}
                           closed={true}
                         />
-                      </Box>
+                      </Tr>
                     )
                   );
                 default:
                   return <></>;
               }
             })}
-          </Box>
+          </>
         );
       });
     case ReportType.SAR:
       return entities.map((entity, idx) => {
         return (
-          <Box sx={sx.container} key={`${reportType}${idx}`}>
-            <Tr>
+          <>
+            <Tr key={`${reportType}${idx}`}>
               <Td sx={sx.statusIcon}>
                 <EntityStatusIcon
                   entity={entity}
@@ -242,24 +247,24 @@ export function renderModalOverlayTableBody(
                 switch (step.stepType) {
                   case OverlayModalStepTypes.OBJECTIVE_PROGRESS:
                     return (
-                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
+                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
                         <ExportedOverlayModalReportSection
                           section={dynamicSection[idx] as OverlayModalPageShape}
                           entity={entity}
                           entityStep={step}
                         />
-                      </Box>
+                      </Tr>
                     );
                   case EntityDetailsStepTypes.INITIAVTIVE_PROGRESS:
                     return (
-                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
-                        <ExportedEntityDetailsOverlaySection
+                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
+                        {/* <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
                           entityStep={step}
                           showHintText={true}
-                        />
-                      </Box>
+                        /> */}
+                      </Tr>
                     );
                   case EntityDetailsStepTypes.EXPENDITURES: {
                     const cloneSection = structuredClone(step);
@@ -273,14 +278,14 @@ export function renderModalOverlayTableBody(
                       tableSection.form.fields.pop();
 
                     return (
-                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
-                        <ExportedEntityDetailsOverlaySection
+                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
+                        {/* <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
                           entityStep={cloneSection}
                           tableSection={tableSection}
-                        />
-                      </Box>
+                        /> */}
+                      </Tr>
                     );
                   }
                   default:
@@ -288,7 +293,7 @@ export function renderModalOverlayTableBody(
                 }
               }
             )}
-          </Box>
+          </>
         );
       });
     default:
@@ -374,5 +379,7 @@ const sx = {
   },
   container: {
     paddingTop: "2rem",
+    display: "flex",
+    flexDirection: "column",
   },
 };

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -7,7 +7,7 @@ import {
   Alert,
   ExportedOverlayModalReportSection,
 } from "components";
-import { Heading, Image, Td, Text, Tr } from "@chakra-ui/react";
+import { Box, Heading, Image, Td, Text, Tr } from "@chakra-ui/react";
 // types
 import {
   AlertTypes,
@@ -55,8 +55,8 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
         />
       )}
       <Table
-        sx={sx.root}
         sxOverride={{ container: { ...sx.container } }}
+        sx={sx.root}
         content={{}}
         data-testid="exportTable"
       >
@@ -167,34 +167,34 @@ export function renderModalOverlayTableBody(
               switch (type) {
                 case EntityDetailsStepTypes.DEFINE_INITIATIVE:
                   return (
-                    <Tr key={`${type}${idx}${stepIdx}`}>
+                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
                       <ExportedEntityDetailsOverlaySection
                         section={section as ModalOverlayReportPageShape}
                         entity={entity}
                         entityStep={step}
                         showHintText={true}
                       />
-                    </Tr>
+                    </Box>
                   );
                 case OverlayModalStepTypes.EVALUATION_PLAN:
                   return (
-                    <Tr key={`${type}${idx}${stepIdx}`}>
+                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
                         entityStep={step}
                       />
-                    </Tr>
+                    </Box>
                   );
                 case OverlayModalStepTypes.FUNDING_SOURCES:
                   return (
-                    <Tr key={`${type}${idx}${stepIdx}`}>
+                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
                         entityStep={step}
                       />
-                    </Tr>
+                    </Box>
                   );
                 case EntityDetailsStepTypes.CLOSE_OUT_INFORMATION:
                   //clean up title
@@ -202,7 +202,7 @@ export function renderModalOverlayTableBody(
 
                   return (
                     entity?.isInitiativeClosed && (
-                      <Tr key={`${type}${idx}${stepIdx}`}>
+                      <Box as="tr" key={`${type}${idx}${stepIdx}`}>
                         <ExportedEntityDetailsOverlaySection
                           section={section as ModalOverlayReportPageShape}
                           entity={entity}
@@ -210,7 +210,7 @@ export function renderModalOverlayTableBody(
                           showHintText={false}
                           closed={true}
                         />
-                      </Tr>
+                      </Box>
                     )
                   );
                 default:
@@ -247,24 +247,24 @@ export function renderModalOverlayTableBody(
                 switch (step.stepType) {
                   case OverlayModalStepTypes.OBJECTIVE_PROGRESS:
                     return (
-                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
+                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
                         <ExportedOverlayModalReportSection
                           section={dynamicSection[idx] as OverlayModalPageShape}
                           entity={entity}
                           entityStep={step}
                         />
-                      </Tr>
+                      </Box>
                     );
                   case EntityDetailsStepTypes.INITIAVTIVE_PROGRESS:
                     return (
-                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
-                        {/* <ExportedEntityDetailsOverlaySection
+                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
+                        <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
                           entityStep={step}
                           showHintText={true}
-                        /> */}
-                      </Tr>
+                        />
+                      </Box>
                     );
                   case EntityDetailsStepTypes.EXPENDITURES: {
                     const cloneSection = structuredClone(step);
@@ -278,14 +278,14 @@ export function renderModalOverlayTableBody(
                       tableSection.form.fields.pop();
 
                     return (
-                      <Tr key={`${step.stepType}${idx}${stepIdx}`}>
-                        {/* <ExportedEntityDetailsOverlaySection
+                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
+                        <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
                           entityStep={cloneSection}
                           tableSection={tableSection}
-                        /> */}
-                      </Tr>
+                        />
+                      </Box>
                     );
                   }
                   default:

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
@@ -1,5 +1,5 @@
 // components
-import { Box, Heading, Text, Td } from "@chakra-ui/react";
+import { Box, Heading, Text } from "@chakra-ui/react";
 // utils
 import { getFormattedEntityData } from "utils";
 import {
@@ -32,7 +32,12 @@ export const ExportedOverlayModalReportSection = ({
     }
   );
   return (
-    <Td mt="2rem" data-testid="exportedOverlayModalPage" sx={sx.container}>
+    <Box
+      as="td"
+      mt="2rem"
+      data-testid="exportedOverlayModalPage"
+      sx={sx.container}
+    >
       <Heading as="h4">
         <Box sx={sx.stepName}>{title}</Box>
         <Box sx={sx.stepHint}>{info || hint}</Box>
@@ -63,7 +68,7 @@ export const ExportedOverlayModalReportSection = ({
           />
         );
       })}
-    </Td>
+    </Box>
   );
 };
 

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
@@ -1,5 +1,5 @@
 // components
-import { Box, Heading, Text } from "@chakra-ui/react";
+import { Box, Heading, Text, Td } from "@chakra-ui/react";
 // utils
 import { getFormattedEntityData } from "utils";
 import {
@@ -32,7 +32,7 @@ export const ExportedOverlayModalReportSection = ({
     }
   );
   return (
-    <Box mt="2rem" data-testid="exportedOverlayModalPage" sx={sx.container}>
+    <Td mt="2rem" data-testid="exportedOverlayModalPage" sx={sx.container}>
       <Heading as="h4">
         <Box sx={sx.stepName}>{title}</Box>
         <Box sx={sx.stepHint}>{info || hint}</Box>
@@ -63,7 +63,7 @@ export const ExportedOverlayModalReportSection = ({
           />
         );
       })}
-    </Box>
+    </Td>
   );
 };
 

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -27,7 +27,12 @@ export const Table = ({
   ...props
 }: Props) => {
   return (
-    <TableRoot variant={variant} size="sm" sx={{ ...sx.root }} {...props}>
+    <TableRoot
+      variant={variant}
+      size="sm"
+      sx={{ ...sx.root, ...sxOverride }}
+      {...props}
+    >
       <TableCaption placement="top" sx={sx.captionBox}>
         <VisuallyHidden>{content.caption}</VisuallyHidden>
       </TableCaption>
@@ -39,7 +44,7 @@ export const Table = ({
               <Th
                 key={index}
                 scope="col"
-                sx={{ ...sx.tableHeader }}
+                sx={{ ...sx.tableHeader, ...sxOverride }}
                 aria-label={ariaOverride?.headRow?.[index]}
               >
                 {sanitizeAndParseHtml(headerCell)}
@@ -81,7 +86,7 @@ export const Table = ({
                     <Th
                       key={rowIndex}
                       scope="col"
-                      sx={{ ...sx.tableHeader }}
+                      sx={{ ...sx.tableHeader, ...sxOverride }}
                       aria-label={ariaOverride?.footRow?.[index][rowIndex]}
                     >
                       {sanitizeAndParseHtml(headerCell)}

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -27,12 +27,7 @@ export const Table = ({
   ...props
 }: Props) => {
   return (
-    <TableRoot
-      variant={variant}
-      size="sm"
-      sx={{ ...sx.root, ...sxOverride }}
-      {...props}
-    >
+    <TableRoot variant={variant} size="sm" sx={{ ...sx.root }} {...props}>
       <TableCaption placement="top" sx={sx.captionBox}>
         <VisuallyHidden>{content.caption}</VisuallyHidden>
       </TableCaption>
@@ -44,7 +39,7 @@ export const Table = ({
               <Th
                 key={index}
                 scope="col"
-                sx={{ ...sx.tableHeader, ...sxOverride }}
+                sx={{ ...sx.tableHeader }}
                 aria-label={ariaOverride?.headRow?.[index]}
               >
                 {sanitizeAndParseHtml(headerCell)}
@@ -53,7 +48,7 @@ export const Table = ({
           </Tr>
         </Thead>
       )}
-      <Tbody>
+      <Tbody sx={sxOverride?.container}>
         {/* if children prop is passed, just render the children */}
         {children && children}
         {/* if content prop is passed, parse and render rows and cells */}
@@ -86,7 +81,7 @@ export const Table = ({
                     <Th
                       key={rowIndex}
                       scope="col"
-                      sx={{ ...sx.tableHeader, ...sxOverride }}
+                      sx={{ ...sx.tableHeader }}
                       aria-label={ariaOverride?.footRow?.[index][rowIndex]}
                     >
                       {sanitizeAndParseHtml(headerCell)}


### PR DESCRIPTION
### Description
The following error was displaying due to divs wrapping `tr` tags inside some of the PDF tables. 
`<tr> cannot appear as a child of <div> `

I removed the div's and updated the `tr` tags so the styling wouldn't change. Direct child `div` tags inside `tr` tags were converted to `td` tags.


Note: I think initially adding the div as a wrapper was to be able to wrap a whole entity section with this `key={`${reportType}${idx}`}` .  I removed the div and placed the key on the `tr` which only wraps the heading of the section. I think since the key is on each section header it should be enough (if its just an identifier ). I'm open to any thoughts on this.

### Related ticket(s)
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3369

---
### How to test
1. Fill out both WP and SAR reports then check the tables in the PDF against the mockup. Styling shouldn't have changed.
2. Check the console while the WP and SAR PDFs are open and this error shouldnt exist. `<tr> cannot appear as a child of <div> ` 


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
