### PR TITLE
Create helper methods for retrieving report data

### DIFF
--- a/services/app-api/handlers/reports/approve.ts
+++ b/services/app-api/handlers/reports/approve.ts
@@ -1,5 +1,4 @@
 import handler from "../handler-lib";
-import { fetchReport } from "./fetch";
 // utils
 import dynamoDb from "../../utils/dynamo/dynamodb-lib";
 import { error, reportTables } from "../../utils/constants/constants";
@@ -7,9 +6,11 @@ import { hasPermissions } from "../../utils/auth/authorization";
 import { parseSpecificReportParameters } from "../../utils/auth/parameters";
 // types
 import { StatusCodes, UserRoles } from "../../utils/types";
+import { getReportMetadata } from "../../storage/reports";
 
-export const approveReport = handler(async (event, context) => {
-  const { allParamsValid, reportType } = parseSpecificReportParameters(event);
+export const approveReport = handler(async (event) => {
+  const { allParamsValid, reportType, state, id } =
+    parseSpecificReportParameters(event);
   if (!allParamsValid) {
     return {
       status: StatusCodes.BAD_REQUEST,
@@ -25,24 +26,16 @@ export const approveReport = handler(async (event, context) => {
     };
   }
 
-  // Get current report
-  const reportEvent = { ...event, body: "" };
-  const getCurrentReport = await fetchReport(reportEvent, context);
+  const currentReport = await getReportMetadata(reportType, state, id);
 
-  if (!getCurrentReport.body) {
+  if (!currentReport) {
     return {
       status: StatusCodes.NOT_FOUND,
       body: error.NO_MATCHING_RECORD,
     };
   }
 
-  const currentReport = JSON.parse(getCurrentReport.body);
-
   const reportTable = reportTables[reportType];
-
-  // Delete raw data prior to updating
-  delete currentReport.fieldData;
-  delete currentReport.formTemplate;
 
   // toggle archived status in report metadata table
   const reportMetadataParams = {

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -1,16 +1,6 @@
-import { QueryCommandInput } from "@aws-sdk/lib-dynamodb";
 import handler from "../handler-lib";
 // utils
-import dynamoDb from "../../utils/dynamo/dynamodb-lib";
-import s3Lib, {
-  getFieldDataKey,
-  getFormTemplateKey,
-} from "../../utils/s3/s3-lib";
-import {
-  error,
-  reportBuckets,
-  reportTables,
-} from "../../utils/constants/constants";
+import { error } from "../../utils/constants/constants";
 import {
   calculateCompletionStatus,
   isComplete,
@@ -21,7 +11,13 @@ import {
   parseStateReportParameters,
 } from "../../utils/auth/parameters";
 // types
-import { AnyObject, StatusCodes } from "../../utils/types";
+import { StatusCodes } from "../../utils/types";
+import {
+  getReportFieldData,
+  getReportFormTemplate,
+  getReportMetadata,
+  queryReportMetadatasForState,
+} from "../../storage/reports";
 
 export const fetchReport = handler(async (event, _context) => {
   const { allParamsValid, reportType, state, id } =
@@ -40,78 +36,46 @@ export const fetchReport = handler(async (event, _context) => {
     };
   }
 
-  const reportTable = reportTables[reportType];
-  const reportBucket = reportBuckets[reportType];
-
-  // Get current report metadata
-  const reportMetadataParams = {
-    TableName: reportTable,
-    Key: { state, id },
-  };
-
-  try {
-    const response = await dynamoDb.get(reportMetadataParams);
-    if (!response?.Item) {
-      return {
-        status: StatusCodes.NOT_FOUND,
-        body: error.NOT_IN_DATABASE,
-      };
-    }
-
-    const reportMetadata = response.Item as Record<string, any>;
-    const { formTemplateId, fieldDataId } = reportMetadata;
-
-    // Get form template from S3
-    const formTemplateParams = {
-      Bucket: reportBucket,
-      Key: getFormTemplateKey(formTemplateId),
-    };
-
-    const formTemplate = (await s3Lib.get(formTemplateParams)) as AnyObject; // TODO: strict typing
-    if (!formTemplate) {
-      return {
-        status: StatusCodes.NOT_FOUND,
-        body: error.MISSING_FORM_TEMPLATE,
-      };
-    }
-
-    // Get field data from S3
-    const fieldDataParams = {
-      Bucket: reportBucket,
-      Key: getFieldDataKey(state, fieldDataId),
-    };
-
-    const fieldData = (await s3Lib.get(fieldDataParams)) as AnyObject; // TODO: strict typing
-
-    if (!fieldData) {
-      return {
-        status: StatusCodes.NOT_FOUND,
-        body: error.NO_MATCHING_RECORD,
-      };
-    }
-
-    if (!reportMetadata.completionStatus) {
-      reportMetadata.completionStatus = await calculateCompletionStatus(
-        fieldData,
-        formTemplate
-      );
-      reportMetadata.isComplete = isComplete(reportMetadata.completionStatus);
-    }
-
-    return {
-      status: StatusCodes.SUCCESS,
-      body: {
-        ...reportMetadata,
-        formTemplate,
-        fieldData,
-      },
-    };
-  } catch (err) {
+  const reportMetadata = await getReportMetadata(reportType, state, id);
+  if (!reportMetadata) {
     return {
       status: StatusCodes.NOT_FOUND,
       body: error.NO_MATCHING_RECORD,
     };
   }
+
+  const fieldData = await getReportFieldData(reportMetadata);
+  if (!fieldData) {
+    return {
+      status: StatusCodes.NOT_FOUND,
+      body: error.NO_MATCHING_RECORD,
+    };
+  }
+
+  const formTemplate = await getReportFormTemplate(reportMetadata);
+  if (!formTemplate) {
+    return {
+      status: StatusCodes.NOT_FOUND,
+      body: error.NO_MATCHING_RECORD,
+    };
+  }
+
+  if (!reportMetadata.completionStatus) {
+    reportMetadata.completionStatus = await calculateCompletionStatus(
+      fieldData,
+      formTemplate
+    );
+    reportMetadata.isComplete = isComplete(reportMetadata.completionStatus);
+  }
+
+  return {
+    status: StatusCodes.SUCCESS,
+    body: {
+      ...reportMetadata,
+      formTemplate,
+      fieldData,
+    },
+  };
 });
 
 export const fetchReportsByState = handler(async (event, _context) => {
@@ -131,20 +95,7 @@ export const fetchReportsByState = handler(async (event, _context) => {
     };
   }
 
-  const reportTable = reportTables[reportType];
-
-  const queryParams: QueryCommandInput = {
-    TableName: reportTable,
-    KeyConditionExpression: "#state = :state",
-    ExpressionAttributeValues: {
-      ":state": state!,
-    },
-    ExpressionAttributeNames: {
-      "#state": "state",
-    },
-  };
-
-  const reportsByState = await dynamoDb.query(queryParams);
+  const reportsByState = await queryReportMetadatasForState(reportType, state);
 
   return {
     status: StatusCodes.SUCCESS,

--- a/services/app-api/storage/reports.test.ts
+++ b/services/app-api/storage/reports.test.ts
@@ -1,0 +1,132 @@
+// System under test
+import {
+  queryReportMetadatasForState,
+  getReportMetadata,
+  getReportFieldData,
+  getReportFormTemplate,
+} from "./reports";
+// Mocks
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+// Types
+import {
+  ReportFieldData,
+  ReportJson,
+  ReportMetadataShape,
+  ReportType,
+} from "../utils/types";
+
+const mockDynamo = mockClient(DynamoDBDocumentClient);
+const mockS3 = mockClient(S3Client);
+
+const mockReportMetadata = {
+  reportType: ReportType.WP,
+  state: "CO",
+  id: "abc",
+  fieldDataId: "def",
+  formTemplateId: "ghi",
+} as ReportMetadataShape;
+
+const mockReportFieldData = {
+  mockFieldId: "mockFieldValue",
+} as ReportFieldData;
+
+const mockReportFormTemplate = {
+  routes: [
+    {
+      form: {
+        fields: [
+          {
+            id: "mockFieldId",
+            validation: "text",
+          },
+        ],
+      },
+    },
+  ],
+} as ReportJson;
+
+describe("Report storage", () => {
+  beforeEach(() => {
+    mockDynamo.reset();
+    mockS3.reset();
+  });
+
+  it("Should call Dynamo to query report metadata for a state", async () => {
+    const mockQuery = jest.fn().mockResolvedValue({
+      Items: [mockReportMetadata],
+      LastEvaluatedKey: undefined,
+    });
+    mockDynamo.on(QueryCommand).callsFake(mockQuery);
+    const metadatas = await queryReportMetadatasForState(ReportType.WP, "CO");
+    expect(metadatas).toEqual([mockReportMetadata]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-wp-reports",
+        ExpressionAttributeValues: { ":state": "CO" },
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call Dynamo to get metadata for a specific report", async () => {
+    const mockGet = jest.fn().mockResolvedValue({
+      Item: mockReportMetadata,
+    });
+    mockDynamo.on(GetCommand).callsFake(mockGet);
+    const metadata = await getReportMetadata(ReportType.WP, "CO", "abc123");
+    expect(metadata).toBe(mockReportMetadata);
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-wp-reports",
+        Key: { state: "CO", id: "abc123" },
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call S3 to retrieve report field data", async () => {
+    const mockGet = jest.fn().mockResolvedValue({
+      Body: {
+        transformToString: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify(mockReportFieldData)),
+      },
+    });
+    mockS3.on(GetObjectCommand).callsFake(mockGet);
+    const fieldData = await getReportFieldData(mockReportMetadata);
+    expect(fieldData).toEqual(mockReportFieldData);
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: "database-local-wp",
+        Key: "fieldData/CO/def.json",
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call S3 to retrieve report form templates", async () => {
+    const mockGet = jest.fn().mockResolvedValue({
+      Body: {
+        transformToString: jest
+          .fn()
+          .mockResolvedValue(JSON.stringify(mockReportFormTemplate)),
+      },
+    });
+    mockS3.on(GetObjectCommand).callsFake(mockGet);
+    const formTemplate = await getReportFormTemplate(mockReportMetadata);
+    expect(formTemplate).toEqual(mockReportFormTemplate);
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: "database-local-wp",
+        Key: "formTemplates/ghi.json",
+      }),
+      expect.any(Function)
+    );
+  });
+});

--- a/services/app-api/storage/reports.ts
+++ b/services/app-api/storage/reports.ts
@@ -1,0 +1,91 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { GetCommand, paginateQuery } from "@aws-sdk/lib-dynamodb";
+import {
+  ReportFieldData,
+  ReportJson,
+  ReportMetadataShape,
+  ReportType,
+  State,
+} from "../utils/types/index";
+import {
+  createClient as createDynamoClient,
+  collectPageItems,
+} from "../utils/dynamo/dynamodb-lib";
+import {
+  createClient as createS3Client,
+  parseS3Response,
+} from "../utils/s3/s3-lib";
+import { reportBuckets, reportTables } from "../utils/constants/constants";
+
+const dynamoClient = createDynamoClient();
+const s3Client = createS3Client();
+
+/* METADATA (dynamo) */
+
+export const queryReportMetadatasForState = async (
+  reportType: ReportType,
+  state: State
+) => {
+  const table = reportTables[reportType];
+  const responsePages = paginateQuery(
+    { client: dynamoClient },
+    {
+      TableName: table,
+      KeyConditionExpression: "#state = :state",
+      ExpressionAttributeNames: { "#state": "state" },
+      ExpressionAttributeValues: { ":state": state },
+    }
+  );
+  const metadatas = await collectPageItems(responsePages);
+  return metadatas as ReportMetadataShape[];
+};
+
+export const getReportMetadata = async (
+  reportType: ReportType,
+  state: State,
+  id: string
+) => {
+  const table = reportTables[reportType];
+  const response = await dynamoClient.send(
+    new GetCommand({
+      TableName: table,
+      Key: { state, id },
+    })
+  );
+  return response.Item as ReportMetadataShape | undefined;
+};
+
+/* FIELD DATA (s3) */
+
+export const getReportFieldData = async ({
+  reportType,
+  state,
+  fieldDataId,
+}: Pick<ReportMetadataShape, "reportType" | "state" | "fieldDataId">) => {
+  const bucket = reportBuckets[reportType];
+  const response = await s3Client.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: `fieldData/${state}/${fieldDataId}.json`,
+    })
+  );
+  const fieldData = await parseS3Response(response);
+  return fieldData as ReportFieldData | undefined;
+};
+
+/* FORM TEMPLATES (s3) */
+
+export const getReportFormTemplate = async ({
+  reportType,
+  formTemplateId,
+}: Pick<ReportMetadataShape, "reportType" | "formTemplateId">) => {
+  const bucket = reportBuckets[reportType];
+  const response = await s3Client.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: `formTemplates/${formTemplateId}.json`,
+    })
+  );
+  const fieldData = await parseS3Response(response);
+  return fieldData as ReportJson | undefined;
+};

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -1,3 +1,5 @@
+import { ReportType } from "../types/reports";
+
 export const error = {
   // generic errors
   UNAUTHORIZED: "User is not authorized to access this resource.",
@@ -91,12 +93,12 @@ export enum States {
 
 // REPORTS
 
-export const reportTables = {
+export const reportTables: { [key in ReportType]: string } = {
   SAR: process.env.SAR_REPORT_TABLE_NAME!,
   WP: process.env.WP_REPORT_TABLE_NAME!,
 };
 
-export const reportBuckets = {
+export const reportBuckets: { [key in ReportType]: string } = {
   SAR: process.env.SAR_FORM_BUCKET!,
   WP: process.env.WP_FORM_BUCKET!,
 };

--- a/services/app-api/utils/dynamo/dynamodb-lib.test.ts
+++ b/services/app-api/utils/dynamo/dynamodb-lib.test.ts
@@ -1,4 +1,4 @@
-import dynamoLib, { getConfig } from "./dynamodb-lib";
+import dynamoLib, { collectPageItems, createClient } from "./dynamodb-lib";
 import {
   DeleteCommand,
   DynamoDBDocumentClient,
@@ -61,16 +61,46 @@ describe("Test DynamoDB Interaction API Build Structure", () => {
   });
 });
 
-describe("Checking Environment Variable Changes", () => {
-  test("Check if statement with DYNAMODB_URL set", () => {
-    process.env.DYNAMODB_URL = "mock url";
-    const config = getConfig();
-    expect(config).toHaveProperty("region", "localhost");
+describe("createClient", () => {
+  let originalUrl: string | undefined;
+  beforeAll(() => {
+    originalUrl = process.env.DYNAMODB_URL;
+  });
+  afterAll(() => {
+    process.env.DYNAMODB_URL = originalUrl;
   });
 
-  test("Check if statement with DYNAMODB_URL undefined", () => {
+  const getRegion = async (client: DynamoDBDocumentClient) => {
+    const configValue = client.config.region;
+    if (typeof configValue === "string") {
+      return configValue;
+    } else {
+      return await configValue();
+    }
+  };
+
+  it("should return a local client if DYNAMODB_URL is set", async () => {
+    process.env.DYNAMODB_URL = "mock url";
+    const client = createClient();
+    const region = await getRegion(client);
+    expect(region).toBe("localhost");
+  });
+
+  it("should return a live client if DYNAMODB_URL is undefined", async () => {
     delete process.env.DYNAMODB_URL;
-    const config = getConfig();
-    expect(config).toHaveProperty("region", "us-east-1");
+    const client = createClient();
+    const region = await getRegion(client);
+    expect(region).toBe("us-east-1");
+  });
+});
+
+describe("collectPageItems", () => {
+  it("should combine items from multiple pages into one array", async () => {
+    const mockPaginator = (async function* () {
+      yield { Items: [{ foo: "bar" }] };
+      yield { Items: [{ foo: "baz" }] };
+    })() as any;
+    const allItems = await collectPageItems(mockPaginator);
+    expect(allItems).toEqual([{ foo: "bar" }, { foo: "baz" }]);
   });
 });

--- a/services/app-api/utils/s3/s3-lib.ts
+++ b/services/app-api/utils/s3/s3-lib.ts
@@ -5,6 +5,7 @@ import {
   GetObjectCommandInput,
   GetObjectCommand,
   GetObjectRequest,
+  GetObjectCommandOutput,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { logger } from "../debugging/debug-lib";
@@ -27,10 +28,22 @@ const awsConfig = {
   logger,
 };
 
-export const getConfig = () => {
+const getConfig = () => {
   return process.env.S3_LOCAL_ENDPOINT ? localConfig : awsConfig;
 };
-const client = new S3Client(getConfig());
+
+export const createClient = () => new S3Client(getConfig());
+
+export const parseS3Response = async (response: GetObjectCommandOutput) => {
+  const stringBody = await response.Body?.transformToString();
+  if (!stringBody) {
+    logger.warn(`Empty response from S3`);
+    return undefined;
+  }
+  return JSON.parse(stringBody);
+};
+
+const client = createClient();
 
 export default {
   put: async (params: PutObjectCommandInput) =>

--- a/services/app-api/utils/testing/mocks/mockDynamo.ts
+++ b/services/app-api/utils/testing/mocks/mockDynamo.ts
@@ -1,5 +1,5 @@
 import sign from "jwt-encode";
-import { WPReportMetadata } from "../../types";
+import { ReportMetadataShape, ReportStatus, ReportType } from "../../types";
 import { mockReportKeys } from "../setupJest";
 
 export const mockApiKey = sign(
@@ -32,12 +32,12 @@ export const mockDynamoData = {
   lastAltered: 162515200000,
 };
 
-export const mockDynamoDataWPLocked: WPReportMetadata = {
+export const mockDynamoDataWPLocked: ReportMetadataShape = {
   ...mockReportKeys,
   archived: false,
-  reportType: "WP",
+  reportType: ReportType.WP,
   submissionName: "testProgram",
-  status: "Not started",
+  status: ReportStatus.NOT_STARTED,
   lastAlteredBy: "Thelonious States",
   fieldDataId: "mockReportFieldData",
   formTemplateId: "mockReportJson",
@@ -52,11 +52,11 @@ export const mockDynamoDataWPLocked: WPReportMetadata = {
   dueDate: "11/01/2021",
 };
 
-export const mockDynamoDataWPCompleted: WPReportMetadata = {
+export const mockDynamoDataWPCompleted: ReportMetadataShape = {
   ...mockReportKeys,
-  reportType: "WP",
+  reportType: ReportType.WP,
   submissionName: "testProgram",
-  status: "Not started",
+  status: ReportStatus.NOT_STARTED,
   lastAlteredBy: "Thelonious States",
   fieldDataId: "mockReportFieldData",
   formTemplateId: "mockReportJson",
@@ -68,7 +68,7 @@ export const mockDynamoDataWPCompleted: WPReportMetadata = {
   lastAltered: 162515200000,
   archived: false,
   submittedBy: "",
-  submittedOnDate: "",
+  submittedOnDate: 0,
   submissionCount: 0,
   locked: false,
   previousRevisions: [],

--- a/services/app-api/utils/testing/mocks/mockReport.ts
+++ b/services/app-api/utils/testing/mocks/mockReport.ts
@@ -79,7 +79,7 @@ export const mockWPDynamoData = {
 
 export const mockWPMetadata = {
   submissionName: "New Jersey MFP Work Plan 2023 - Period 2",
-  dueDate: 1699496172798,
+  dueDate: "11/08/2023",
   formTemplateId: "wp-form-template",
   lastAlteredBy: "Anthony Soprano",
   versionNumber: 2,
@@ -98,7 +98,9 @@ export const mockWPMetadata = {
     "/wp/general-information": true,
     "/wp/transition-benchmarks": false,
     "/wp/transition-benchmark-strategy": false,
-    "/wp/state-or-territory-specific-initiatives": [],
+    "/wp/state-or-territory-specific-initiatives": {
+      "/wp/state-or-territory-specific-initiatives/sub-route": true,
+    },
   },
   isComplete: false,
   formTemplate: {

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -1,5 +1,10 @@
 import { ServerSideEncryption } from "@aws-sdk/client-s3";
 
+process.env.WP_REPORT_TABLE_NAME = "local-wp-reports";
+process.env.SAR_REPORT_TABLE_NAME = "local-sar-reports";
+process.env.WP_FORM_BUCKET = "database-local-wp";
+process.env.SAR_FORM_BUCKET = "database-local-sar";
+
 export const mockS3PutObjectCommandOutput = {
   $metadata: { attempts: 1 },
   ETag: "some etag value",

--- a/services/app-api/utils/types/reportContext.ts
+++ b/services/app-api/utils/types/reportContext.ts
@@ -1,5 +1,5 @@
 import { Choice } from "./formFields";
-import { AnyObject, ErrorVerbiage, State } from "./other";
+import { AnyObject, CompletionData, ErrorVerbiage, State } from "./other";
 import { ReportJson, ReportType } from "./reports";
 
 // REPORT PROVIDER/CONTEXT
@@ -14,6 +14,10 @@ export interface ReportMetadataShape extends ReportKeys {
   // Main Report Information
   submissionName: string;
   status: ReportStatus;
+  fieldDataId: string;
+  formTemplateId: string;
+  completionStatus?: CompletionData;
+  isComplete?: boolean;
   // Who Touched It/Submitted It
   createdAt: number;
   lastAltered: number;
@@ -21,8 +25,12 @@ export interface ReportMetadataShape extends ReportKeys {
   submittedBy?: string;
   submitterEmail?: string;
   submittedOnDate?: number;
+  previousRevisions?: string[];
+  /** Do we ever USE the versionNumber on the ReportMetadata? Maybe not. */
+  versionNumber?: number;
   // Time Information
-  dueDate: number;
+  /** dueDate is formatted as MM/dd/yyyy */
+  dueDate: string;
   reportPeriod: number;
   reportYear: number;
   // Admin Use Cases
@@ -63,6 +71,7 @@ export interface ReportContextShape extends ReportContextMethods {
 export enum ReportStatus {
   NOT_STARTED = "Not started",
   IN_PROGRESS = "In progress",
+  IN_REVISION = "In revision",
   SUBMITTED = "Submitted",
   APPROVED = "Approved",
 }

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -1,5 +1,5 @@
 import { FormJson } from "./formFields";
-import { AnyObject, CompletionData, CustomHtmlElement, State } from "./other";
+import { AnyObject, CustomHtmlElement } from "./other";
 
 // REPORT STRUCTURE
 
@@ -230,35 +230,6 @@ export interface EntityOverlayPageVerbiage extends ReportPageVerbiage {
     closeOutModalBodyText?: string;
     closeOutModalConfirmButtonText?: string;
   };
-}
-
-// REPORT METADATA
-
-export interface ReportMetadata {
-  submissionName: string;
-  archived: boolean;
-  reportType: string;
-  submittedBy?: string;
-  createdAt: number;
-  lastAltered: number;
-  state: State;
-  id: string;
-  submittedOnDate?: string;
-  fieldDataId: string;
-  formTemplateId: string;
-  lastAlteredBy: string;
-  status: string;
-  isComplete: boolean;
-  completionStatus?: CompletionData;
-  reportPeriod: number;
-  reportYear: number;
-  dueDate: string;
-}
-
-export interface WPReportMetadata extends ReportMetadata {
-  locked: boolean;
-  submissionCount: number;
-  previousRevisions: string[];
 }
 
 export enum ReportType {

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -12,7 +12,7 @@ import {
 // utils
 import { validateFieldData } from "./completionValidation";
 
-export const isComplete = (completionStatus: CompletionData): Boolean => {
+export const isComplete = (completionStatus: CompletionData): boolean => {
   const flatten = (obj: AnyObject, out: AnyObject) => {
     Object.keys(obj).forEach((key) => {
       if (typeof obj[key] == "object") {


### PR DESCRIPTION
### Description
**Broad strokes**
  * Create a new directory for "storage" methods. Today, it will include helper methods for fetching report data stored in DynamoDB and S3. Eventually, it should include helper methods for _all_ Dynamo and S3 access. Possibly SSM access as well.
  * Tweak dynamodb-lib.ts and s3-lib.ts to expose their clients directly. Eventually, the wrapper methods should be completely removed; the storage helpers will provide sufficient abstraction.
  * Update all the report API endpoints to use the new storage helpers (except create).
    * In some cases this replaces direct calls to dynamo, making the storage helper a clear win for readability
    * In other cases this replaces internal calls to the fetch endpoint. This saves us `event` manipulation shenanigans, JSON deserialization, and usually two s3 calls (as we often don't need the field data or form template)
  * Update all the corresponding tests. Mocking the storage helpers is easier and clearer than mocking dynamodb-lib or DynamoDBDocumentClient.

**Detailed list of behavioral changes**
  * if fetch cannot find a form template, it returns a less specific error message (NO_MATCHING_RECORD instead of MISSING_FORM_TEMPLATE)
  * if release encounters an error during metadata get, it will return 500 instead of 404
  * if release encounters an error during field data get or form template get, it will return a more vague, less misleading error message along with its 500
  * if release cannot find field data, it will return 404 instead of quietly ignoring
  * if release cannot find form template, it will return 404 instead of 500
  * if submit encounters an error during field data get or form template get, it will return a more vague, less misleading error message along with its 500
  * if submit cannot find field data or form template, it will return 500 instead of quietly ignoring
  * if update cannot find field data, it will return 500 instead of quietly ignoring
  * if update cannot find form template, it will return 404 instead of 500
  * if S3 throws an error, it will bubble up past the deserialization function
  * if S3 returns a response with no body, or an empty body, we will log a warning about it

**Detailed list of transparent changes**
  * approve no longer calls fetch; it only needs metadata
  * archive no longer calls fetch; it only needs metadata
  * fetch now leverages the new methods
  * IN_REVISION report status is now dignified in app-api type definition
  * submit uses a `+ 1` instead of a `++submissionCount`
    * I believe the increment and decrement digraphs should generally be avoided; they do two things at once and that's weird.
    * Only one of the two things was relevant here, as we never read the value of `reportMetadata.submissionCount` afterward
    * For further discussion, see point 3 here: https://www.informit.com/articles/article.aspx?p=2425867
  * update no longer calls fetch; it calls helpers individually
  * reportTables and reportBuckets type definition changed to throw type error if we add a new report type without updating them
  * dynamo lib now exports createClient, so that the helper methods can bypass the client wrapper
  * dynamo lib now exports collectPageItems - the one part of the client wrapper that was not shallow
  * s3 lib now exports createClient, so that the helper methods can bypass the client wrapper
  * s3 lib now exports parseS3Respoonse, the non-shallow part of that wrapper
  * Some mock data changes, to align with the types
  * set some environment variables within setupJest, for convenience in tests
  * update ReportMetadataShape, to align with how our data actually looks
  * Remove ReportMetadata, WPReportMetadata - they were mostly redundant with ReportMetadataShape, and weren't even entirely accurate
  * Update signature on completionStatus.ts:isComplete for accuracy; a `Boolean` is not a `boolean`

**Follow-up work for future PRs**
  * Replace the few remaining report fetches with calls to these helper methods
    * We fetch field data during the report copy process
    * We fetch work plans during SAR creation
  * Create new helper methods for putting report data, probably named `putReportMetadata`, `putReportFieldData`, `putReportFormTemplate`, and use them
  * Create new helper methods for dealing with form template version info, probably `queryFormTemplateVersionByHash`, `getLatestFormTemplateVersionNumber`, and `putFormTemplateVersion`, and use them
  * Give Banners the same treatment as Reports
  * Maybe more, idk, we'll see.

### Related ticket(s)
n/a

---
### How to test
None of the behavioral changes are important, so it will be sufficient just to verify that none of our API endpoints error out.

### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- ~[ ] I have performed a self-review of my code~
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
