### PR TITLE
Fix Artifact Upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,10 +48,15 @@ jobs:
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
+        #if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: unit_test_results
-          path: ${{github.workspace}}/services/ui-src/coverage/lcov.info
+          path: |
+            ${{github.workspace}}/services/app-api/coverage/lcov.info
+            ${{github.workspace}}/services/ui-src/coverage/lcov.info
+          retention-days: 14
 
   deploy:
     needs: unit-tests
@@ -225,12 +230,14 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        if: failure()
+        #if: failure()
+        if: always()
         with:
-          name: cypress-screenshots
+          name: cypress-artifacts
           path: |
-            tests/cypress/screenshots/
-            tests/cypress/videos/
+            ${{github.workspace}}/tests/screenshots/
+            ${{github.workspace}}/tests/videos/
+          retention-days: 14
 
   a11y-tests:
     name: E2E A11y Tests
@@ -257,12 +264,14 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        if: failure()
+        #if: failure()
+        if: always()        
         with:
-          name: cypress-screenshots
+          name: a11y-artifacts
           path: |
-            tests/cypress/screenshots/
-            tests/cypress/videos/
+            ${{github.workspace}}/tests/screenshots/
+            ${{github.workspace}}/tests/videos/
+          retention-days: 14
 
   cleanup:
     name: Delist GHA Runner CIDR Blocks

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit_test_results
+          name: unit-test-results
           path: |
             ${{github.workspace}}/services/app-api/coverage/lcov.info
             ${{github.workspace}}/services/ui-src/coverage/lcov.info
@@ -233,7 +233,7 @@ jobs:
         #if: failure()
         if: always()
         with:
-          name: cypress-artifacts
+          name: cypress-test-results
           path: |
             ${{github.workspace}}/tests/screenshots/
             ${{github.workspace}}/tests/videos/
@@ -267,7 +267,7 @@ jobs:
         #if: failure()
         if: always()        
         with:
-          name: a11y-artifacts
+          name: a11y-test-results
           path: |
             ${{github.workspace}}/tests/screenshots/
             ${{github.workspace}}/tests/videos/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,7 @@ jobs:
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results
-        #if: failure()
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-results
@@ -230,8 +229,7 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        #if: failure()
-        if: always()
+        if: failure()
         with:
           name: cypress-test-results
           path: |
@@ -264,8 +262,7 @@ jobs:
           CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        #if: failure()
-        if: always()        
+        if: failure()
         with:
           name: a11y-test-results
           path: |


### PR DESCRIPTION
### Description
There were a few problem with the artifact upload:

- Unit tests were configuration in such a way that they would probably not upload artifacts should the tests fail (this is an unverified assumption).  Also api unit tests were not being packaged.
- Cypress and A11y test paths pointed to directories one level deeper than they were actually being stored.
- Cypress and A11y artifact name would produce a collision and fail the job, so if both failed, the slower job would not be able to upload artifacts
- No retention was set so it would default to 90 days.  I picked 14 because I wouldn't expect to need to retrieve artifacts from a build older than 2 weeks


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3551

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
I pushed a build set to always upload artifacts.  The artifacts can be seen to be correctly publishing [here](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/8742532084).  A successful build will not produce artifacts.


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
