### PR TITLE
Prevent submission of forms when the API would reject them

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
@@ -3,7 +3,16 @@ import { axe } from "jest-axe";
 // components
 import { ReportPageFooter } from "components";
 //utils
-import { mockForm, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockForm,
+  mockReportStore,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
+import { useStore } from "utils";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockReportStore);
 
 const mockRoutes = {
   previousRoute: "/mock-previous-route",
@@ -37,20 +46,38 @@ const reportPageComponentOnModalOverlayPage = (
   </RouterWrappedComponent>
 );
 
-describe("Test ReportPageFooter without form", () => {
-  test("Check that ReportPageFooter without form renders", () => {
+describe("ReportPageFooter behavior", () => {
+  it("Should render without a form", () => {
     render(reportPageComponentWithoutForm);
     expect(screen.getByText("Continue")).toBeVisible();
   });
 
-  test("Check that ReportPageFooter with form renders", () => {
+  it("Should render with a form", () => {
     render(reportPageComponentWithForm);
     expect(screen.getByText("Continue")).toBeVisible();
   });
 
-  test("Check that ReportPageFooter on modal overlay page renders correct text", () => {
+  it("Should render correctly on a modal overlay page", () => {
     render(reportPageComponentOnModalOverlayPage);
     expect(screen.getByText("Review & Submit")).toBeVisible();
+  });
+
+  it("Should render a submit button for state users", () => {
+    mockedUseStore.mockReturnValue({
+      user: { userIsEndUser: true },
+      ...mockReportStore,
+    });
+    render(reportPageComponentWithForm);
+    expect(screen.getByText("Continue")).toHaveAttribute("type", "submit");
+  });
+
+  it("Should render only a navigation button for admins", () => {
+    mockedUseStore.mockReturnValue({
+      user: { userIsAdmin: true },
+      ...mockReportStore,
+    });
+    render(reportPageComponentWithForm);
+    expect(screen.getByText("Continue")).not.toHaveAttribute("type", "submit");
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -28,7 +28,7 @@ export const ReportPageFooter = ({
    */
   const reportWithSubmittedStatus = report?.status === ReportStatus.SUBMITTED;
   const { userIsAdmin, userIsEndUser } = useStore().user ?? {};
-  const formIsDisabled = 
+  const formIsDisabled =
     (userIsAdmin && !form?.editableByAdmins) ||
     (userIsEndUser && reportWithSubmittedStatus) ||
     !editable ||

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
 // utils
 import { parseCustomHtml, useFindRoute, useStore } from "utils";
-import { AnyObject, FormJson } from "types";
+import { AnyObject, FormJson, ReportStatus } from "types";
 // assets
 import nextIcon from "assets/icons/icon_next_white.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
@@ -15,13 +15,24 @@ export const ReportPageFooter = ({
   ...props
 }: Props) => {
   const navigate = useNavigate();
-  const formIsDisabled = false;
-  const report = useStore().report;
+  const { report, editable, selectedEntity } = useStore();
   const { previousRoute, nextRoute } = useFindRoute(
     report?.formTemplate.flatRoutes,
     report?.formTemplate?.basePath
   );
   const hidePrevious = previousRoute === "/wp" || previousRoute === "/sar";
+
+  /*
+   * By default, the Continue button submits the form AND navigates.
+   * If the form is disabled, the button will navigate only.
+   */
+  const reportWithSubmittedStatus = report?.status === ReportStatus.SUBMITTED;
+  const { userIsAdmin, userIsEndUser } = useStore().user ?? {};
+  const formIsDisabled = 
+    (userIsAdmin && !form?.editableByAdmins) ||
+    (userIsEndUser && reportWithSubmittedStatus) ||
+    !editable ||
+    selectedEntity?.isInitiativeClosed;
 
   // initiatives page requires a different button text
   const rightButtonText =


### PR DESCRIPTION
### Description
* State users are allowed to make changes to report data, and admin users are not.
* Every report page is a form for report data, and the report page footer contains a submit button for that form
* Currently, when an admin user navigates from page to page, they are continually submitting and re-submitting those forms
   * This fails because the API recognizes that admin users are not allowed to PUT to report endpoints
   * It also fails because the API endpoint for updating reports contains a state abbreviation, pulled from the user's data. Since admin users aren't associated with a specific state, this URL ends up malformed.
* This PR replaces the footer's submit button with a simple navigation button, when it detects that the user is an admin
   * Or when it detects that the form would not be editable for other reasons, such as the report having been submitted.

### Related ticket(s)
CMDCT-3533

---
### How to test
* Log in as an admin
* Enter any report, such as a workplan
* Open the network tab, and clear it
* Click the "Continue" button at the bottom of the page
* Note that the traffic does _not_ contain a failed PUT to `api/WP/undefined/abc-123`

### Notes
n/a

---
### Pre-review checklist

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~

---
### Pre-merge checklist

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
