### PR TITLE
[MFP]  Add Copy Over Subtext to WP Dashboard

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -300,6 +300,7 @@ export const createReport = handler(
         ),
         reportYear,
         reportPeriod,
+        isCopied: overrideCopyOver ? true : false,
         dueDate: calculateDueDate(reportYear, reportPeriod, reportType),
         associatedWorkPlan: workPlanMetadata?.id,
       },

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -132,11 +132,10 @@ describe("Test Report Dashboard view (Desktop)", () => {
 
   test("Show copied from verbiage on report versions 2 or higher", () => {
     mockedUseStore.mockReturnValue(mockUseStore);
-    const { container } = render(dashboardViewWithReports);
+    render(dashboardViewWithReports);
     const subText = screen.getByText(
       "copied from {undefined - Period undefined}"
     );
-    screen.debug(container);
     expect(subText).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -132,10 +132,11 @@ describe("Test Report Dashboard view (Desktop)", () => {
 
   test("Show copied from verbiage on report versions 2 or higher", () => {
     mockedUseStore.mockReturnValue(mockUseStore);
-    render(dashboardViewWithReports);
+    const { container } = render(dashboardViewWithReports);
     const subText = screen.getByText(
       "copied from {undefined - Period undefined}"
     );
+    screen.debug(container);
     expect(subText).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -133,9 +133,7 @@ describe("Test Report Dashboard view (Desktop)", () => {
   test("Show copied from verbiage on report versions 2 or higher", () => {
     mockedUseStore.mockReturnValue(mockUseStore);
     render(dashboardViewWithReports);
-    const subText = screen.getByText(
-      "copied from {undefined - Period undefined}"
-    );
+    const subText = screen.getByText("copied from {2023 - Period 1}");
     expect(subText).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -133,7 +133,7 @@ describe("Test Report Dashboard view (Desktop)", () => {
   test("Show copied from verbiage on report versions 2 or higher", () => {
     mockedUseStore.mockReturnValue(mockUseStore);
     render(dashboardViewWithReports);
-    const subText = screen.getByText("copied from {2023 - Period 1}");
+    const subText = screen.getByText("copied from 2023 - Period 1");
     expect(subText).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -18,6 +18,7 @@ import {
   mockUseStore,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
+
 import { useBreakpoint, useStore, makeMediaQueryClasses } from "utils";
 import { useUser } from "utils/auth/useUser";
 import { ReportType } from "types";
@@ -127,6 +128,15 @@ describe("Test Report Dashboard view (Desktop)", () => {
       wpVerbiage.body.callToActionAdditions
     );
     expect(callToActionButton).toBeDisabled();
+  });
+
+  test("Show copied from verbiage on report versions 2 or higher", () => {
+    mockedUseStore.mockReturnValue(mockUseStore);
+    render(dashboardViewWithReports);
+    const subText = screen.getByText(
+      "copied from {undefined - Period undefined}"
+    );
+    expect(subText).toBeInTheDocument();
   });
 
   test("Check that you can enter a WP", async () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -164,7 +164,6 @@ export const DashboardPage = ({ reportType }: Props) => {
     setEditable(isReportEditable(selectedReport));
     navigate(firstReportPagePath);
   };
-
   const openAddEditReportModal = (report?: ReportShape) => {
     let formData = undefined;
     //
@@ -241,7 +240,6 @@ export const DashboardPage = ({ reportType }: Props) => {
       confirmUnlockModalOnOpenHandler();
     }
   };
-
   const isAddSubmissionDisabled = (): boolean => {
     switch (reportType) {
       case ReportType.SAR:
@@ -272,7 +270,6 @@ export const DashboardPage = ({ reportType }: Props) => {
   } = useDisclosure();
 
   const fullStateName = States[activeState as keyof typeof States];
-
   return (
     <PageTemplate type="report" sx={sx.layout}>
       <Link as={RouterLink} to="/" sx={sx.returnLink}>

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -125,8 +125,7 @@ export const copyOverSubText = (
   report: ReportMetadataShape,
   reportsByState: ReportMetadataShape[]
 ) =>
-  report.versionNumber &&
-  report?.versionNumber > 1 && (
+  report.isCopied && (
     <Text sx={sx.copyOverText}>{`copied from {${
       reportsByState[reportsByState.indexOf(report) + 1]?.reportYear
     } - Period ${

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -126,11 +126,11 @@ export const copyOverSubText = (
   reportsByState: ReportMetadataShape[]
 ) =>
   report.isCopied && (
-    <Text sx={sx.copyOverText}>{`copied from {${
+    <Text sx={sx.copyOverText}>{`copied from ${
       reportsByState[reportsByState.indexOf(report) + 1]?.reportYear
     } - Period ${
       reportsByState[reportsByState.indexOf(report) + 1]?.reportPeriod
-    }}`}</Text>
+    }`}</Text>
   );
 
 interface DashboardTableProps {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -121,7 +121,7 @@ export const DashboardTable = ({
   </Table>
 );
 
-const copyOverSubText = (
+export const copyOverSubText = (
   report: ReportMetadataShape,
   reportsByState: ReportMetadataShape[]
 ) =>

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -1,5 +1,5 @@
 // components
-import { Button, Image, Td, Tr, Spinner } from "@chakra-ui/react";
+import { Button, Image, Td, Tr, Spinner, Text } from "@chakra-ui/react";
 import { Table } from "components";
 // utils
 import {
@@ -41,7 +41,12 @@ export const DashboardTable = ({
         )}
         {/* Report Name */}
         {reportType === ReportType.WP ? (
-          <Td sx={sxOverride.wpSubmissionNameText}>{report.submissionName}</Td>
+          <>
+            <Td sx={sxOverride.wpSubmissionNameText}>
+              {report.submissionName}
+              {copyOverSubText(report, reportsByState)}
+            </Td>
+          </>
         ) : (
           <Td sx={sxOverride.sarSubmissionNameText}>{report.submissionName}</Td>
         )}
@@ -115,6 +120,19 @@ export const DashboardTable = ({
     ))}
   </Table>
 );
+
+const copyOverSubText = (
+  report: ReportMetadataShape,
+  reportsByState: ReportMetadataShape[]
+) =>
+  report.versionNumber &&
+  report?.versionNumber > 1 && (
+    <Text sx={sx.copyOverText}>{`copied from {${
+      reportsByState[reportsByState.indexOf(report) + 1]?.reportYear
+    } - Period ${
+      reportsByState[reportsByState.indexOf(report) + 1]?.reportPeriod
+    }}`}</Text>
+  );
 
 interface DashboardTableProps {
   reportsByState: ReportMetadataShape[];
@@ -302,5 +320,10 @@ const sx = {
         minWidth: "2rem",
       },
     },
+  },
+  copyOverText: {
+    fontSize: "xs",
+    fontWeight: "300",
+    color: "palette.gray_medium",
   },
 };

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -5,7 +5,7 @@ import { AnyObject, ReportMetadataShape, ReportType } from "types";
 import { convertDateUtcToEt, prettifyChoices } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
-import { getStatus } from "./DashboardTable";
+import { getStatus, copyOverSubText } from "./DashboardTable";
 
 export const MobileDashboardTable = ({
   reportsByState,
@@ -41,6 +41,7 @@ export const MobileDashboardTable = ({
             )}
             <Text sx={sxOverride.submissionNameText}>
               {report.submissionName}
+              {copyOverSubText(report, reportsByState)}
             </Text>
           </Flex>
         </Box>

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -33,6 +33,7 @@ export interface ReportMetadataShape extends ReportKeys {
   // Any additional questions that are asked when creating a report are appended here
   finalSar?: Choice[];
   populations?: Choice[];
+  versionNumber?: number;
 }
 
 export interface ReportShape extends ReportMetadataShape {

--- a/services/ui-src/src/types/reportContext.ts
+++ b/services/ui-src/src/types/reportContext.ts
@@ -34,6 +34,7 @@ export interface ReportMetadataShape extends ReportKeys {
   finalSar?: Choice[];
   populations?: Choice[];
   versionNumber?: number;
+  isCopied?: boolean;
 }
 
 export interface ReportShape extends ReportMetadataShape {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -261,6 +261,7 @@ export const mockWPFullReport = {
   reportPeriod: 1,
   locked: false,
   reportYear: 2023,
+  versionNumber: 2,
 };
 
 export const mockSARFullReport = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -261,7 +261,62 @@ export const mockWPFullReport = {
   reportPeriod: 1,
   locked: false,
   reportYear: 2023,
-  versionNumber: 2,
+  versionNumber: 1,
+};
+
+export const mockWPCopiedReport = {
+  ...mockReportKeys,
+  reportType: "WP",
+  formTemplate: mockReportJson,
+  submissionName: "2023 - Alabama 1",
+  status: ReportStatus.NOT_STARTED,
+  dueDate: 168515200000,
+  createdAt: 162515200000,
+  lastAltered: 162515200000,
+  lastAlteredBy: "Thelonious States",
+  submittedOnDate: Date.now(),
+  fieldData: mockReportFieldData,
+  completionStatus: {
+    "/mock/mock-route-1": true,
+    "/mock/mock-route-2": {
+      "/mock/mock-route-2a": false,
+      "/mock/mock-route-2b": true,
+      "/mock/mock-route-2c": true,
+    },
+  },
+  isComplete: false,
+  reportPeriod: 1,
+  locked: false,
+  reportYear: 2023,
+  versionNumber: 1,
+  isCopied: true,
+};
+
+export const mockWPNotStartedReport = {
+  ...mockReportKeys,
+  reportType: "WP",
+  formTemplate: mockReportJson,
+  submissionName: "2023 - Alabama 1",
+  status: ReportStatus.NOT_STARTED,
+  dueDate: 168515200000,
+  createdAt: 162515200000,
+  lastAltered: 162515200000,
+  lastAlteredBy: "Thelonious States",
+  submittedOnDate: Date.now(),
+  fieldData: mockReportFieldData,
+  completionStatus: {
+    "/mock/mock-route-1": true,
+    "/mock/mock-route-2": {
+      "/mock/mock-route-2a": false,
+      "/mock/mock-route-2b": true,
+      "/mock/mock-route-2c": true,
+    },
+  },
+  isComplete: false,
+  reportPeriod: 1,
+  locked: false,
+  reportYear: 2023,
+  versionNumber: 1,
 };
 
 export const mockSARFullReport = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -292,33 +292,6 @@ export const mockWPCopiedReport = {
   isCopied: true,
 };
 
-export const mockWPNotStartedReport = {
-  ...mockReportKeys,
-  reportType: "WP",
-  formTemplate: mockReportJson,
-  submissionName: "2023 - Alabama 1",
-  status: ReportStatus.NOT_STARTED,
-  dueDate: 168515200000,
-  createdAt: 162515200000,
-  lastAltered: 162515200000,
-  lastAlteredBy: "Thelonious States",
-  submittedOnDate: Date.now(),
-  fieldData: mockReportFieldData,
-  completionStatus: {
-    "/mock/mock-route-1": true,
-    "/mock/mock-route-2": {
-      "/mock/mock-route-2a": false,
-      "/mock/mock-route-2b": true,
-      "/mock/mock-route-2c": true,
-    },
-  },
-  isComplete: false,
-  reportPeriod: 1,
-  locked: false,
-  reportYear: 2023,
-  versionNumber: 1,
-};
-
 export const mockSARFullReport = {
   ...mockReportKeys,
   reportType: "SAR",

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -187,9 +187,9 @@ export const mockBannerStore: AdminBannerState = {
 export const mockReportStore: MfpReportState = {
   report: mockWPFullReport as ReportShape,
   reportsByState: [
-    mockWPCopiedReport,
     mockWPFullReport,
     mockWPSubmittedReport,
+    mockWPCopiedReport,
     mockWPApprovedFullReport,
   ],
   submittedReportsByState: [mockWPFullReport],

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -20,6 +20,7 @@ import {
   mockWPApprovedFullReport,
   mockWPSubmittedReport,
   mockWPFullReport,
+  mockWPCopiedReport,
   mockSARFullReport,
   mockEvaluationPlan,
   mockObjectiveProgress,
@@ -186,6 +187,7 @@ export const mockBannerStore: AdminBannerState = {
 export const mockReportStore: MfpReportState = {
   report: mockWPFullReport as ReportShape,
   reportsByState: [
+    mockWPCopiedReport,
     mockWPFullReport,
     mockWPSubmittedReport,
     mockWPApprovedFullReport,


### PR DESCRIPTION
### Description

When an WP report is approved and user selects "continue MFP Work Plan for next period", the new copied report will display this sub text dynamically displays "copied from { reportYear - reportPeriod }".

<img width="825" alt="Screenshot 2024-03-21 at 2 18 49 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/b9b6744d-fcd6-4fe4-9daa-2c25efec6c7d">

Note: isCopied logic is being set on the api side so when testing it on the frontend I'm only testing "if the subtext is displayed if isCopied is set to true"

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3422

---
### How to test
1. Create a WP with stateuser
2. Approve WP with admin user
3. Go back to stateuser dashboard and select "continue MFP Work Plan for next period"
4. A new "not started" WP should be generated with the copy over text under the submission name


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
