### PR TITLE
Add handling for internal user

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -101,11 +101,12 @@ export const DashboardPage = ({ reportType }: Props) => {
   const dashboardVerbiage = dashboardVerbiageMap[reportType]!;
   const { intro, body } = dashboardVerbiage;
 
-  // if an admin has selected a state, retrieve it from local storage
+  // if an admin or a read-only user has selected a state, retrieve it from local storage
   const adminSelectedState = localStorage.getItem("selectedState") || undefined;
 
-  // if a user is an admin type, use the selected state, otherwise use their assigned state
-  const activeState = userIsAdmin ? adminSelectedState : userState;
+  // if a user is an admin or a read-only type, use the selected state, otherwise use their assigned state
+  const activeState =
+    userIsAdmin || userIsReadOnly ? adminSelectedState : userState;
 
   const showSarAlert =
     reportType === ReportType.SAR && !workPlanToCopyFrom && reportsToDisplay;

--- a/services/ui-src/src/types/users.ts
+++ b/services/ui-src/src/types/users.ts
@@ -2,8 +2,9 @@
 
 export enum UserRoles {
   ADMIN = "mdctmfp-bor", // "MDCT MFP Business Owner Representative"
-  HELP_DESK = "mdctmfp-help-desk", // "MDCT MFP Help Desk"
   APPROVER = "mdctmfp-approver", // "MDCT MFP Approver"
+  HELP_DESK = "mdctmfp-help-desk", // "MDCT MFP Help Desk"
+  INTERNAL = "mdctmfp-internal-user", // "MDCT MFP Internal User"
   STATE_USER = "mdctmfp-state-user", // "MDCT MFP State User"
 }
 

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -24,7 +24,6 @@ async function getReportsByState(reportType: string, state: string) {
   const request = {
     headers: { ...requestHeaders },
   };
-
   updateTimeout();
   const response = await API.get(
     "mfp",

--- a/services/ui-src/src/utils/auth/UserProvider.tsx
+++ b/services/ui-src/src/utils/auth/UserProvider.tsx
@@ -77,7 +77,8 @@ export const UserProvider = ({ children }: Props) => {
       const userCheck = {
         userIsAdmin:
           userRole === UserRoles.ADMIN || userRole === UserRoles.APPROVER,
-        userIsReadOnly: userRole === UserRoles.HELP_DESK,
+        userIsReadOnly:
+          userRole === UserRoles.HELP_DESK || userRole === UserRoles.INTERNAL,
         userIsEndUser: userRole === UserRoles.STATE_USER,
       };
       const currentUser: MFPUser = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This fixes two issues:
1. the frontend of MFP does not currently account for internal users at all
2. read-only users were not being handled correctly in the admin dashboard state selection form

Changes:
- Added internal user to valid users for the frontend
- Extended read-only user check to include internal user alongside help desk user
- Changed logic related to state selection so the correct state will be selected now

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Log in as internal user, navigate to dashboard, select state and WP, confirm it loads correctly.
2. Repeat the same as help desk user.
3. Repeat the same as state user to confirm no lost functionality.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
