### PR TITLE
Add ensureAvailableReport to Cypress commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,11 +208,10 @@ jobs:
     outputs:
       ipset_name: ${{ steps.fetch-ip-set-info.outputs.IPSET_NAME }}
       ipset_id: ${{ steps.fetch-ip-set-info.outputs.IPSET_ID }}
-    
 
   e2e-test:
     name: E2E Integration Tests
-    needs: 
+    needs:
       - deploy
       - register-runner
     if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}
@@ -224,6 +223,7 @@ jobs:
         with:
           working-directory: tests
           spec: |
+            cypress/e2e/wp/*.cy.js
             cypress/e2e/*.cy.js
           browser: chrome
           config: baseUrl=${{ needs.deploy.outputs.application_endpoint }}
@@ -245,7 +245,7 @@ jobs:
 
   a11y-tests:
     name: E2E A11y Tests
-    needs: 
+    needs:
       - deploy
       - register-runner
     if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' }}

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -264,6 +264,7 @@ const AdminArchiveButton = ({
     <Td>
       <Button
         variant="link"
+        data-cy={`${report?.archived ? "Unarchive" : "Archive"}`}
         sx={sxOverride.adminActionButton}
         onClick={() => archiveReport!(report)}
       >

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   experimentalStudio: true,
   redirectionLimit: 20,
-  retries: 1,
+  retries: 0,
   watchForFileChanges: true,
   fixturesFolder: "fixtures",
   screenshotsFolder: "screenshots",
@@ -18,6 +18,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: "http://127.0.0.1:3000/",
     testIsolation: false,
+    experimentalRunAllSpecs: true,
     setupNodeEvents(on, _config) {
       on("task", {
         log(message) {

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   experimentalStudio: true,
   redirectionLimit: 20,
-  retries: 0,
+  retries: 2,
   watchForFileChanges: true,
   fixturesFolder: "fixtures",
   screenshotsFolder: "screenshots",

--- a/tests/cypress/e2e/wp/dashboard.cy.js
+++ b/tests/cypress/e2e/wp/dashboard.cy.js
@@ -3,7 +3,7 @@ const currentYear = new Date().getFullYear();
 describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
   describe("MFP Work Plan Dashboard Page - State User Report Creation", () => {
     it("State users can create Work Plans", () => {
-      cy.ensureAvailableReport();
+      cy.archiveAnyExistingWorkPlans();
       cy.authenticate("stateUser");
 
       //Given I've logged in

--- a/tests/cypress/e2e/wp/dashboard.cy.js
+++ b/tests/cypress/e2e/wp/dashboard.cy.js
@@ -1,6 +1,7 @@
 describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
   describe("MFP Work Plan Dashboard Page - State User Report Creation", () => {
     it("State users can create Work Plans", () => {
+      cy.ensureAvailableReport();
       cy.authenticate("stateUser");
 
       //Given I've logged in

--- a/tests/cypress/e2e/wp/dashboard.cy.js
+++ b/tests/cypress/e2e/wp/dashboard.cy.js
@@ -1,3 +1,5 @@
+const currentYear = new Date().getFullYear();
+
 describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
   describe("MFP Work Plan Dashboard Page - State User Report Creation", () => {
     it("State users can create Work Plans", () => {
@@ -13,10 +15,16 @@ describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
 
       //When I click the create Work Plan Button and create a WP
       cy.contains("Start MFP Work Plan").click();
+      cy.get(`[id="reportYear-${currentYear}"]`).check();
+      cy.get(`[id="reportPeriod-1"]`).check();
+
       cy.contains("Start new").click();
 
       //Then there is a new Workplan with the title
-      cy.contains("MFP Work Plan", { matchCase: true }).should("be.visible");
+      cy.contains(
+        `District of Columbia MFP Work Plan ${currentYear} - Period 1`,
+        { matchCase: true }
+      ).should("be.visible");
     });
   });
 
@@ -36,9 +44,12 @@ describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
       cy.url().should("include", "/wp");
 
       //Then there is a new Workplan with the title
-      cy.contains("District of Columbia MFP Work Plan", {
-        matchCase: true,
-      }).should("be.visible");
+      cy.contains(
+        `District of Columbia MFP Work Plan ${currentYear} - Period 1`,
+        {
+          matchCase: true,
+        }
+      ).should("be.visible");
 
       //And when the admin clicks archive/unarchive it should do that to the report
       cy.contains("Archive").click();
@@ -46,6 +57,9 @@ describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
 
       cy.contains("Unarchive").click();
       cy.contains("Archive").should("be.visible");
+
+      cy.contains("Archive").click();
+      cy.contains("Unarchive").should("be.visible");
     });
   });
 });

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -6,7 +6,7 @@ const currentYear = new Date().getFullYear();
 
 describe("MFP Work Plan E2E Submission", () => {
   it("State users can create Work Plans", () => {
-    cy.ensureAvailableReport();
+    cy.archiveAnyExistingWorkPlans();
     cy.authenticate("stateUser");
 
     //Given I've logged in

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -16,6 +16,9 @@ describe("MFP Work Plan E2E Submission", () => {
 
     //When I click the create Work Plan Button and create a WP
     cy.contains("Start MFP Work Plan").click();
+    cy.get(`[id="reportYear-${new Date().getFullYear()}"]`).check();
+    cy.get(`[id="reportPeriod-1"]`).check();
+
     cy.contains("Start new").click();
 
     //Then there is a new Workplan with the title

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -2,6 +2,8 @@
 import wpTemplate from "../../../..//services/app-api/forms/wp.json";
 import { traverseRoutes } from "../../support/form";
 
+const currentYear = new Date().getFullYear();
+
 describe("MFP Work Plan E2E Submission", () => {
   it("State users can create Work Plans", () => {
     cy.ensureAvailableReport();
@@ -16,13 +18,16 @@ describe("MFP Work Plan E2E Submission", () => {
 
     //When I click the create Work Plan Button and create a WP
     cy.contains("Start MFP Work Plan").click();
-    cy.get(`[id="reportYear-${new Date().getFullYear()}"]`).check();
+    cy.get(`[id="reportYear-${currentYear}"]`).check();
     cy.get(`[id="reportPeriod-1"]`).check();
 
     cy.contains("Start new").click();
 
     //Then there is a new Workplan with the title
-    cy.contains("MFP Work Plan", { matchCase: true }).should("be.visible");
+    cy.contains(
+      `District of Columbia MFP Work Plan ${currentYear} - Period 1`,
+      { matchCase: true }
+    ).should("be.visible");
 
     //Find our new program and open it
     cy.get("table").within(() => {

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -4,6 +4,7 @@ import { traverseRoutes } from "../../support/form";
 
 describe("MFP Work Plan E2E Submission", () => {
   it("State users can create Work Plans", () => {
+    cy.ensureAvailableReport();
     cy.authenticate("stateUser");
 
     //Given I've logged in

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -49,7 +49,7 @@ Cypress.Commands.add("testPageAccessibility", () => {
   }
 });
 
-Cypress.Commands.add("ensureAvailableReport", () => {
+Cypress.Commands.add("archiveAnyExistingWorkPlans", () => {
   // login as admin
   cy.authenticate("adminUser");
   cy.navigateToHomePage();

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -49,6 +49,30 @@ Cypress.Commands.add("testPageAccessibility", () => {
   }
 });
 
+Cypress.Commands.add("ensureAvailableReport", () => {
+  // login as admin
+  cy.authenticate("adminUser");
+  cy.navigateToHomePage();
+
+  /*
+   * Check if there is already a workplan, if so, archive
+   * is to ensure a clean test bed
+   */
+  cy.get(
+    '[aria-label="List of states, including District of Columbia and Puerto Rico"]'
+  ).select("DC");
+  cy.get('[id="report-WP"]').click();
+  cy.contains("Go to Report Dashboard").click();
+  cy.wait(3000);
+
+  cy.get("table").then(($table) => {
+    if ($table.find('*[data-cy^="Archive"]').length > 0) {
+      cy.get('*[data-cy^="Archive"]').first().click();
+      cy.wait(500);
+    }
+  });
+});
+
 Cypress.Commands.add("fillOutForm", (formInputs) => {
   formInputs.forEach((row) => {
     /*
@@ -96,6 +120,7 @@ Cypress.Commands.add("fillOutForm", (formInputs) => {
 });
 
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
+  Cypress.session.clearAllSavedSessions();
   cy.session([userType, userCredentials], () => {
     cy.visit("/");
     cy.wait(2000);

--- a/tests/cypress/support/form.js
+++ b/tests/cypress/support/form.js
@@ -38,7 +38,7 @@ const completeDrawerForm = (drawerForm) => {
       .find('[aria-label="edit button"]')
       .each(($button) => {
         cy.wrap($button).click();
-        cy.wait(500);
+        cy.wait(1250);
         completeForm(drawerForm);
         cy.get("form").submit();
       });
@@ -52,7 +52,7 @@ const completeModalForm = (path, modalForm, buttonText) => {
       cy.get(`button:contains("${buttonText}")`).focus().click();
       completeForm(modalForm, i);
       cy.get('[data-testid="modal-submit-button"]').focus().click();
-      cy.wait(500);
+      cy.wait(1250);
     }
   } else {
     //open the modal, then fill out the form and save it
@@ -60,7 +60,7 @@ const completeModalForm = (path, modalForm, buttonText) => {
       cy.get(`button:contains("${buttonText}")`).focus().click();
       completeForm(modalForm);
       cy.get('[data-testid="modal-submit-button"]').focus().click();
-      cy.wait(500);
+      cy.wait(1250);
     }
   }
 };
@@ -70,18 +70,18 @@ const completeOverlayEntity = (path, entitySteps) => {
     entitySteps &&
     path === "/wp/state-and-territory-specific-initiatives/initiatives"
   ) {
-    cy.wait(500);
+    cy.wait(1250);
 
     //Edit each of the 5 initiatives
     for (let i = 0; i < 5; i++) {
       cy.get("table").find('[aria-label="edit button"]').eq(i).click();
-      cy.wait(500);
+      cy.wait(1250);
       completeOverlayEntityStep(entitySteps);
       cy.get('button:contains("Return to all initiatives")')
         .first()
         .focus()
         .click();
-      cy.wait(500);
+      cy.wait(1250);
     }
   }
 };
@@ -89,32 +89,34 @@ const completeOverlayEntity = (path, entitySteps) => {
 const completeOverlayEntityStep = (entitySteps) => {
   //first step
   cy.get("table").find('[aria-label="edit button"]').first().click();
-  cy.wait(500);
+  cy.wait(1250);
   completeForm(entitySteps[0].form);
   cy.get('button:contains("Save")').focus().click();
-  cy.wait(500);
+  cy.wait(1250);
 
   //second step
   cy.get("table").find('[aria-label="edit button"]').eq(1).click();
-  cy.wait(500);
+  cy.wait(1250);
   completeModalForm(
     undefined,
     entitySteps[1].modalForm,
     entitySteps[1].verbiage.addEntityButtonText
   );
-  cy.get('button:contains("Save")').focus().click();
-  cy.wait(500);
+  cy.get('button:contains("Return to dashboard for this initiative")')
+    .focus()
+    .click();
+  cy.wait(1250);
 
   //third step
   cy.get("table").find('[aria-label="edit button"]').eq(2).click();
-  cy.wait(500);
+  cy.wait(1250);
   completeModalForm(
     undefined,
     entitySteps[2].modalForm,
     entitySteps[2].verbiage.addEntityButtonText
   );
   cy.get('button:contains("Save")').focus().click();
-  cy.wait(500);
+  cy.wait(1250);
 };
 
 const completeForm = (form, optionToSelect = 0) => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

This adds a cypress command to make sure that any e2e test that fails can reset itself and be able to run again without having to clean anything out of the DB or start a whole new PR. It also enables the dashboard and WP e2e test to run as part of the Git Action

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3502

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Note the password is the same for logging in as a state user or admin user in MFP. If you don't have the password or think its been updated, check the proj-cms-mdct-devs channel for the pinned message at the top called MDCT App Access

- Navigate to tests/cypress
- Run `CYPRESS_ADMIN_USER_PASSWORD='insertpasswordhere!' CYPRESS_STATE_USER_PASSWORD='Insertpasswordhere!' yarn test`
- Click e2e configuration
- Run the new tests! 

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary

---
