### PR TITLE
[CMDCT-3440] Tealium correct param

### DIFF
--- a/services/ui-src/public/index.html
+++ b/services/ui-src/public/index.html
@@ -23,7 +23,7 @@
     <!-- Tealium Analytics Tag Manager -->
     <script>
       var tealiumEnvMap = {
-        "mdctmfp.cms.gov": "production",
+        "mdctmfp.cms.gov": "prod",
         "mdctmfpval.cms.gov": "qa",
       };
       var tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";

--- a/services/ui-src/src/utils/tracking/tealium.js
+++ b/services/ui-src/src/utils/tracking/tealium.js
@@ -2,7 +2,7 @@ export const fireTealiumPageView = (user, url, pathname, isReportPage) => {
   const contentType = isReportPage ? "form" : "app";
   const sectionName = isReportPage ? pathname.split("/")[1] : "main app";
   const tealiumEnvMap = {
-    "mdctmfp.cms.gov": "production",
+    "mdctmfp.cms.gov": "production", // Different than the url value (index.html)
     "mdctmfpval.cms.gov": "qa",
   };
   const tealiumEnv = tealiumEnvMap[window.location.hostname] || "dev";


### PR DESCRIPTION
### Description
Corrects the url param used when in production from `production` to `prod`. This is not the same as the site_environment flag, and the two have been flipped back and forth together in the past.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3440

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Only testable in production, tealium script should no longer return an empty file and a cloudfront error.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
