### PR TITLE
[CMDCT-3535] - Fix display value for currency data

### DIFF
--- a/services/ui-src/src/components/export/ExportEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportEntityDetailsTable.test.tsx
@@ -13,16 +13,16 @@ import { AnyObject, EntityShape } from "types";
 
 const expenditureRows = {
   ["row 1"]: [
-    { label: "Actual spending (First quarter: Mock)", value: 2 },
-    { label: "Projected spending (First quarter: Mock)", value: 6 },
-    { label: "Actual spending (Second quarter: Mock)", value: 2 },
-    { label: "Projected spending (Second quarter: Mock)", value: 6 },
+    { label: "Actual spending (First quarter: Mock)", value: "2" },
+    { label: "Projected spending (First quarter: Mock)", value: "6" },
+    { label: "Actual spending (Second quarter: Mock)", value: "2" },
+    { label: "Projected spending (Second quarter: Mock)", value: "6" },
   ],
   ["row 2"]: [
-    { label: "Actual spending (First quarter: Mock)", value: 4 },
-    { label: "Projected spending (First quarter: Mock)", value: 8 },
-    { label: "Actual spending (Second quarter: Mock)", value: 8 },
-    { label: "Projected spending (Second quarter: Mock)", value: 12 },
+    { label: "Actual spending (First quarter: Mock)", value: "4000" },
+    { label: "Projected spending (First quarter: Mock)", value: "8000" },
+    { label: "Actual spending (Second quarter: Mock)", value: "4000" },
+    { label: "Projected spending (Second quarter: Mock)", value: "12000" },
   ],
 };
 
@@ -59,6 +59,9 @@ const entity: EntityShape = {
 };
 
 describe("Test table functions specific for Expenditures", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   test("Test formatHeaderLabel functionality", () => {
     const headerLabels: string[] = expenditureRows["row 1"].map(
       (row) => row.label
@@ -77,7 +80,7 @@ describe("Test table functions specific for Expenditures", () => {
     formatColumns(expenditureRows, "expenditures");
     expect(expenditureRows["row 1"][2]).toStrictEqual({
       label: "Total actual spending",
-      value: "$4",
+      value: "$4.00",
     });
     expect(expenditureRows["row 1"][5]).toStrictEqual({
       label: "% of total projected spending",
@@ -85,11 +88,11 @@ describe("Test table functions specific for Expenditures", () => {
     });
     expect(expenditureRows["row 2"][2]).toStrictEqual({
       label: "Total actual spending",
-      value: "$12",
+      value: "$8,000.00",
     });
     expect(expenditureRows["row 2"][5]).toStrictEqual({
       label: "% of total projected spending",
-      value: "60.00%",
+      value: "40.00%",
     });
   });
 });

--- a/services/ui-src/src/components/export/ExportEntityDetailsTable.tsx
+++ b/services/ui-src/src/components/export/ExportEntityDetailsTable.tsx
@@ -4,6 +4,7 @@ import { Box } from "@chakra-ui/react";
 import { Table } from "components";
 // utils
 import { notAnsweredText } from "../../constants";
+import { convertToThousandsSeparatedString } from "utils";
 
 export const generateMainTable = (rows: AnyObject, caption?: string) => {
   const headerRow: string[] = generateTableHeader(rows, "Spending");
@@ -55,20 +56,26 @@ export const formatColumns = (rows: AnyObject, type: string) => {
     });
 
     cols.forEach((col: any[]) => {
-      const totalAcutual: number | string =
+      const totalActual: number | string =
         Number(col?.[0].value) + Number(col?.[1].value);
       const totalProjected: number | string =
         Number(col?.[2].value) + Number(col?.[3].value);
       col.map((data) => {
-        if (!isNaN(Number(data.value))) data.value = "$" + data.value;
+        if (!isNaN(Number(data.value)))
+          data.value =
+            "$" + convertToThousandsSeparatedString(data.value, 2).maskedValue;
         return data;
       });
 
       const perTotalProjected: number | string =
-        (totalAcutual / totalProjected) * 100;
+        (totalActual / totalProjected) * 100;
+      const formattedTotal = convertToThousandsSeparatedString(
+        totalActual.toString(),
+        2
+      ).maskedValue;
       col.splice(2, 0, {
         label: "Total actual spending",
-        value: totalAcutual ? `$${totalAcutual}` : "-",
+        value: totalActual ? `$${formattedTotal}` : "-",
       });
       col.push({
         label: "% of total projected spending",

--- a/services/ui-src/src/utils/reports/entities.test.ts
+++ b/services/ui-src/src/utils/reports/entities.test.ts
@@ -49,6 +49,8 @@ describe("entity utilities", () => {
         ],
         fundingSources_quarters2023Q1: "mock sources 2023-1",
         fundingSources_quarters2023Q2: "mock sources 2023-2",
+        fundingSources_quarters2023Q3: "25.75",
+        fundingSources_quarters2023Q4: "1000",
       };
 
       const result = getFormattedEntityData(
@@ -62,6 +64,8 @@ describe("entity utilities", () => {
         quarters: [
           { id: "2023 Q1", value: "$mock sources 2023-1" },
           { id: "2023 Q2", value: "$mock sources 2023-2" },
+          { id: "2023 Q3", value: "$25.75" },
+          { id: "2023 Q4", value: "$1,000.00" },
         ],
       });
     });

--- a/services/ui-src/src/utils/reports/entities.ts
+++ b/services/ui-src/src/utils/reports/entities.ts
@@ -1,4 +1,5 @@
 import { EntityShape, OverlayModalStepTypes, AnyObject } from "types";
+import { convertToThousandsSeparatedString } from "utils/other/mask";
 
 const getRadioValue = (entity: EntityShape | undefined, label: string) => {
   const radioLabelValue = entity?.[label]?.[0].value;
@@ -20,7 +21,8 @@ const getRepeatedField = (
         let displayValue = `${value}`;
 
         if (repeatedKey === "fundingSources_quarters") {
-          displayValue = `$${value}`;
+          const formattedValue = convertToThousandsSeparatedString(value, 2);
+          displayValue = `$${formattedValue.maskedValue}`;
         }
 
         quarters.push({ id: `${id[0]} Q${id[1]}`, value: displayValue });


### PR DESCRIPTION
### Description
Fixes display of large currency values to include commas


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3535

---
### How to test
Cloudfront: https://d67035zzzhyab.cloudfront.net/

`stateuser@test.com` has a WP and SAR with big numbers you can review

---

| Incorrect | Correct |
| --- | --- |
| $1000.00 | $1,000.00|
| $1000 | $1,000.00|

1. In a work plan, under the State or Territory-Specific Initiatives section, add a funding source. Include some numbers over 1,000 in the quarter fields.
2. After saving the funding source, the table in the card should display the large numbers in the correct format.
3. Review the PDF. The table for the funding source section should display the large numbers in the correct format.
4. Submit and approve the work plan, then create a SAR.
5. In the funding sources section, the large numbers should display in the correct format. Same for the PDF.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ x I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
