### PR TITLE
Fixing slack endpoint notification

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -34,7 +34,7 @@ jobs:
         id: getendpoint
         run: |
           set +e
-          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name om-ui-infra-master --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
+          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name ui-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
           set -e
           if [[ -z $application_endpoint_url || ! $application_endpoint_url == http* ]]; then
               application_endpoint_url="endpoint not found"


### PR DESCRIPTION
### Description
ran into a scenario where if a pull request is opened before an environment is deployed the pr-notification workflow was failing. 

This fixes that scenario by allowing the notification to run all the way through and alerts to the integrations channel that the endpoint does not exist but still links the pr. 

in reality we shouldnt really be doing this as developers but it accounts for the scenario. The valid scenario here is where snyk opens a PR immediately and before an endpoint exists. This was exiting and erroring out before it got to the conditional that says oh you're a snyk branch dont send a notification anyway. 


### Related ticket(s)
-

---
### How to test
i testing this on a snyk branch already 
![Screenshot 2024-04-19 at 1 09 50 PM](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/52459927/a55fc665-5c5d-443b-b683-04ed182229c2)


### Notes
will port these over to all the open pr's 


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
