### PR TITLE
CMDCT-3536: [SAR] "Report objective progress" Modal Title

### DIFF
--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
@@ -206,15 +206,6 @@ describe("Test AddEditOverlayEntityModal for WP", () => {
     ).toBeTruthy();
   });
 
-  test("AddEditOverlayEntityModal shows the correct contents for SAR", () => {
-    expect(
-      screen.getByText(
-        mockOverlayModalPageVerbiage.addEditModalAddTitle +
-          selectedStepEntity.objectiveProgress_objectiveName
-      )
-    ).toBeTruthy();
-  });
-
   test("AddEditOverlayEntityModal cancel button closes the modal", () => {
     fireEvent.click(screen.getByText("Cancel"));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
@@ -235,14 +226,14 @@ describe("Test AddEditOverlayEntityModal for SAR", () => {
   });
 
   afterEach(() => {
-    wpReport.fieldData.initiative = [mockInitiative];
+    sarReport.fieldData.initiative = [mockInitiative];
     jest.clearAllMocks();
   });
 
   test("AddEditOverlayEntityModal shows the correct contents for SAR", () => {
     expect(
       screen.getByText(
-        mockOverlayModalPageVerbiage.addEditModalAddTitle +
+        mockOverlayModalPageVerbiage.addEditModalEditTitle +
           selectedStepEntity.objectiveProgress_objectiveName
       )
     ).toBeTruthy();

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
@@ -201,7 +201,7 @@ describe("Test AddEditOverlayEntityModal for WP", () => {
   test("AddEditOverlayEntityModal shows the correct contents for WP", () => {
     expect(
       screen.getByText(
-        mockOverlayModalPageVerbiage.addEditModalAddTitle + mockEntityName
+        `${mockOverlayModalPageVerbiage.addEditModalAddTitle} ${mockEntityName}`
       )
     ).toBeTruthy();
   });
@@ -233,8 +233,7 @@ describe("Test AddEditOverlayEntityModal for SAR", () => {
   test("AddEditOverlayEntityModal shows the correct contents for SAR", () => {
     expect(
       screen.getByText(
-        mockOverlayModalPageVerbiage.addEditModalEditTitle +
-          selectedStepEntity.objectiveProgress_objectiveName
+        `${mockOverlayModalPageVerbiage.addEditModalEditTitle} ${selectedStepEntity.objectiveProgress_objectiveName}`
       )
     ).toBeTruthy();
   });

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -170,7 +170,7 @@ export const AddEditOverlayEntityModal = ({
       ? (title = verbiage.addEditModalEditTitle)
       : (title = verbiage.addEditModalAddTitle);
     if (report?.reportType === ReportType.WP && entityName) {
-      `${title} ${entityName}`;
+      title = `${title} ${entityName}`;
     } else if (
       report?.reportType === ReportType.SAR &&
       selectedEntity?.objectiveProgress_objectiveName

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -11,6 +11,7 @@ import {
   FormJson,
   isFieldElement,
   ReportStatus,
+  ReportType,
 } from "types";
 import {
   entityWasUpdated,
@@ -168,8 +169,13 @@ export const AddEditOverlayEntityModal = ({
     selectedEntity?.id
       ? (title = verbiage.addEditModalEditTitle)
       : (title = verbiage.addEditModalAddTitle);
-    if (entityName) {
+    if (report?.reportType === ReportType.WP && entityName) {
       title += entityName;
+    } else if (
+      report?.reportType === ReportType.SAR &&
+      selectedEntity?.objectiveProgress_objectiveName
+    ) {
+      title += selectedEntity?.objectiveProgress_objectiveName;
     }
     return title;
   };

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -170,12 +170,12 @@ export const AddEditOverlayEntityModal = ({
       ? (title = verbiage.addEditModalEditTitle)
       : (title = verbiage.addEditModalAddTitle);
     if (report?.reportType === ReportType.WP && entityName) {
-      `{${title} ${entityName}}`;
+      `${title} ${entityName}`;
     } else if (
       report?.reportType === ReportType.SAR &&
       selectedEntity?.objectiveProgress_objectiveName
     ) {
-      title = `{${title} ${selectedEntity?.objectiveProgress_objectiveName}}`;
+      title = `${title} ${selectedEntity?.objectiveProgress_objectiveName}`;
     }
     return title;
   };

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -175,7 +175,7 @@ export const AddEditOverlayEntityModal = ({
       report?.reportType === ReportType.SAR &&
       selectedEntity?.objectiveProgress_objectiveName
     ) {
-      title = `${title} ${selectedEntity?.objectiveProgress_objectiveName}`;
+      title = `${title} ${selectedEntity.objectiveProgress_objectiveName}`;
     }
     return title;
   };

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -170,12 +170,12 @@ export const AddEditOverlayEntityModal = ({
       ? (title = verbiage.addEditModalEditTitle)
       : (title = verbiage.addEditModalAddTitle);
     if (report?.reportType === ReportType.WP && entityName) {
-      title += entityName;
+      `{${title} ${entityName}}`;
     } else if (
       report?.reportType === ReportType.SAR &&
       selectedEntity?.objectiveProgress_objectiveName
     ) {
-      title += selectedEntity?.objectiveProgress_objectiveName;
+      title = `{${title} ${selectedEntity?.objectiveProgress_objectiveName}}`;
     }
     return title;
   };

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -175,7 +175,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
   };
 
   const tableHeaders = {
-    headRow: ["", "", ""],
+    headRow: ["", "", "", ""],
   };
 
   return (

--- a/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
+++ b/services/ui-src/src/components/reports/OverlayModalPage.test.tsx
@@ -84,7 +84,7 @@ describe("Test overlayModalPage with Work Plans's Evaluation Plan Entity", () =>
     expect(screen.getByRole("dialog")).toBeVisible();
     expect(
       screen.getByText(
-        `${addEditModalEditTitle}${mockEntityStore.selectedEntity?.initiative_name}`
+        `${addEditModalEditTitle} ${mockEntityStore.selectedEntity?.initiative_name}`
       )
     ).toBeVisible;
     const closeButton = screen.getByText("Close");

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -420,7 +420,10 @@ export const mockSARReportContext = {
   report: mockSARFullReport,
   reportsByState: mockSARReportsByState,
   copyEligibleReportsByState: mockReportsByState,
-  errorMessage: "",
+  errorMessage: {
+    title: "We've run into a problem",
+    description: genericErrorContent,
+  },
   lastSavedTime: "2:00 PM",
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The `Report on objective progress` modal title is incorrectly showing the entity name, not the objective name. 

I also snuck in a lil' styling fix!

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3536

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create and submit a WP
- Log in as an admin user
- Approve submitted WP
- Log back in as a state user
- Create a SAR
- Navigate to the `/sar/state-or-territory-specific-initiatives` section
- Go to the **Report on objectives progress** step

You should see the objective name in the title, not the initiative name.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
