### PR TITLE
Fix Submit Container styling for Mobile View

### DIFF
--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.tsx
@@ -27,7 +27,12 @@ import {
 // types
 import { AlertTypes, AnyObject, ReportStatus } from "types";
 // utils
-import { parseCustomHtml, useStore, utcDateToReadableDate } from "utils";
+import {
+  parseCustomHtml,
+  useStore,
+  utcDateToReadableDate,
+  useBreakpoint,
+} from "utils";
 // verbiage
 import WPVerbiage from "verbiage/pages/wp/wp-review-and-submit";
 import SARVerbiage from "verbiage/pages/sar/sar-review-and-submit";
@@ -151,6 +156,7 @@ const ReadyToSubmit = ({
   const { userIsAdmin } = useStore().user ?? {};
   const { review } = reviewVerbiage;
   const { intro, modal, pageLink } = review;
+  const { isMobile } = useBreakpoint();
   return (
     <Flex sx={sx.contentContainer} data-testid="ready-view">
       <Box sx={sx.leadTextBox}>
@@ -172,7 +178,7 @@ const ReadyToSubmit = ({
           <StatusTable />
         </Box>
       </Box>
-      <Flex sx={sx.submitContainer}>
+      <Flex sx={isMobile ? sx.mobileSubmitContainer : sx.submitContainer}>
         <PrintButton />
         {!userIsAdmin && (
           <Button
@@ -364,6 +370,14 @@ const sx = {
   submitContainer: {
     width: "100%",
     justifyContent: "space-between",
+  },
+  mobileSubmitContainer: {
+    display: "flex",
+    flexDirection: "column",
+
+    "a:first-child": {
+      marginBottom: "1.5rem",
+    },
   },
   alert: {
     marginBottom: "2rem",


### PR DESCRIPTION
### Description
Added styling to report submit container -> mobile view of 560px wide or less 


<img width="725" alt="Screenshot 2024-04-16 at 10 29 52 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/9f5b80a5-f673-43f8-a96a-6ed784f2737f">


<img width="286" alt="Screenshot 2024-04-16 at 10 24 58 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/14514294/1c01da74-9ad8-4d45-a036-62330acc4a4c">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-https://jiraent.cms.gov/browse/CMDCT-3499

---
### How to test
1. Log in as a state user and go to the Review and Submit page, then shrink the viewport below 560px wide.
2. Review PDF and Submit button should stack with 1.5rem gap. 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
