### PR TITLE
3413 - Fix home page console errors and warnings

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -24,6 +24,7 @@ export const DropdownField = ({
   styleAsOptional,
   ...props
 }: Props) => {
+  const { ariaLabel } = props;
   // fetch the option values and format them if necessary
   const formatOptions = (options: DropdownOptions[] | string) => {
     let dropdownOptions: any[] = [];
@@ -142,13 +143,13 @@ export const DropdownField = ({
         name={name}
         id={name}
         label={labelText || ""}
+        ariaLabel={ariaLabel}
         options={formattedOptions}
         hint={parsedHint}
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
         errorMessage={errorMessage}
         value={displayValue?.value}
-        {...props}
       />
     </Box>
   );

--- a/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
+++ b/services/ui-src/src/forms/adminDashSelector/adminDashSelector.ts
@@ -35,7 +35,7 @@ export default {
       props: {
         hint: "Select state or territory:",
         options: dropdownOptions,
-        "aria-label":
+        ariaLabel:
           "List of states, including District of Columbia and Puerto Rico",
       },
     },


### PR DESCRIPTION
### Description
Fix console errors and warnings on the home page


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3413

---
### How to test
**Cloudfront URL: https://d2m59pw5vafr8o.cloudfront.net/** 

1. Log in to MFP as an admin user
2. Open the console in dev tools and make sure there is no console error about invalid property `autosave`
3. Run the unit tests for Homepage. There should be no console errors and no warnings about providing `ariaLabel` to the Dropdown component.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---


#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
