### PR TITLE
Disable Funding Source Radio List 

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -3,14 +3,8 @@ import { axe } from "jest-axe";
 //components
 import { useFormContext } from "react-hook-form";
 import { ChoiceListField, ReportContext } from "components";
-import {
-  mockReportMethods,
-  mockReportsByState,
-  mockWPCopiedReport,
-  mockWpReportContext,
-} from "../../utils/testing/mockReport";
+import { mockWpReportContext } from "../../utils/testing/mockReport";
 import { ReportStatus } from "../../types";
-import { genericErrorContent } from "verbiage/errors";
 
 const mockTrigger = jest.fn().mockReturnValue(true);
 const mockSetValue = jest.fn();
@@ -179,18 +173,6 @@ const RadioComponent = (
     validateOnRender={true}
   />
 );
-
-const mockCopiedWpReportContext = {
-  ...mockReportMethods,
-  report: mockWPCopiedReport,
-  reportsByState: mockReportsByState,
-  copyEligibleReportsByState: mockReportsByState,
-  errorMessage: {
-    title: "We've run into a problem",
-    description: genericErrorContent,
-  },
-  lastSavedTime: "2:00 PM",
-};
 
 describe("Test ChoiceListField component rendering", () => {
   it("ChoiceList should render a normal Radiofield that doesn't have children", () => {
@@ -877,29 +859,6 @@ describe("ChoiceListField handles triggering validation", () => {
     mockGetValues(undefined);
     render(choiceListFieldValidateOnRenderComponent);
     expect(mockTrigger).toHaveBeenCalled();
-  });
-});
-
-describe("Test ChoiceList disabling", () => {
-  const disabledChoiceListFieldComponent = (
-    <ReportContext.Provider value={mockCopiedWpReportContext}>
-      <ChoiceListField
-        choices={mockChoices}
-        label="Checkbox example"
-        name="checkboxField"
-        type="checkbox"
-        disabled={true}
-        validateOnRender
-      />
-    </ReportContext.Provider>
-  );
-
-  test("Should disable radiofield when state user is in copy over report", async () => {
-    mockGetValues(undefined);
-    render(disabledChoiceListFieldComponent);
-    const radioBtn = document.querySelector(".ds-c-choice-wrapper")
-      ?.children[0];
-    expect(radioBtn).toBeDisabled();
   });
 });
 

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -3,8 +3,14 @@ import { axe } from "jest-axe";
 //components
 import { useFormContext } from "react-hook-form";
 import { ChoiceListField, ReportContext } from "components";
-import { mockWpReportContext } from "../../utils/testing/mockReport";
+import {
+  mockReportMethods,
+  mockReportsByState,
+  mockWPCopiedReport,
+  mockWpReportContext,
+} from "../../utils/testing/mockReport";
 import { ReportStatus } from "../../types";
+import { genericErrorContent } from "verbiage/errors";
 
 const mockTrigger = jest.fn().mockReturnValue(true);
 const mockSetValue = jest.fn();
@@ -173,6 +179,18 @@ const RadioComponent = (
     validateOnRender={true}
   />
 );
+
+const mockCopiedWpReportContext = {
+  ...mockReportMethods,
+  report: mockWPCopiedReport,
+  reportsByState: mockReportsByState,
+  copyEligibleReportsByState: mockReportsByState,
+  errorMessage: {
+    title: "We've run into a problem",
+    description: genericErrorContent,
+  },
+  lastSavedTime: "2:00 PM",
+};
 
 describe("Test ChoiceListField component rendering", () => {
   it("ChoiceList should render a normal Radiofield that doesn't have children", () => {
@@ -859,6 +877,29 @@ describe("ChoiceListField handles triggering validation", () => {
     mockGetValues(undefined);
     render(choiceListFieldValidateOnRenderComponent);
     expect(mockTrigger).toHaveBeenCalled();
+  });
+});
+
+describe("Test ChoiceList disabling", () => {
+  const disabledChoiceListFieldComponent = (
+    <ReportContext.Provider value={mockCopiedWpReportContext}>
+      <ChoiceListField
+        choices={mockChoices}
+        label="Checkbox example"
+        name="checkboxField"
+        type="checkbox"
+        disabled={true}
+        validateOnRender
+      />
+    </ReportContext.Provider>
+  );
+
+  test("Should disable radiofield when state user is in copy over report", async () => {
+    mockGetValues(undefined);
+    render(disabledChoiceListFieldComponent);
+    const radioBtn = document.querySelector(".ds-c-choice-wrapper")
+      ?.children[0];
+    expect(radioBtn).toBeDisabled();
   });
 });
 

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -2,6 +2,9 @@
 import { Box } from "@chakra-ui/react";
 import { ChoiceListField } from "components";
 // utils
+import { useStore } from "utils";
+
+// types
 import { ChoiceFieldProps } from "types";
 
 export const RadioField = ({
@@ -11,6 +14,13 @@ export const RadioField = ({
   sxOverride,
   ...props
 }: ChoiceFieldProps) => {
+  const { userIsEndUser } = useStore().user ?? {};
+  const { report } = useStore();
+
+  const isEditableRadioFields = () => {
+    return label === "Funding source:" && userIsEndUser && report?.isCopied;
+  };
+
   return (
     <Box sx={{ ...sx, ...sxOverride }}>
       <ChoiceListField
@@ -19,6 +29,7 @@ export const RadioField = ({
         label={label}
         choices={choices}
         {...props}
+        disabled={isEditableRadioFields()}
       />
     </Box>
   );

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -1,9 +1,6 @@
 // components
 import { Box } from "@chakra-ui/react";
 import { ChoiceListField } from "components";
-// utils
-import { useStore } from "utils";
-
 // types
 import { ChoiceFieldProps } from "types";
 
@@ -14,13 +11,6 @@ export const RadioField = ({
   sxOverride,
   ...props
 }: ChoiceFieldProps) => {
-  const { userIsEndUser } = useStore().user ?? {};
-  const { report } = useStore();
-
-  const isEditableRadioFields = () => {
-    return label === "Funding source:" && userIsEndUser && report?.isCopied;
-  };
-
   return (
     <Box sx={{ ...sx, ...sxOverride }}>
       <ChoiceListField
@@ -29,7 +19,6 @@ export const RadioField = ({
         label={label}
         choices={choices}
         {...props}
-        disabled={isEditableRadioFields()}
       />
     </Box>
   );

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -103,7 +103,7 @@ export const Form = ({
   // hydrate and create form fields using formFieldFactory
   const renderFormFields = (fields: (FormField | FormLayoutElement)[]) => {
     const fieldsToRender = hydrateFormFields(
-      updateRenderFields(report!, fields),
+      updateRenderFields(report!, fields, formData),
       formData
     );
     const updateFieldsToRenderWithAriaLabels = (

--- a/services/ui-src/src/components/reports/OverlayModalPage.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.tsx
@@ -88,7 +88,7 @@ export const OverlayModalPage = ({
   } = useDisclosure();
 
   const openAddEditEntityModal = (entity?: EntityShape) => {
-    if (entity) setSelectedStepEntity(entity);
+    setSelectedStepEntity(entity);
     addEditEntityModalOnOpenHandler();
   };
 
@@ -138,7 +138,7 @@ export const OverlayModalPage = ({
           <>
             <Button
               sx={sx.addEntityButton}
-              onClick={addEditEntityModalOnOpenHandler}
+              onClick={() => openAddEditEntityModal()}
               leftIcon={<Image sx={sx.buttonIcons} src={addIcon} alt="Add" />}
             >
               {verbiage.addEntityButtonText}

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -12,7 +12,7 @@ import {
   disableCopiedFundingSources,
 } from "./forms";
 // types
-import { FormField } from "types";
+import { FormField, ReportShape } from "types";
 import {
   mockDateField,
   mockFormField,
@@ -46,14 +46,27 @@ describe("form utilities", () => {
       }
     });
 
-    describe("Test Choice List Disabling", () => {
+    describe("disableCopiedFundingSources", () => {
       it("should disable choicelist on copy over report - funding source section", () => {
-        const fields: FormField[] = [mockFundingSourceFormField];
-        const disabledFields = disableCopiedFundingSources(
-          fields,
-          mockWPCopiedReport
-        );
-        expect(disabledFields[0].props?.disabled).toBe(true);
+        const fields: FormField[] = [
+          structuredClone(mockFundingSourceFormField),
+        ];
+        disableCopiedFundingSources(mockWPCopiedReport, fields);
+        expect(fields[0].props?.disabled).toBe(true);
+      });
+
+      it("should not disable funding sources for non-copied reports", () => {
+        const fields: FormField[] = [
+          structuredClone(mockFundingSourceFormField),
+        ];
+        disableCopiedFundingSources({} as ReportShape, fields);
+        expect(fields[0].props?.disabled).toBeFalsy();
+      });
+
+      it("should not disable fields other than funding sources", () => {
+        const fields: FormField[] = [structuredClone(mockFormField)];
+        disableCopiedFundingSources(mockWPCopiedReport, fields);
+        expect(fields[0].props?.disabled).toBeFalsy();
       });
     });
 

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -9,6 +9,7 @@ import {
   resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
+  disableCopiedFundingSources,
 } from "./forms";
 // types
 import { FormField } from "types";
@@ -25,8 +26,14 @@ import {
   mockTargetPopReqButNotApplicable,
   mockTargetPopDefaultAndApplicable,
   mockTargetPopDefaultButNotApplicable,
+  mockWPCopiedReport,
+  mockFundingSourceFormField,
 } from "utils/testing/setupJest";
 import { AnyObject } from "yup/lib/types";
+
+global.structuredClone = jest.fn((val) => {
+  return JSON.parse(JSON.stringify(val));
+});
 
 describe("form utilities", () => {
   describe("Test resetClearProp", () => {
@@ -37,6 +44,17 @@ describe("form utilities", () => {
       for (let choice of fields[0].props!.choices) {
         expect(choice.props!.clear).toBe(false);
       }
+    });
+
+    describe("Test Choice List Disabling", () => {
+      it("should disable choicelist on copy over report - funding source section", () => {
+        const fields: FormField[] = [mockFundingSourceFormField];
+        const disabledFields = disableCopiedFundingSources(
+          fields,
+          mockWPCopiedReport
+        );
+        expect(disabledFields[0].props?.disabled).toBe(true);
+      });
     });
 
     it("should reset clear for text fields", async () => {

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -35,6 +35,29 @@ global.structuredClone = jest.fn((val) => {
   return JSON.parse(JSON.stringify(val));
 });
 
+const mockFormData = {
+  fundingSources_quarters2024Q3: "8.00",
+  fundingSources_quarters2024Q4: "8.00",
+  fundingSources_quarters2025Q1: "8.00",
+  fundingSources_quarters2025Q2: "8.00",
+  fundingSources_quarters2025Q3: "888.00",
+  fundingSources_quarters2025Q4: "8.00",
+  fundingSources_quarters2026Q1: "88.00",
+  fundingSources_quarters2026Q2: "8.00",
+  fundingSources_quarters2026Q3: "8.00",
+  fundingSources_quarters2026Q4: "8.00",
+  fundingSources_wpTopic: [
+    {
+      isCopied: true,
+      key: "",
+      value: "MFP cooperative agreement funds for supplemental services",
+    },
+  ],
+  id: "635d43f-21c8-3234-5630-a2d4c7ad8ca8",
+  initiative_wp_otherTopic: "",
+  isCopied: true,
+};
+
 describe("form utilities", () => {
   describe("Test resetClearProp", () => {
     it("should reset clear for choicelist fields and its nested children", async () => {
@@ -51,7 +74,7 @@ describe("form utilities", () => {
         const fields: FormField[] = [
           structuredClone(mockFundingSourceFormField),
         ];
-        disableCopiedFundingSources(mockWPCopiedReport, fields);
+        disableCopiedFundingSources(mockWPCopiedReport, fields, mockFormData);
         expect(fields[0].props?.disabled).toBe(true);
       });
 
@@ -59,13 +82,13 @@ describe("form utilities", () => {
         const fields: FormField[] = [
           structuredClone(mockFundingSourceFormField),
         ];
-        disableCopiedFundingSources({} as ReportShape, fields);
+        disableCopiedFundingSources({} as ReportShape, fields, mockFormData);
         expect(fields[0].props?.disabled).toBeFalsy();
       });
 
       it("should not disable fields other than funding sources", () => {
         const fields: FormField[] = [structuredClone(mockFormField)];
-        disableCopiedFundingSources(mockWPCopiedReport, fields);
+        disableCopiedFundingSources(mockWPCopiedReport, fields, mockFormData);
         expect(fields[0].props?.disabled).toBeFalsy();
       });
     });

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -322,10 +322,29 @@ export const convertTargetPopulationsFromWPToSAREntity = (
   });
 };
 
+const disableCopiedFundingSources = (
+  fields: (FormField | FormLayoutElement)[],
+  report: ReportShape
+) => {
+  const disabledChoiceListFields = structuredClone(fields);
+
+  disabledChoiceListFields.map((field) => {
+    if (field.id === "fundingSources_wpTopic" && report?.isCopied) {
+      field.props = { ...field.props, disabled: true };
+    }
+  });
+  return disabledChoiceListFields;
+};
+
 export const updateRenderFields = (
   report: ReportShape,
   fields: (FormField | FormLayoutElement)[]
 ) => {
+  // disable funding source radio buttons on copy over reports
+  fields[0].id === "fundingSources_wpTopic"
+    ? (fields = disableCopiedFundingSources(fields, report))
+    : fields;
+
   const targetPopulations = report?.fieldData?.targetPopulations;
 
   const hcbsPopulation = {
@@ -346,13 +365,13 @@ export const updateRenderFields = (
     filteredTargetPopulations
   );
 
-  const updateTargetPopulationChoiceList = updateFieldChoicesByID(
+  const updateChoiceList = updateFieldChoicesByID(
     fields,
     "targetPopulations",
     formatChoiceList
   );
 
-  return updateTargetPopulationChoiceList;
+  return updateChoiceList;
 };
 
 export const updateFieldChoicesByID = (

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -322,29 +322,35 @@ export const convertTargetPopulationsFromWPToSAREntity = (
   });
 };
 
+/**
+ * Prevent users from changing a funding source's type in a copied report.
+ *
+ * If the user copied work plan A to make work plan B, we assume that the
+ * data in A was correct. When editing B, they can adjust amounts and
+ * projections, but they can't make fundamental changes to the source.
+ */
 export const disableCopiedFundingSources = (
-  fields: (FormField | FormLayoutElement)[],
-  report: ReportShape
+  report: ReportShape,
+  fields: (FormField | FormLayoutElement)[]
 ) => {
-  const disabledChoiceListFields = structuredClone(fields);
+  if (!report?.isCopied) {
+    return;
+  }
 
-  disabledChoiceListFields.map((field) => {
-    if (field.id === "fundingSources_wpTopic" && report?.isCopied) {
-      field.props = { ...field.props, disabled: true };
-    }
-  });
-  return disabledChoiceListFields;
+  const fundingSourceField = fields.find(
+    (field) => field.id === "fundingSources_wpTopic"
+  );
+
+  if (fundingSourceField) {
+    fundingSourceField.props!.disabled = true;
+  }
 };
 
 export const updateRenderFields = (
   report: ReportShape,
   fields: (FormField | FormLayoutElement)[]
 ) => {
-  // disable funding source radio buttons on copy over reports
-  fields[0]?.id === "fundingSources_wpTopic"
-    ? (fields = disableCopiedFundingSources(fields, report))
-    : fields;
-
+  disableCopiedFundingSources(report, fields);
   const targetPopulations = report?.fieldData?.targetPopulations;
 
   const hcbsPopulation = {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -331,7 +331,8 @@ export const convertTargetPopulationsFromWPToSAREntity = (
  */
 export const disableCopiedFundingSources = (
   report: ReportShape,
-  fields: (FormField | FormLayoutElement)[]
+  fields: (FormField | FormLayoutElement)[],
+  formData?: AnyObject
 ) => {
   if (!report?.isCopied) {
     return;
@@ -341,16 +342,23 @@ export const disableCopiedFundingSources = (
     (field) => field.id === "fundingSources_wpTopic"
   );
 
-  if (fundingSourceField) {
-    fundingSourceField.props!.disabled = true;
+  if (!fundingSourceField) {
+    // This must be some other form; don't touch it.
+    return;
   }
+
+  console.log("form data", formData);
+
+  const disabled = formData && formData.isCopied;
+  fundingSourceField.props!.disabled = disabled;
 };
 
 export const updateRenderFields = (
   report: ReportShape,
-  fields: (FormField | FormLayoutElement)[]
+  fields: (FormField | FormLayoutElement)[],
+  formData?: AnyObject
 ) => {
-  disableCopiedFundingSources(report, fields);
+  disableCopiedFundingSources(report, fields, formData);
   const targetPopulations = report?.fieldData?.targetPopulations;
 
   const hcbsPopulation = {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -347,8 +347,6 @@ export const disableCopiedFundingSources = (
     return;
   }
 
-  console.log("form data", formData);
-
   const disabled = formData && formData.isCopied;
   fundingSourceField.props!.disabled = disabled;
 };

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -322,7 +322,7 @@ export const convertTargetPopulationsFromWPToSAREntity = (
   });
 };
 
-const disableCopiedFundingSources = (
+export const disableCopiedFundingSources = (
   fields: (FormField | FormLayoutElement)[],
   report: ReportShape
 ) => {
@@ -341,7 +341,7 @@ export const updateRenderFields = (
   fields: (FormField | FormLayoutElement)[]
 ) => {
   // disable funding source radio buttons on copy over reports
-  fields[0].id === "fundingSources_wpTopic"
+  fields[0]?.id === "fundingSources_wpTopic"
     ? (fields = disableCopiedFundingSources(fields, report))
     : fields;
 

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -86,6 +86,24 @@ export const mockNestedFormField = {
   },
 };
 
+export const mockFundingSourceFormField = {
+  id: "fundingSources_wpTopic",
+  type: "radio",
+  validation: "radio",
+  props: {
+    label: "mock radio field",
+    choices: [
+      { id: "option1uuid", label: "option 1" },
+      { id: "option2uuid", label: "option 2" },
+      {
+        id: "option3uuid",
+        label: "option 3",
+        children: [mockFormField],
+      },
+    ],
+  },
+};
+
 export const mockSectionHeaderField = {
   type: "sectionHeader",
   id: "testfield",


### PR DESCRIPTION
### Description
[Dev link](https://d158nmtni3yrdc.cloudfront.net/)
Disabled editable capabilities on Funding Source RadioList when a state user is in a 'copy over' report. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-[ cmdct-3487-disablefs](https://jiraent.cms.gov/browse/CMDCT-3487)

---
### How to test
1. Create a WP report 
2. Create a copy over report 
3. Go into report and select an an initiative from State or Territory-Specific Initiatives
4. Edit III. Funding sources and you should only be able to access the quarters ( radio buttons should all be disabled )


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
