### PR TITLE
Fix Disabled Field Color 

### DIFF
--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -224,7 +224,7 @@ const sx = {
 
   // disabled field
   ".ds-c-field[disabled]": {
-    color: "palette.gray_medium",
+    color: "palette.base",
   },
   // field hint
   ".ds-c-field__hint": {


### PR DESCRIPTION
### Description
Changed disabled field color to correct gray based on figma mockup (#262626)


Before:
<img width="642" alt="Screenshot 2024-04-05 at 2 42 05 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/17aeb849-11b6-4964-ada4-0fe34a124ff4">


After:
<img width="635" alt="Screenshot 2024-04-05 at 2 37 23 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/6c4537b1-820c-4836-ba85-8ada99e42873">

### Related ticket(s)
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3489

---
### How to test
Log in as an admin user and view any report that has text fields that have been previously filled by a state user. Example in screenshots below.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
