### PR TITLE
Upgrade cypress to resolve vulkan issue

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "axe-core": "^4.8.4",
-    "cypress": "^13.6.6",
+    "cypress": "^13.8.0",
     "cypress-axe": "^1.5.0"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -321,10 +321,10 @@ cypress-axe@^1.5.0:
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.5.0.tgz#95082734583da77b51ce9b7784e14a442016c7a1"
   integrity sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==
 
-cypress@^13.6.6:
-  version "13.6.6"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.6.tgz#5133f231ed1c6e57dc8dcbf60aade220bcd6884b"
-  integrity sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==
+cypress@^13.8.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.8.0.tgz#118e94161334e03841714c9b9b3600ae853c11f9"
+  integrity sha512-Qau//mtrwEGOU9cn2YjavECKyDUwBh8J2tit+y9s1wsv6C3BX+rlv6I9afmQnL8PmEEzJ6be7nppMHacFzZkTw==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
[Cypress changelog](https://docs.cypress.io/guides/references/changelog#13-8-0)
In version 13.7.3 cypress fixed* an issue with the vulkan warnings in CI environments. Although it's not a great solution, I'm hoping this will reduce errors and retries on our end.

*[suppressed the warning](https://github.com/cypress-io/cypress/pull/29278/files#diff-97683c9a2857a02cef5d6db17bfc7c2bb6957e10b38b1f62dfc387c6031ea2f0R76)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Original push to this branch](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/8757012526/job/24035933456#step:3:101) (no changes)
[CI run after upgrade](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/8757044196/job/24036535448#step:3:80) didn't show warning on the same test, or any

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
