### PR TITLE
invoke cleanup at the end of .sh

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -54,6 +54,4 @@ jobs:
         run: ./.github/github-lock.sh $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Delete topics
-        run: run deleteTopics --stage $STAGE_NAME
       - run: ./scripts/destroy.sh $STAGE_PREFIX$branch_name

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -183,3 +183,10 @@ apiGatewayExecutionLogs=($(aws logs describe-log-groups --query "logGroups[*].lo
 if [[ -n $apiGatewayExecutionLogs ]]; then
   aws logs delete-log-group --log-group-name $apiGatewayExecutionLogs
 fi
+
+# Cleanup bigmac topics for branch
+data='{"project":"mfp","stage":"'"$stage"'"}'
+pushd services/topics
+install_deps
+sls invoke --stage main --function deleteTopics --data $data
+popd


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add the cleanup process to the end of the destroy.sh rather than attempting to invoke it in the destroy.yml.

This should resolve failing destroys going forward

Note: this invokes main's destroy topics command, as we're setup to only allow that lambda to do the cleanup process. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
