### PR TITLE
[3420, 3418] Fixing more console errors

### DIFF
--- a/services/app-api/utils/testing/mocks/mockForm.ts
+++ b/services/app-api/utils/testing/mocks/mockForm.ts
@@ -43,6 +43,7 @@ export const mockDropdownField = {
   props: {
     label: "mock dropdown field",
     options: "mock plans",
+    ariaLabel: "mock dropdown field",
   },
 };
 

--- a/services/ui-src/src/components/fields/ChoiceListField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.test.tsx
@@ -124,6 +124,7 @@ const mockNestedChildren = [
     type: "dropdown",
     props: {
       options: [...mockDropdownOptions],
+      ariaLabel: "test nest child dropdown",
     },
   },
 ];

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -136,7 +136,6 @@ export const DateField = ({
         value={displayValue}
         hint={parsedHint}
         errorMessage={errorMessage}
-        {...props}
       />
     </Box>
   );

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -162,7 +162,6 @@ export const NumberField = ({
           onBlur={onBlurHandler}
           value={displayValue}
           errorMessage={errorMessage}
-          {...props}
         />
         <SymbolOverlay
           fieldMask={mask}

--- a/services/ui-src/src/components/fields/TextAreaField.test.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.test.tsx
@@ -23,7 +23,7 @@ const textAreaFieldComponent = (
 describe("Test TextAreaField component", () => {
   test("TextAreaField is visible", () => {
     render(textAreaFieldComponent);
-    const textAreaField = screen.getByTestId("test-text-area-field");
+    const textAreaField = screen.getByRole("textbox");
     expect(textAreaField).toBeVisible();
   });
 });

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -72,7 +72,7 @@ describe("Test TextField component", () => {
     mockedUseStore.mockReturnValue(mockStateUserStore);
     mockGetValues("");
     render(textFieldComponent);
-    const textField = screen.getByTestId("test-text-field");
+    const textField = screen.getByRole("textbox");
     expect(textField).toBeVisible();
     jest.clearAllMocks();
   });

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -28,6 +28,7 @@ export const TextField = ({
   heading,
   ...props
 }: Props) => {
+  const { rows, multiline } = props;
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
 
@@ -135,6 +136,8 @@ export const TextField = ({
         onBlur={(e) => onBlurHandler(e)}
         errorMessage={errorMessage}
         value={displayValue}
+        rows={rows}
+        multiline={multiline}
       />
     </Box>
   );

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -135,7 +135,6 @@ export const TextField = ({
         onBlur={(e) => onBlurHandler(e)}
         errorMessage={errorMessage}
         value={displayValue}
-        {...props}
       />
     </Box>
   );

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -47,6 +47,7 @@ export const mockDropdownField = {
   props: {
     label: "mock dropdown field",
     options: "mock plans",
+    ariaLabel: "mock dropdown field",
   },
 };
 


### PR DESCRIPTION
### Description
Fixing more console errors in the unit tests


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3420
CMDCT-3418

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run the following test suites, notice no more console errors:

- ModalDrawerReportPage
- ModalOverlayReportPage
- ChoiceListField
- DateField
- NumberField
- TextField

