### PR TITLE
clean up non-number report period

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -118,8 +118,7 @@ export const createReport = handler(
     const { metadata: unvalidatedMetadata, fieldData: unvalidatedFieldData } =
       unvalidatedPayload;
 
-    const creationValidationJson = {
-      reportPeriod: "text",
+    const creationFieldDataValidationJson = {
       stateName: "text",
       stateOrTerritory: "text",
       submissionCount: "number",
@@ -171,7 +170,7 @@ export const createReport = handler(
 
     // Setup validation for what we expect to see in the payload
     let validatedFieldData = await validateFieldData(
-      creationValidationJson,
+      creationFieldDataValidationJson,
       unvalidatedFieldData
     );
 

--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -283,7 +283,7 @@ const firstQuarterOfThePeriod = (
     type: `${field.type}`,
     props: {
       content:
-        reportPeriod == 1
+        reportPeriod === 1
           ? "First quarter (January 1 - March 31)"
           : "Third quarter (July 1 - September 30)",
     },
@@ -300,7 +300,7 @@ const secondQuarterOfThePeriod = (
     type: `${field.type}`,
     props: {
       content:
-        reportPeriod == 1
+        reportPeriod === 1
           ? "Second quarter (April 1 - June 30)"
           : "Fourth quarter (October 1 - December 31)",
     },
@@ -425,12 +425,12 @@ export const quantitativeQuarters = (
 
   if (objectiveToUse?.evaluationPlan_includesTargets?.[0]?.value === "Yes") {
     const headingStringFirstQuarter =
-      reportPeriod == 1
+      reportPeriod === 1
         ? "First quarter (January 1 - March 31)"
         : "Third quarter (July 1 - September 30)";
 
     const headingStringSecondQuarter =
-      reportPeriod == 1
+      reportPeriod === 1
         ? "Second quarter (April 1 - June 30)"
         : "Fourth quarter (October 1 - December 31)";
 

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -92,14 +92,12 @@ export const AddEditReportModal = ({
   const prepareSarPayload = (formData: any) => {
     const submissionName = formData["associatedWorkPlan"];
     const stateOrTerritory = formData["stateOrTerritory"];
-    const reportPeriod = formData["reportPeriod"];
     const populations = formData["populations"];
     const finalSar = formData["finalSar"];
     return {
       metadata: {
         submissionName,
         stateOrTerritory,
-        reportPeriod,
         lastAlteredBy: full_name,
         locked: false,
         previousRevisions: [],
@@ -109,7 +107,6 @@ export const AddEditReportModal = ({
       fieldData: {
         submissionName,
         stateOrTerritory,
-        reportPeriod,
       },
     };
   };


### PR DESCRIPTION
Deployed env: https://d1evf704f7yu4c.cloudfront.net/

### Description
<!-- Detailed description of changes and related context -->

- Remove `reportPeriod` from create payload
- Remove `reportPeriod` from field data schema
- Tighten up reportPeriod equalities to type check

**Feedback** do we need to modify this [add/edit SAR definition](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/ui-src/src/forms/addEditSarReport/addEditSarReport.json#L32-L34)? I think our edit buttons were disabled anyway 🤔 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3477

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Test WP and SAR creation.
No change to app functionality. No new errors.
I created some reports on `stateuser1` if you want to verify any data from those

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment