### PR TITLE
[CMDCT-3412, CMDCT-3416]: Fix errors & warnings

### DIFF
--- a/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsOverlaySection.tsx
@@ -31,7 +31,7 @@ export const ExportedEntityDetailsOverlaySection = ({
   const { report } = useStore() ?? {};
 
   return (
-    <Box as="td" sx={sx.sectionHeading} {...props}>
+    <Box sx={sx.sectionHeading}>
       {report &&
         renderEntityDetailTables(
           report,

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.test.tsx
@@ -89,7 +89,6 @@ const exportedEntityDetailsTableComponent = () => (
     <ExportedEntityDetailsTable
       fields={fields}
       entity={entity}
-      data-testid="exportedEntityDetailsTable"
     ></ExportedEntityDetailsTable>
   </ReportContext.Provider>
 );

--- a/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportedEntityDetailsTable.tsx
@@ -30,11 +30,10 @@ export const ExportedEntityDetailsTable = ({
     tableHeaders.indicator,
     tableHeaders.response,
   ];
-  const hideHintText = !props.showHintText;
 
   return (
     <Table
-      {...props}
+      data-testid="exportedEntityDetailsTable"
       sx={sx.root}
       content={{
         headRow: threeColumnHeaderItems,
@@ -44,7 +43,7 @@ export const ExportedEntityDetailsTable = ({
         fields!,
         "modalOverlay",
         report,
-        !hideHintText,
+        !!props.showHintText,
         entity.id,
         entityType
       )}

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -2,12 +2,11 @@ import { useStore } from "utils";
 // components
 import {
   EntityStatusIcon,
-  Table,
   ExportedEntityDetailsOverlaySection,
   Alert,
   ExportedOverlayModalReportSection,
 } from "components";
-import { Box, Heading, Image, Td, Text, Tr } from "@chakra-ui/react";
+import { Box, Flex, Heading, Image, Text } from "@chakra-ui/react";
 // types
 import {
   AlertTypes,
@@ -54,19 +53,14 @@ export const ExportedModalOverlayReportSection = ({ section }: Props) => {
           description={(alertVerbiage as AlertVerbiage)[entityType].description}
         />
       )}
-      <Table
-        sxOverride={{ container: { ...sx.container } }}
-        sx={sx.root}
-        content={{}}
-        data-testid="exportTable"
-      >
+      <Box sx={sx.container} data-testid="exportTable">
         {report?.fieldData[entityType] &&
           renderModalOverlayTableBody(
             section,
             report,
             report?.fieldData[entityType]
           )}
-      </Table>
+      </Box>
       {(!report?.fieldData[entityType] ||
         report?.fieldData[entityType].length === 0) && (
         <Text sx={sx.emptyState}> No entities found.</Text>
@@ -142,16 +136,16 @@ export function renderModalOverlayTableBody(
     case ReportType.WP:
       return entities.map((entity, idx) => {
         return (
-          <>
-            <Tr key={`${reportType}${idx}`}>
-              <Td sx={sx.statusIcon}>
+          <Box key={`${reportType}${idx}`}>
+            <Flex>
+              <Box sx={sx.statusIcon}>
                 <EntityStatusIcon
                   entity={entity}
                   isPdf={isPdf}
                   entityStatus={getInitiativeStatus(report, entity, isPdf)}
                 />
-              </Td>
-              <Td>
+              </Box>
+              <Box>
                 <Heading sx={sx.heading} as="h3">
                   {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
                   <br />
@@ -159,15 +153,15 @@ export function renderModalOverlayTableBody(
                     {entity.initiative_wpTopic[0].value}
                   </Text>
                 </Heading>
-              </Td>
-            </Tr>
+              </Box>
+            </Flex>
             {/* Depending on what the entity step type is, render its corresponding component */}
             {entitySteps.map((step, stepIdx) => {
               const type = step[0].toString();
               switch (type) {
                 case EntityDetailsStepTypes.DEFINE_INITIATIVE:
                   return (
-                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
+                    <Box key={`${type}${idx}${stepIdx}`}>
                       <ExportedEntityDetailsOverlaySection
                         section={section as ModalOverlayReportPageShape}
                         entity={entity}
@@ -178,7 +172,7 @@ export function renderModalOverlayTableBody(
                   );
                 case OverlayModalStepTypes.EVALUATION_PLAN:
                   return (
-                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
+                    <Box key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
@@ -188,7 +182,7 @@ export function renderModalOverlayTableBody(
                   );
                 case OverlayModalStepTypes.FUNDING_SOURCES:
                   return (
-                    <Box as="tr" key={`${type}${idx}${stepIdx}`}>
+                    <Box key={`${type}${idx}${stepIdx}`}>
                       <ExportedOverlayModalReportSection
                         section={section as OverlayModalPageShape}
                         entity={entity}
@@ -199,10 +193,9 @@ export function renderModalOverlayTableBody(
                 case EntityDetailsStepTypes.CLOSE_OUT_INFORMATION:
                   //clean up title
                   step[1] = (step[1] as string).replace(" (if applicable)", "");
-
                   return (
                     entity?.isInitiativeClosed && (
-                      <Box as="tr" key={`${type}${idx}${stepIdx}`}>
+                      <Box key={`${type}${idx}${stepIdx}`}>
                         <ExportedEntityDetailsOverlaySection
                           section={section as ModalOverlayReportPageShape}
                           entity={entity}
@@ -217,22 +210,22 @@ export function renderModalOverlayTableBody(
                   return <></>;
               }
             })}
-          </>
+          </Box>
         );
       });
     case ReportType.SAR:
       return entities.map((entity, idx) => {
         return (
-          <>
-            <Tr key={`${reportType}${idx}`}>
-              <Td sx={sx.statusIcon}>
+          <Box key={`${reportType}${idx}`}>
+            <Flex>
+              <Box sx={sx.statusIcon}>
                 <EntityStatusIcon
                   entity={entity}
                   isPdf={isPdf}
                   entityStatus={getInitiativeStatus(report, entity, isPdf)}
                 />
-              </Td>
-              <Td>
+              </Box>
+              <Box>
                 <Heading sx={sx.heading} as="h2">
                   {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
                   <br />
@@ -240,14 +233,14 @@ export function renderModalOverlayTableBody(
                     {entity.initiative_wpTopic[0].value}
                   </Text>
                 </Heading>
-              </Td>
-            </Tr>
+              </Box>
+            </Flex>
             {dynamicSection[idx].entitySteps.map(
               (step: any, stepIdx: number) => {
                 switch (step.stepType) {
                   case OverlayModalStepTypes.OBJECTIVE_PROGRESS:
                     return (
-                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
+                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
                         <ExportedOverlayModalReportSection
                           section={dynamicSection[idx] as OverlayModalPageShape}
                           entity={entity}
@@ -257,7 +250,7 @@ export function renderModalOverlayTableBody(
                     );
                   case EntityDetailsStepTypes.INITIAVTIVE_PROGRESS:
                     return (
-                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
+                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
                         <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
@@ -278,7 +271,7 @@ export function renderModalOverlayTableBody(
                       tableSection.form.fields.pop();
 
                     return (
-                      <Box as="tr" key={`${step.stepType}${idx}${stepIdx}`}>
+                      <Box key={`${step.stepType}${idx}${stepIdx}`}>
                         <ExportedEntityDetailsOverlaySection
                           section={step}
                           entity={entity}
@@ -293,7 +286,7 @@ export function renderModalOverlayTableBody(
                 }
               }
             )}
-          </>
+          </Box>
         );
       });
     default:

--- a/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedOverlayModalReportSection.tsx
@@ -32,12 +32,7 @@ export const ExportedOverlayModalReportSection = ({
     }
   );
   return (
-    <Box
-      as="td"
-      mt="2rem"
-      data-testid="exportedOverlayModalPage"
-      sx={sx.container}
-    >
+    <Box mt="2rem" data-testid="exportedOverlayModalPage" sx={sx.container}>
       <Heading as="h4">
         <Box sx={sx.stepName}>{title}</Box>
         <Box sx={sx.stepHint}>{info || hint}</Box>

--- a/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.test.tsx
@@ -183,7 +183,7 @@ describe("Test AddEditEntityModal functionality", () => {
     });
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
@@ -211,7 +211,7 @@ describe("Test AddEditEntityModal functionality", () => {
     ];
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
 

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.test.tsx
@@ -278,7 +278,7 @@ describe("Test AddEditOverlayEntityModal functionality", () => {
     expect(mockUpdateReport).toHaveBeenCalledTimes(1);
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
 
@@ -314,7 +314,7 @@ describe("Test AddEditOverlayEntityModal functionality", () => {
     ];
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
 

--- a/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
+++ b/services/ui-src/src/components/modals/DeleteEntityModal.test.tsx
@@ -199,7 +199,7 @@ describe("Test DeleteEntityModal functionality", () => {
     };
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
 
@@ -221,7 +221,7 @@ describe("Test DeleteEntityModal functionality", () => {
     };
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
   });
@@ -241,7 +241,7 @@ describe("Test DeleteEntityModal functionality", () => {
     };
 
     expect(mockUpdateReport).toHaveBeenCalledWith(
-      mockReportKeys,
+      { ...mockReportKeys, id: "mock-wp-full-report-id" },
       expectedUpdateCallPayload
     );
   });

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -41,8 +41,8 @@ export const MobileDashboardTable = ({
             )}
             <Text sx={sxOverride.submissionNameText}>
               {report.submissionName}
-              {copyOverSubText(report, reportsByState)}
             </Text>
+            {copyOverSubText(report, reportsByState)}
           </Flex>
         </Box>
         {!isAdmin && reportType === "SAR" && report?.populations && (

--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -64,9 +64,7 @@ export const renderOverlayEntityDataCell = (
     !parentFieldCheckedChoiceIds?.includes(entity.id);
   return (
     <Box>
-      <Text>
-        {renderResponseData(formField, entity[formField.id], notApplicable)}
-      </Text>
+      {renderResponseData(formField, entity[formField.id], notApplicable)}
     </Box>
   );
 };

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -240,6 +240,7 @@ export const mockWPDynamoData = {
 
 export const mockWPFullReport = {
   ...mockReportKeys,
+  id: "mock-wp-full-report-id",
   reportType: "WP",
   formTemplate: mockReportJson,
   submissionName: "2023 - Alabama 1",
@@ -267,6 +268,7 @@ export const mockWPFullReport = {
 
 export const mockWPCopiedReport = {
   ...mockReportKeys,
+  id: "mock-wp-copied-report-id",
   reportType: "WP",
   formTemplate: mockReportJson,
   submissionName: "2023 - Alabama 1",
@@ -295,6 +297,7 @@ export const mockWPCopiedReport = {
 
 export const mockSARFullReport = {
   ...mockReportKeys,
+  id: "mock-sar-full-report-id",
   reportType: "SAR",
   formTemplate: mockReportJson,
   submissionName: "2023 - Alabama 1",
@@ -321,6 +324,7 @@ export const mockSARFullReport = {
 
 export const mockWPSubmittedReport = {
   ...mockReportKeys,
+  id: "mock-wp-submitted-report-id",
   reportType: "WP",
   formTemplate: mockReportJson,
   submissionName: "2023 - Alabama 1",
@@ -346,6 +350,7 @@ export const mockWPSubmittedReport = {
 
 export const mockWPApprovedFullReport = {
   ...mockReportKeys,
+  id: "mock-wp-approved-full-report-id",
   reportType: "WP",
   formTemplate: mockReportJson,
   submissionName: "2023 - Alabama 1",

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -6270,9 +6270,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332:
-  version "1.0.30001442"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+  version "1.0.30001611"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz"
+  integrity sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We have several pesky console warnings that appear both in-app and when running unit tests.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3412, CMDCT-3416

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run the following unit tests and observe that the associated console errors do not appear: 
1. `DashboardPage.test.tsx`:  
    - _Warning: Encountered two children with the same key, `mock-report-id`._
2. `ExportedEntityDetailsTable.test.tsx`: 
    - _Warning: validateDOMNesting(...): `<p>` cannot appear as a descendant of `<p>`._
    - _Warning: React does not recognize the `showHintText` prop on a DOM element._
3. `ExportedReportWrapper.test.tsx`:
    - _Warning: Each child in a list should have a unique "key" prop._

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
