### PR TITLE
[CMDCT-3372] Add E2E test for workplan

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1190,6 +1190,7 @@
                       "rule": "nextTwelveQuarters"
                     },
                     "props": {
+                      "data-cy": "transformedFundingSources",
                       "mask": "currency"
                     }
                   }

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -155,7 +155,7 @@ export const EntityRow = ({
               sx={sx.editNameButton}
               variant="none"
               onClick={() => openAddEditEntityModal(entity)}
-              aria-label="edit button"
+              aria-label="edit entity button"
             >
               {!editable || isInitiativeClosed
                 ? verbiage.readOnlyEntityButtonText

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -1,0 +1,48 @@
+// Feature: MCPAR E2E Form Submission
+import wpTemplate from "../../../..//services/app-api/forms/wp.json";
+import { traverseRoutes } from "../../support/form";
+
+describe("MFP Work Plan E2E Submission", () => {
+  it("State users can create Work Plans", () => {
+    cy.authenticate("stateUser");
+
+    //Given I've logged in
+    cy.url().should("include", "/");
+
+    //And I enter the Work Plan Dashboard
+    cy.contains("Enter Work Plan online").click();
+    cy.url().should("include", "/wp");
+
+    //When I click the create Work Plan Button and create a WP
+    cy.contains("Start MFP Work Plan").click();
+    cy.contains("Start new").click();
+
+    //Then there is a new Workplan with the title
+    cy.contains("MFP Work Plan", { matchCase: true }).should("be.visible");
+
+    //Find our new program and open it
+    cy.get("table").within(() => {
+      cy.get("td").as("workplan").contains("MFP Work Plan");
+      cy.get("@workplan").parent().as("workplancontainer");
+      cy.get("@workplancontainer")
+        .find('button:contains("Edit")')
+        .as("editbutton");
+      cy.get("@editbutton").focus();
+      cy.get("@editbutton").click();
+    });
+
+    //Using the json as a guide, traverse all the routes/forms and fill it out dynamically
+    const template = wpTemplate;
+    traverseRoutes(template.routes);
+
+    // Confirm form is submittable
+    cy.get('div[role*="alert"]').should("not.exist");
+    cy.get(`button:contains("Submit")`).should("not.be.disabled");
+
+    //Submit the program
+    cy.get(`button:contains("Submit")`).focus().click();
+    cy.get('[data-testid="modal-submit-button"]').focus().click();
+
+    cy.contains("Successfully Submitted").should("be.visible");
+  });
+});

--- a/tests/cypress/support/form.js
+++ b/tests/cypress/support/form.js
@@ -1,0 +1,202 @@
+export const traverseRoutes = (routes) => {
+  //iterate over each route
+  routes.forEach((route) => {
+    traverseRoute(route);
+  });
+};
+
+const traverseRoute = (route) => {
+  //only perform checks on route if it contains some kind of form fill
+  if (route.form || route.modalForm || route.drawerForm) {
+    //validate we are on the URL we expect to be
+    cy.url().should("include", route.path);
+    //Validate the intro section is presented
+    if (route.verbiage?.intro?.section)
+      cy.contains(route.verbiage?.intro?.section);
+    if (route.verbiage?.intro?.subsection)
+      cy.contains(route.verbiage?.intro?.subsection);
+
+    //Fill out the 3 different types of forms
+    completeForm(route.form);
+    completeModalForm(
+      route.path,
+      route.modalForm,
+      route.verbiage?.addEntityButtonText
+    );
+    completeDrawerForm(route.drawerForm);
+    completeOverlayEntity(route.path, route.entitySteps);
+
+    cy.get('button:contains("Continue")').focus().click();
+  }
+  //If this route has children routes, traverse those as well
+  if (route.children) traverseRoutes(route.children);
+};
+
+const completeDrawerForm = (drawerForm) => {
+  if (drawerForm) {
+    cy.get("table")
+      .find('[aria-label="edit button"]')
+      .each(($button) => {
+        cy.wrap($button).click();
+        cy.wait(500);
+        completeForm(drawerForm);
+        cy.get("form").submit();
+      });
+  }
+};
+
+const completeModalForm = (path, modalForm, buttonText) => {
+  if (path === "/wp/state-and-territory-specific-initiatives/initiatives") {
+    //Create 5 initiatives
+    for (let i = 0; i < 5; i++) {
+      cy.get(`button:contains("${buttonText}")`).focus().click();
+      completeForm(modalForm, i);
+      cy.get('[data-testid="modal-submit-button"]').focus().click();
+      cy.wait(500);
+    }
+  } else {
+    //open the modal, then fill out the form and save it
+    if (modalForm && buttonText) {
+      cy.get(`button:contains("${buttonText}")`).focus().click();
+      completeForm(modalForm);
+      cy.get('[data-testid="modal-submit-button"]').focus().click();
+      cy.wait(500);
+    }
+  }
+};
+
+const completeOverlayEntity = (path, entitySteps) => {
+  if (
+    entitySteps &&
+    path === "/wp/state-and-territory-specific-initiatives/initiatives"
+  ) {
+    cy.wait(500);
+
+    //Edit each of the 5 initiatives
+    for (let i = 0; i < 5; i++) {
+      cy.get("table").find('[aria-label="edit button"]').eq(i).click();
+      cy.wait(500);
+      completeOverlayEntityStep(entitySteps);
+      cy.get('button:contains("Return to all initiatives")')
+        .first()
+        .focus()
+        .click();
+      cy.wait(500);
+    }
+  }
+};
+
+const completeOverlayEntityStep = (entitySteps) => {
+  //first step
+  cy.get("table").find('[aria-label="edit button"]').first().click();
+  cy.wait(500);
+  completeForm(entitySteps[0].form);
+  cy.get('button:contains("Save")').focus().click();
+  cy.wait(500);
+
+  //second step
+  cy.get("table").find('[aria-label="edit button"]').eq(1).click();
+  cy.wait(500);
+  completeModalForm(
+    undefined,
+    entitySteps[1].modalForm,
+    entitySteps[1].verbiage.addEntityButtonText
+  );
+  cy.get('button:contains("Save")').focus().click();
+  cy.wait(500);
+
+  //third step
+  cy.get("table").find('[aria-label="edit button"]').eq(2).click();
+  cy.wait(500);
+  completeModalForm(
+    undefined,
+    entitySteps[2].modalForm,
+    entitySteps[2].verbiage.addEntityButtonText
+  );
+  cy.get('button:contains("Save")').focus().click();
+  cy.wait(500);
+};
+
+const completeForm = (form, optionToSelect = 0) => {
+  //iterate over each field and fill it appropriately
+  form?.fields?.forEach((field) => processField(field, optionToSelect));
+};
+
+const processField = (field, optionToSelect) => {
+  //only try to fill it out if it's enabled
+  if (!field.props?.disabled) {
+    //Validation method shifts around based on field type
+    const validationType = field.validation?.type
+      ? field.validation?.type
+      : field.validation;
+    switch (field.type) {
+      case "text":
+      case "textarea":
+        switch (validationType) {
+          case "email":
+            cy.get(`[name="${field.id}"]`).type("email@fill.com");
+            break;
+          case "url":
+            cy.get(`[name="${field.id}"]`).type("https://fill.com");
+            break;
+          case "text":
+            cy.get(`[name="${field.id}"]`).type(`Text Fill`);
+            break;
+          default:
+            cy.get(`[name="${field.id}"]`).type("Unknown Fill");
+        }
+        break;
+      case "date":
+        cy.get(`[name="${field.id}"]`).type(
+          new Date().toLocaleDateString("en-US")
+        );
+        break;
+      case "dynamic":
+        cy.get(`[name="${field.id}[0]"`).type("Dynamic Fill");
+        break;
+      case "number":
+        switch (validationType) {
+          case "ratio":
+            cy.get(`[name="${field.id}"]`).type("1:1");
+            break;
+          default:
+            if (
+              field.props["data-cy"] &&
+              field.props["data-cy"] == "transformedFundingSources"
+            ) {
+              cy.get("form")
+                .find('*[data-cy^="transformedFundingSources"]')
+                .each(($numberfield) => {
+                  cy.get($numberfield).type(Math.ceil(Math.random() * 100));
+                });
+            } else {
+              cy.get(`[name="${field.id}"]`).type(
+                Math.ceil(Math.random() * 100)
+              );
+            }
+        }
+        break;
+      case "dropdown":
+        cy.get(`[name="${field.id}"]`).select(1);
+        break;
+      case "radio":
+      case "checkbox":
+        /*
+         * This is a unique case where we're dealing with a transformed field. The options
+         * won't exist in the wp.json to reference.
+         */
+        if (field.props.choices.length === 0) {
+          cy.get("input[type=checkbox]").eq(0).check();
+        } else {
+          cy.get(
+            `[id="${field.id}-${field.props.choices[optionToSelect].id}"]`
+          ).check();
+          field.props.choices[0].children?.forEach((childField) =>
+            processField(childField)
+          );
+        }
+
+        break;
+    }
+  }
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

It be doing what it titled friend.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3372

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Note the password is the same for logging in as a state user or admin user in MFP. If you don't have the password or think its been updated, check the proj-cms-mdct-devs channel for the pinned message at the top called MDCT App Access

- Navigate to tests/cypress
- Run `CYPRESS_ADMIN_USER_PASSWORD='insertpasswordhere!' CYPRESS_STATE_USER_PASSWORD='Insertpasswordhere!' yarn test`
- Click e2e configuration
- Run the new tests! 

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
