### PR TITLE
3541 - Change validation for quarterly projections in WP

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1062,12 +1062,15 @@
                           "children": [
                             {
                               "id": "quarterlyProjections",
-                              "type": "number",
+                              "type": "text",
                               "validation": {
-                                "type": "number",
+                                "type": "text",
                                 "parentFieldName": "evaluationPlan_includesTargets",
                                 "parentOptionId": "evaluationPlan_includesTargets-7FP4jcg4jK7Ssqp3cCW5vQ",
                                 "nested": true
+                              },
+                              "props": {
+                                "className": "number-field"
                               },
                               "transformation": {
                                 "rule": "nextTwelveQuarters"

--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1050,7 +1050,7 @@
                     "validation": "radio",
                     "props": {
                       "label": "Does the performance measure include quantitative targets?",
-                      "hint": "Note: If 'Yes', fields use calendar year quarters. Fields require whole numbers. Enter N/A for quarters you do not expect to report.",
+                      "hint": "Fields allow percentages or numbers. If you wish to report percentages, enter the number in the fields and the percentage sign “%”. Enter N/A for quarters you do not expect to report.",
                       "choices": [
                         {
                           "id": "UL4dAeyyvCFAXttxZioacR",

--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -457,10 +457,11 @@ export const quantitativeQuarters = (
 
       const formFieldActual: FormField = {
         id: `objectiveTargets_actual_${reportYear}Q${quarterNumber}`,
-        type: "number",
-        validation: "number",
+        type: "text",
+        validation: "text",
         props: {
           label: "Actual value",
+          className: "number-field",
         },
       };
       fieldsToAppend.push(formFieldActual);

--- a/services/app-api/utils/transformations/transformations.ts
+++ b/services/app-api/utils/transformations/transformations.ts
@@ -467,12 +467,13 @@ export const quantitativeQuarters = (
 
       const formFieldTarget: FormField = {
         id: `objectiveTargets_projections_${reportYear}Q${quarterNumber}`,
-        type: "number",
-        validation: "number",
+        type: "text",
+        validation: "text",
         props: {
           label: "Target Value",
           hint: "Auto-populates from Work Plan.",
           disabled: true,
+          className: "number-field",
         },
       };
       fieldsToAppend.push(formFieldTarget);

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -221,7 +221,11 @@ const sx = {
   ".ds-c-field": {
     margin: "0.5rem 0 0.25rem",
   },
-
+  ".number-field .ds-c-field": {
+    maxWidth: "15rem",
+    paddingLeft: ".5rem",
+    paddingRight: ".5rem",
+  },
   // disabled field
   ".ds-c-field[disabled]": {
     color: "palette.base",

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -15,8 +15,8 @@ describe("entity utilities", () => {
             value: "Yes",
           },
         ],
-        quarterlyProjections2023Q1: "mock projections 2023-1",
-        quarterlyProjections2023Q2: "mock projections 2023-2",
+        quarterlyProjections2023Q1: "99%",
+        quarterlyProjections2023Q2: "99.9%",
         evaluationPlan_additionalDetails: "mock details",
       };
 
@@ -31,8 +31,8 @@ describe("entity utilities", () => {
         targets: "mock targets",
         includesTargets: "Yes",
         quarters: [
-          { id: "2023 Q1", value: "mock projections 2023-1" },
-          { id: "2023 Q2", value: "mock projections 2023-2" },
+          { id: "2023 Q1", value: "99%" },
+          { id: "2023 Q2", value: "99.9%" },
         ],
         additionalDetails: "mock details",
       });

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,5 +1,4 @@
 import { EntityShape, OverlayModalStepTypes, AnyObject } from "types";
-import { convertToThousandsSeparatedString } from "utils";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
   const radioLabelValue = entity?.[label]?.[0].value;
@@ -18,10 +17,12 @@ const getRepeatedField = (
     for (const [key, value] of Object.entries(entity)) {
       if (key.includes(repeatedKey) && value) {
         const id = key.replace(repeatedKey, "").split("Q");
-        const displayValue =
-          repeatedKey === "fundingSources_quarters"
-            ? `$${value}`
-            : convertToThousandsSeparatedString(value).maskedValue;
+        let displayValue = `${value}`;
+
+        if (repeatedKey === "fundingSources_quarters") {
+          displayValue = `$${value}`;
+        }
+
         quarters.push({ id: `${id[0]} Q${id[1]}`, value: displayValue });
       }
     }


### PR DESCRIPTION
### Description
Changes validation for _quarterly projection_ "number" fields in the WP so that users can enter whole numbers OR percentages.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3541

---
### How to test
**Test link: **https://d3ozpalbymoth5.cloudfront.net/
User with plans: `stateuser@test.com` / PR / Puerto Rico

#### Work plan:
1. Create a work plan and go the the State or Territory-Specific Initiatives section.
2. Add a new initiative and in the Evaluation Plan section, click "Add objective."
3. In the Add Objective modal, select Yes for "Does the performance measure include quantitative targets?"
    - The quarterly objectives fields should allow user to enter any text, not just numbers. (e.g., "50%" should be a valid input)
    - The validation for required should still work. 
    - There should be no masking of input.
    - The styling of the input should look the same as other number fields (slightly less wide than normal text inputs).

<img width="587" alt="Screenshot 2024-04-26 at 11 24 57 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/592cf313-e229-4083-b378-66c984e7f279">

#### SAR:

1. Create a SAR associated with the previous work plan
2. In the State or Territory-Specific Initiatives section, open a specific initiative dashboard, and select Edit for Objective Progress (be sure to pick one where quarterly projections were entered in the WP).
3. Click "Report objective progress" to open the modal.
    - The "Actual value" input fields should follow the same validation rules (styled like number inputs, but validated like text)
    - The "Target value" fields should have the values formatted the same way as they were when entered in the WP.
    
#### Regression test:
Other numerical inputs should behave the same as expected:

1. Funding source input fields are still masked as currency and only allow number inputs
2. Transition Benchmark projections should only allow whole integers or "N/A"

<img width="618" alt="Screenshot 2024-04-26 at 11 29 05 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/730b0079-4e89-40ed-bbe2-dacf4a96a815">

<img width="1270" alt="Screenshot 2024-04-26 at 11 19 44 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/72f2d73b-6cd3-448a-9d97-309a0f682bd0">


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
