### PR TITLE
Add helpers for creating/updating reports and template versions

### DIFF
--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -1,18 +1,15 @@
 import { archiveReport } from "./archive";
 // utils
 import { proxyEvent } from "../../utils/testing/proxyEvent";
-import {
-  mockDynamoPutCommandOutput,
-  mockWPReport,
-} from "../../utils/testing/setupJest";
+import { mockWPReport } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
-import dynamodbLib from "../../utils/dynamo/dynamodb-lib";
-import { getReportMetadata } from "../../storage/reports";
+import { getReportMetadata, putReportMetadata } from "../../storage/reports";
 // types
 import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
 
 jest.mock("../../storage/reports", () => ({
   getReportMetadata: jest.fn(),
+  putReportMetadata: jest.fn(),
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
@@ -43,13 +40,11 @@ describe("Test archiveReport method", () => {
   });
 
   test("Test archive report passes with valid data", async () => {
-    const dynamoPutSpy = jest.spyOn(dynamodbLib, "put");
-    dynamoPutSpy.mockResolvedValue(mockDynamoPutCommandOutput);
     mockAuthUtil.hasPermissions.mockReturnValueOnce(true);
     (getReportMetadata as jest.Mock).mockResolvedValue(mockWPReport);
     const res: any = await archiveReport(archiveEvent, null);
     const body = JSON.parse(res.body);
-    expect(dynamoPutSpy).toHaveBeenCalled();
+    expect(putReportMetadata).toHaveBeenCalled();
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);
     expect(body.archived).toBe(true);
   });

--- a/services/app-api/handlers/reports/submit.test.ts
+++ b/services/app-api/handlers/reports/submit.test.ts
@@ -10,13 +10,13 @@ import {
   mockDynamoDataWPCompleted,
   mockReportFieldData,
   mockReportJson,
-  mockS3PutObjectCommandOutput,
 } from "../../utils/testing/setupJest";
-import s3Lib from "../../utils/s3/s3-lib";
 import {
   getReportFieldData,
   getReportFormTemplate,
   getReportMetadata,
+  putReportFieldData,
+  putReportMetadata,
 } from "../../storage/reports";
 // types
 import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
@@ -27,6 +27,8 @@ jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
   getReportFormTemplate: jest.fn(),
   getReportMetadata: jest.fn(),
+  putReportFieldData: jest.fn(),
+  putReportMetadata: jest.fn(),
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
@@ -60,8 +62,6 @@ describe("Test submitReport API method", () => {
     );
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
-    const s3PutSpy = jest.spyOn(s3Lib, "put");
-    s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
 
     const res = await submitReport(testSubmitEvent, null);
     const body = JSON.parse(res.body);
@@ -74,6 +74,8 @@ describe("Test submitReport API method", () => {
     expect(body.submittedBy).toStrictEqual("Thelonious States");
     expect(body.submittedOnDate).toBeTruthy();
     expect(body.locked).toBe(true);
+    expect(putReportMetadata).toHaveBeenCalled();
+    expect(putReportFieldData).toHaveBeenCalled();
   });
 
   test("Test WP reports get locked and have submission count updated.", async () => {
@@ -82,8 +84,6 @@ describe("Test submitReport API method", () => {
     );
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
-    const s3PutSpy = jest.spyOn(s3Lib, "put");
-    s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
 
     const res = await submitReport(testSubmitEvent, null);
     const body = JSON.parse(res.body);

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -1,6 +1,4 @@
 import { updateReport } from "./update";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
-import { mockClient } from "aws-sdk-client-mock";
 // utils
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import {
@@ -8,24 +6,24 @@ import {
   mockWPReport,
   mockReportFieldData,
   mockReportJson,
-  mockS3PutObjectCommandOutput,
 } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
-import s3Lib from "../../utils/s3/s3-lib";
 import {
   getReportFieldData,
   getReportFormTemplate,
   getReportMetadata,
+  putReportFieldData,
+  putReportMetadata,
 } from "../../storage/reports";
 // types
 import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
-
-const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
   getReportFormTemplate: jest.fn(),
   getReportMetadata: jest.fn(),
+  putReportFieldData: jest.fn(),
+  putReportMetadata: jest.fn(),
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
@@ -90,17 +88,12 @@ describe("Test updateReport API method", () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
-    dynamoClientMock.reset();
   });
 
   test("Test report update submission succeeds", async () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(mockDynamoData);
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
-    const s3PutSpy = jest.spyOn(s3Lib, "put");
-    s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
-    const mockPut = jest.fn();
-    dynamoClientMock.on(PutCommand).callsFake(mockPut);
 
     const response = await updateReport(submissionEvent, null);
     const body = JSON.parse(response.body);
@@ -108,22 +101,21 @@ describe("Test updateReport API method", () => {
     expect(body.status).toContain("submitted");
     expect(body.fieldData["mock-number-field"]).toBe("2");
     expect(response.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(mockPut).toHaveBeenCalled();
+    expect(putReportFieldData).toHaveBeenCalled();
+    expect(putReportMetadata).toHaveBeenCalled();
   });
 
   test("Test report update with invalid fieldData fails", async () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(mockDynamoData);
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
-    const s3PutSpy = jest.spyOn(s3Lib, "put");
-    s3PutSpy.mockResolvedValue(mockS3PutObjectCommandOutput);
-    const mockPut = jest.fn();
-    dynamoClientMock.on(PutCommand).callsFake(mockPut);
 
     const response = await updateReport(invalidFieldDataSubmissionEvent, null);
 
     expect(response.statusCode).toBe(StatusCodes.SERVER_ERROR);
     expect(response.body).toContain(error.INVALID_DATA);
+    expect(putReportFieldData).not.toHaveBeenCalled();
+    expect(putReportMetadata).not.toHaveBeenCalled();
   });
 
   test("Test attempted report update with invalid data throws 400", async () => {

--- a/services/app-api/storage/reports.test.ts
+++ b/services/app-api/storage/reports.test.ts
@@ -4,17 +4,29 @@ import {
   getReportMetadata,
   getReportFieldData,
   getReportFormTemplate,
+  putReportMetadata,
+  putReportFieldData,
+  putReportFormTemplate,
+  putFormTemplateVersion,
+  queryFormTemplateVersionByHash,
+  queryLatestFormTemplateVersionNumber,
 } from "./reports";
 // Mocks
 import { mockClient } from "aws-sdk-client-mock";
 import {
   DynamoDBDocumentClient,
   GetCommand,
+  PutCommand,
   QueryCommand,
 } from "@aws-sdk/lib-dynamodb";
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
 // Types
 import {
+  FormTemplateVersion,
   ReportFieldData,
   ReportJson,
   ReportMetadataShape,
@@ -51,10 +63,30 @@ const mockReportFormTemplate = {
   ],
 } as ReportJson;
 
+const mockFormTemplateVersion = {
+  id: "ghi",
+  reportType: ReportType.WP,
+  versionNumber: 7,
+  md5Hash: "0abc8def",
+} as FormTemplateVersion;
+
 describe("Report storage", () => {
   beforeEach(() => {
     mockDynamo.reset();
     mockS3.reset();
+  });
+
+  it("Should call Dynamo to put report metadata for a state", async () => {
+    const mockPut = jest.fn();
+    mockDynamo.on(PutCommand).callsFake(mockPut);
+    await putReportMetadata(mockReportMetadata);
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-wp-reports",
+        Item: mockReportMetadata,
+      }),
+      expect.any(Function)
+    );
   });
 
   it("Should call Dynamo to query report metadata for a state", async () => {
@@ -90,6 +122,20 @@ describe("Report storage", () => {
     );
   });
 
+  it("Should call S3 to store report field data", async () => {
+    const mockPut = jest.fn();
+    mockS3.on(PutObjectCommand).callsFake(mockPut);
+    await putReportFieldData(mockReportMetadata, mockReportFieldData);
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: "database-local-wp",
+        Key: "fieldData/CO/def.json",
+        Body: JSON.stringify(mockReportFieldData),
+      }),
+      expect.any(Function)
+    );
+  });
+
   it("Should call S3 to retrieve report field data", async () => {
     const mockGet = jest.fn().mockResolvedValue({
       Body: {
@@ -105,6 +151,20 @@ describe("Report storage", () => {
       expect.objectContaining({
         Bucket: "database-local-wp",
         Key: "fieldData/CO/def.json",
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call S3 to store report form templates", async () => {
+    const mockPut = jest.fn();
+    mockS3.on(PutObjectCommand).callsFake(mockPut);
+    await putReportFormTemplate(mockReportMetadata, mockReportFormTemplate);
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: "database-local-wp",
+        Key: "formTemplates/ghi.json",
+        Body: JSON.stringify(mockReportFormTemplate),
       }),
       expect.any(Function)
     );
@@ -128,5 +188,74 @@ describe("Report storage", () => {
       }),
       expect.any(Function)
     );
+  });
+
+  it("Should call Dynamo to store form template version info", async () => {
+    const mockPut = jest.fn();
+    mockDynamo.on(PutCommand).callsFake(mockPut);
+    await putFormTemplateVersion(mockFormTemplateVersion);
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-form-template-versions",
+        Item: mockFormTemplateVersion,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call Dynamo to query form template versions by hash", async () => {
+    const mockQuery = jest
+      .fn()
+      .mockResolvedValue({ Items: [mockFormTemplateVersion] });
+    mockDynamo.on(QueryCommand).callsFake(mockQuery);
+
+    const versionInfo = await queryFormTemplateVersionByHash(
+      ReportType.WP,
+      mockFormTemplateVersion.md5Hash
+    );
+
+    expect(versionInfo).toBe(mockFormTemplateVersion);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-form-template-versions",
+        ExpressionAttributeValues: {
+          ":reportType": "WP",
+          ":md5Hash": "0abc8def",
+        },
+        Limit: 1,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should call Dynamo to query form template version numbers", async () => {
+    const mockQuery = jest
+      .fn()
+      .mockResolvedValue({ Items: [mockFormTemplateVersion] });
+    mockDynamo.on(QueryCommand).callsFake(mockQuery);
+
+    const versionNumber = await queryLatestFormTemplateVersionNumber(
+      ReportType.WP
+    );
+
+    expect(versionNumber).toBe(7);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: "local-form-template-versions",
+        ExpressionAttributeValues: { ":reportType": "WP" },
+        Limit: 1,
+        ScanIndexForward: false,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("Should default to version 0 if there are no existing form templates", async () => {
+    const mockQuery = jest.fn().mockResolvedValue({ Items: [] });
+    mockDynamo.on(QueryCommand).callsFake(mockQuery);
+    const versionNumber = await queryLatestFormTemplateVersionNumber(
+      ReportType.WP
+    );
+    expect(versionNumber).toBe(0);
   });
 });

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -93,31 +93,20 @@ export enum States {
 
 // REPORTS
 
-export const reportTables: { [key in ReportType]: string } = {
-  SAR: process.env.SAR_REPORT_TABLE_NAME!,
-  WP: process.env.WP_REPORT_TABLE_NAME!,
-};
-
-export const reportBuckets: { [key in ReportType]: string } = {
-  SAR: process.env.SAR_FORM_BUCKET!,
-  WP: process.env.WP_FORM_BUCKET!,
-};
-
-export const reportNames = {
+export const reportNames: { [key in ReportType]: string } = {
   SAR: "SAR",
   WP: "Work Plan",
 };
 
-export const tableTopics = {
+export const tableTopics: { [key in ReportType]: string } = {
   SAR: "sar-reports",
   WP: "wp-reports",
 };
-export const bucketTopics = {
+
+export const bucketTopics: { [key in ReportType]: string } = {
   SAR: "sar-reports",
   WP: "wp-form",
 };
-
-export const formTemplateTableName = process.env.FORM_TEMPLATE_TABLE_NAME!;
 
 export const DEFAULT_TARGET_POPULATION_NAMES = [
   "Older adults",

--- a/services/app-api/utils/other/copy.test.ts
+++ b/services/app-api/utils/other/copy.test.ts
@@ -1,9 +1,9 @@
-import s3Lib from "../s3/s3-lib";
 import { copyFieldDataFromSource } from "./copy";
+import { getReportFieldData } from "../../storage/reports";
+import { ReportJson, ReportRoute, FormField } from "../types";
 
-jest.mock("../s3/s3-lib", () => ({
-  ...jest.requireActual("../s3/s3-lib"),
-  get: jest.fn(),
+jest.mock("../../storage/reports", () => ({
+  getReportFieldData: jest.fn(),
 }));
 
 describe("Field data copy", () => {
@@ -12,8 +12,8 @@ describe("Field data copy", () => {
   });
 
   test("Should copy validated fields", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
-      mockFieldId: 42,
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
+      mockFieldId: "42",
     });
     const fieldData = {};
     const formTemplate = {
@@ -29,10 +29,9 @@ describe("Field data copy", () => {
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -40,16 +39,16 @@ describe("Field data copy", () => {
     );
 
     expect(copiedData).toEqual({
-      mockFieldId: 42,
+      mockFieldId: "42",
     });
   });
 
   test("Should overwrite populated fields, apparently", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
-      mockFieldId: 42,
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
+      mockFieldId: "42",
     });
     const fieldData = {
-      mockFieldId: 255,
+      mockFieldId: "255",
     };
     const formTemplate = {
       routes: [
@@ -64,10 +63,9 @@ describe("Field data copy", () => {
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -75,21 +73,20 @@ describe("Field data copy", () => {
     );
 
     expect(copiedData).toEqual({
-      mockFieldId: 42,
+      mockFieldId: "42",
     });
   });
 
   test("Should not copy fields with no validation", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
-      mockFieldId: 42,
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
+      mockFieldId: "42",
     });
     const fieldData = {};
     const formTemplate = {
-      routes: [],
-    };
+      routes: [] as ReportRoute[],
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -100,20 +97,19 @@ describe("Field data copy", () => {
   });
 
   test("Should not copy entities with no validated fields", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
-          mockFieldId: 42,
+          mockFieldId: "42",
         },
       ],
     });
     const fieldData = {};
     const formTemplate = {
-      routes: [],
-    };
+      routes: [] as ReportRoute[],
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -124,10 +120,10 @@ describe("Field data copy", () => {
   });
 
   test("Should copy validated fields within entities", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
-          mockFieldId: 42,
+          mockFieldId: "42",
         },
       ],
     });
@@ -147,10 +143,9 @@ describe("Field data copy", () => {
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -160,14 +155,14 @@ describe("Field data copy", () => {
     expect(copiedData).toEqual({
       mockEntityType: [
         expect.objectContaining({
-          mockFieldId: 42,
+          mockFieldId: "42",
         }),
       ],
     });
   });
 
   test("Should copy special fields within entities", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
           mock_name_field: "mock name", // key includes the string "name"
@@ -190,14 +185,13 @@ describe("Field data copy", () => {
           drawerForm: {
             fields: [
               /* no validated fields, so anything copied is special */
-            ],
+            ] as FormField[],
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -222,10 +216,10 @@ describe("Field data copy", () => {
   });
 
   test("Should not copy closed initiatives", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
-          mockFieldId: 42,
+          mockFieldId: "42",
           isInitiativeClosed: true,
         },
       ],
@@ -246,10 +240,9 @@ describe("Field data copy", () => {
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -261,10 +254,10 @@ describe("Field data copy", () => {
   });
 
   test("Should wipe the entire entity if no fields are being copied", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
-          mockFieldId: 42,
+          mockFieldId: "42",
         },
       ],
     });
@@ -277,14 +270,13 @@ describe("Field data copy", () => {
           drawerForm: {
             fields: [
               /* no validated fields, therefore no copied fields */
-            ],
+            ] as FormField[],
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -295,12 +287,12 @@ describe("Field data copy", () => {
   });
 
   test("Should prune entity steps", async () => {
-    (s3Lib.get as jest.Mock).mockResolvedValueOnce({
+    (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockEntityType: [
         {
           mockSteps: [
             {
-              mockFieldId: 42,
+              mockFieldId: "42",
               mockExtraField: "not validated and thus not copied",
             },
           ],
@@ -323,10 +315,9 @@ describe("Field data copy", () => {
           },
         },
       ],
-    };
+    } as ReportJson;
 
     const copiedData = await copyFieldDataFromSource(
-      "mock-bucket-name",
       "CO",
       "mock-source-id",
       formTemplate,
@@ -338,7 +329,7 @@ describe("Field data copy", () => {
         {
           mockSteps: [
             {
-              mockFieldId: 42,
+              mockFieldId: "42",
               isCopied: true,
             },
           ],

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -1,4 +1,18 @@
-import { getReportPeriod, getReportYear } from "./other";
+import {
+  getReportPeriod,
+  getReportYear,
+  getLastCreatedWorkPlan,
+} from "./other";
+import {
+  getReportFieldData,
+  queryReportMetadatasForState,
+} from "../../storage/reports";
+import { ReportStatus } from "../types";
+
+jest.mock("../../storage/reports", () => ({
+  getReportFieldData: jest.fn(),
+  queryReportMetadatasForState: jest.fn(),
+}));
 
 const mockWPData = {
   reportType: "WP",
@@ -25,113 +39,175 @@ const mockUnvalidatedMetadata = {
   isReset: false,
 };
 
-describe("getReportYear", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+describe("API utility functions", () => {
+  describe("getReportYear", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return the report year for a new work plan", () => {
+      const reportData = {
+        ...mockUnvalidatedMetadata,
+        reportPeriod: 1,
+        reportYear: 2020,
+      };
+
+      const response = getReportYear(reportData, false);
+
+      expect(response).toEqual(2020);
+    });
+
+    it("should return the report year for a copied work plan", () => {
+      const reportData = {
+        ...mockUnvalidatedMetadata,
+        copyReport: { reportYear: 2020, reportPeriod: 1, isCopyOverTest: true },
+      };
+
+      const response = getReportYear(reportData, true);
+
+      expect(response).toEqual(2020);
+    });
+
+    it("should return the report year for a copied work plan with reportPeriod 2", () => {
+      const reportData = {
+        ...mockWPData,
+        copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
+      };
+
+      const response = getReportYear(reportData, true);
+
+      expect(response).toEqual(2021);
+    });
+
+    it("should return the report year for a SAR", () => {
+      const reportData = { ...mockWPData, reportPeriod: 1, reportYear: 2020 };
+      const response = getReportYear(reportData, false);
+
+      expect(response).toEqual(2020);
+    });
+
+    it("should throw an error if the report year is not a number", () => {
+      const reportData = { ...mockUnvalidatedMetadata, reportYear: "2020" };
+
+      expect(() => getReportYear(reportData, false)).toThrow(
+        "Invalid value for reportYear"
+      );
+    });
   });
 
-  it("should return the report year for a new work plan", () => {
-    const reportData = {
-      ...mockUnvalidatedMetadata,
-      reportPeriod: 1,
-      reportYear: 2020,
-    };
+  describe("getReportPeriod", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-    const response = getReportYear(reportData, false);
+    it("should return the report period for a new work plan", () => {
+      const reportData = {
+        ...mockUnvalidatedMetadata,
+        reportPeriod: 1,
+        reportYear: 2020,
+      };
 
-    expect(response).toEqual(2020);
+      const response = getReportPeriod(reportData, false);
+
+      expect(response).toEqual(1);
+    });
+
+    it("should return the report period for a copied work plan", () => {
+      const reportData = {
+        ...mockWPData,
+        copyReport: { isCopyOverTest: true, reportPeriod: 1, reportYear: 2020 },
+      };
+      const response = getReportPeriod(reportData, true);
+
+      expect(response).toEqual(2);
+    });
+
+    it("should return the report period for a copied work plan with reportPeriod 2", () => {
+      const reportData = {
+        ...mockWPData,
+        copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
+      };
+      const responsePeriod = getReportPeriod(reportData, true);
+
+      const responseYear = getReportYear(reportData, true);
+
+      expect(responsePeriod).toEqual(1);
+      expect(responseYear).toEqual(2021);
+    });
+
+    it("should return the report period for a SAR", () => {
+      const reportData = { ...mockWPData, reportPeriod: 1, reportYear: 2020 };
+      const response = getReportPeriod(reportData, false);
+
+      expect(response).toEqual(1);
+    });
+
+    it("should throw an error if the report period is not a number", () => {
+      const reportData = { ...mockUnvalidatedMetadata, reportPeriod: "2" };
+
+      expect(() => getReportPeriod(reportData, false)).toThrow(
+        "Invalid value for reportPeriod"
+      );
+    });
   });
 
-  it("should return the report year for a copied work plan", () => {
-    const reportData = {
-      ...mockUnvalidatedMetadata,
-      copyReport: { reportYear: 2020, reportPeriod: 1, isCopyOverTest: true },
-    };
+  describe("getLastCreatedWorkPlan", () => {
+    it("Should retrieve the most recent eligible work plan", async () => {
+      (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
+        {
+          status: ReportStatus.IN_PROGRESS,
+          associatedSar: undefined,
+          createdAt: 1740000000000,
+          id: "wrong-status",
+        },
+        {
+          status: ReportStatus.APPROVED,
+          associatedSar: "mock-sar-id",
+          createdAt: 1730000000000,
+          id: "has-sar",
+        },
+        {
+          status: ReportStatus.APPROVED,
+          associatedSar: undefined,
+          createdAt: 1720000000000,
+          id: "just-right",
+        },
+        {
+          status: ReportStatus.APPROVED,
+          associatedSar: undefined,
+          createdAt: 1710000000000,
+          id: "not-latest",
+        },
+      ]);
+      const mockFieldData = { id: "just-right-data" };
+      (getReportFieldData as jest.Mock).mockResolvedValue(mockFieldData);
 
-    const response = getReportYear(reportData, true);
+      const result = await getLastCreatedWorkPlan("CO");
 
-    expect(response).toEqual(2020);
-  });
+      expect(result.workPlanMetadata!.id).toBe("just-right");
+      expect(result.workPlanFieldData).toBe(mockFieldData);
+    });
 
-  it("should return the report year for a copied work plan with reportPeriod 2", () => {
-    const reportData = {
-      ...mockWPData,
-      copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
-    };
+    it("Should return undefined if no work plans are eligible", async () => {
+      (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
+        {
+          status: ReportStatus.IN_PROGRESS,
+          associatedSar: undefined,
+          createdAt: 1740000000000,
+          id: "wrong-status",
+        },
+        {
+          status: ReportStatus.APPROVED,
+          associatedSar: "mock-sar-id",
+          createdAt: 1730000000000,
+          id: "has-sar",
+        },
+      ]);
 
-    const response = getReportYear(reportData, true);
+      const result = await getLastCreatedWorkPlan("CO");
 
-    expect(response).toEqual(2021);
-  });
-
-  it("should return the report year for a SAR", () => {
-    const reportData = { ...mockWPData, reportPeriod: 1, reportYear: 2020 };
-    const response = getReportYear(reportData, false);
-
-    expect(response).toEqual(2020);
-  });
-
-  it("should throw an error if the report year is not a number", () => {
-    const reportData = { ...mockUnvalidatedMetadata, reportYear: "2020" };
-
-    expect(() => getReportYear(reportData, false)).toThrow(
-      "Invalid value for reportYear"
-    );
-  });
-});
-
-describe("getReportPeriod", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should return the report period for a new work plan", () => {
-    const reportData = {
-      ...mockUnvalidatedMetadata,
-      reportPeriod: 1,
-      reportYear: 2020,
-    };
-
-    const response = getReportPeriod(reportData, false);
-
-    expect(response).toEqual(1);
-  });
-
-  it("should return the report period for a copied work plan", () => {
-    const reportData = {
-      ...mockWPData,
-      copyReport: { isCopyOverTest: true, reportPeriod: 1, reportYear: 2020 },
-    };
-    const response = getReportPeriod(reportData, true);
-
-    expect(response).toEqual(2);
-  });
-
-  it("should return the report period for a copied work plan with reportPeriod 2", () => {
-    const reportData = {
-      ...mockWPData,
-      copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
-    };
-    const responsePeriod = getReportPeriod(reportData, true);
-
-    const responseYear = getReportYear(reportData, true);
-
-    expect(responsePeriod).toEqual(1);
-    expect(responseYear).toEqual(2021);
-  });
-
-  it("should return the report period for a SAR", () => {
-    const reportData = { ...mockWPData, reportPeriod: 1, reportYear: 2020 };
-    const response = getReportPeriod(reportData, false);
-
-    expect(response).toEqual(1);
-  });
-
-  it("should throw an error if the report period is not a number", () => {
-    const reportData = { ...mockUnvalidatedMetadata, reportPeriod: "2" };
-
-    expect(() => getReportPeriod(reportData, false)).toThrow(
-      "Invalid value for reportPeriod"
-    );
+      expect(result.workPlanMetadata).toBeUndefined();
+      expect(result.workPlanFieldData).toBeUndefined();
+    });
   });
 });

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -1,14 +1,16 @@
+import {
+  getReportFieldData,
+  queryReportMetadatasForState,
+} from "../../storage/reports";
 import { States } from "../constants/constants";
 import {
   AnyObject,
-  APIGatewayProxyEvent,
+  ReportFieldData,
   ReportMetadataShape,
-  ReportShape,
   ReportStatus,
   ReportType,
   State,
 } from "../types";
-import { fetchReportsByState, fetchReport } from "../../handlers/reports/fetch";
 
 export const createReportName = (
   reportType: string,
@@ -25,83 +27,26 @@ export const createReportName = (
   return `${fullStateName} MFP ${reportName} ${reportYear} - Period ${period}`;
 };
 
-export const lastCreatedWorkPlan = (
-  currentWorkPlans: ReportMetadataShape[]
-): ReportMetadataShape | undefined => {
-  let lastCreatedWorkPlan: ReportMetadataShape | undefined = undefined;
-
-  // For each work plan...
-  currentWorkPlans.forEach((workPlan: ReportMetadataShape) => {
-    /*
-     * ...if the workplan hasn't been used to create a SAR before AND
-     * the work plan has a status of "Approved"...
-     */
-    if (workPlan.status === ReportStatus.APPROVED && !workPlan?.associatedSar) {
-      /*
-       * ...then do one of two things: if there are multiple work plans that meet this criteria,
-       * grab the one that was created most recently and return that as our work plan to
-       * copy from...
-       */
-      if (
-        lastCreatedWorkPlan &&
-        workPlan.createdAt > lastCreatedWorkPlan?.createdAt
-      ) {
-        lastCreatedWorkPlan = workPlan;
-      } else if (!lastCreatedWorkPlan) {
-        /*
-         * ...Else this is our first run of the form and we found a work plan to copy from, so
-         * set it as out last found submission to be tested against all other possible work plans.
-         */
-        lastCreatedWorkPlan = workPlan;
-      }
-    }
-  });
-
-  return lastCreatedWorkPlan;
-};
-
 export const getLastCreatedWorkPlan = async (
-  event: APIGatewayProxyEvent,
-  _context: any,
-  state: string
+  state: State
 ): Promise<{
   workPlanMetadata?: ReportMetadataShape;
-  workPlanFieldData?: AnyObject;
+  workPlanFieldData?: ReportFieldData;
 }> => {
-  // Fetch All Work Plans for the state
-  const workPlanEvent = event;
-  workPlanEvent.pathParameters = {
-    ...workPlanEvent.pathParameters,
-    reportType: ReportType.WP,
-  };
-  const workPlanSubmissions = await fetchReportsByState(event, _context);
-  const currentWorkPlans = JSON.parse(workPlanSubmissions.body);
-
-  // Get last created Work Plan
-  const eligbleWorkPlan = lastCreatedWorkPlan(currentWorkPlans);
-
-  // And assuming we have one we want to get the data from.
-  if (eligbleWorkPlan) {
-    const fetchWPReportEvent = event;
-    fetchWPReportEvent.pathParameters = {
-      reportType: ReportType.WP,
-      state: state,
-      id: eligbleWorkPlan["id"],
-    };
-    // Get the data of the eligble work plan
-    const workPlan = await fetchReport(fetchWPReportEvent, _context);
-    const workPlanBody: ReportShape = JSON.parse(workPlan.body);
-
-    // fetchReport returns fieldData and formTemplate together with metadata
-    const workPlanMetadata: any = structuredClone(workPlanBody);
-    const workPlanFieldData = workPlanBody.fieldData;
-    // Remove these from our metadata so they don't get saved into the metadata table
-    delete workPlanMetadata.fieldData;
-    delete workPlanMetadata.formTemplate;
-    return { workPlanMetadata, workPlanFieldData };
+  const allWorkPlans = await queryReportMetadatasForState(ReportType.WP, state);
+  const eligibleWorkPlans = allWorkPlans.filter(
+    (wp) => wp.status === ReportStatus.APPROVED && !wp.associatedSar
+  );
+  if (eligibleWorkPlans.length === 0) {
+    // There were no eligible work plans to treat as a base for this SAR
+    return { workPlanMetadata: undefined, workPlanFieldData: undefined };
   }
-  // If there wasn't an eligble work plan to copy from, return undefined
-  return { workPlanMetadata: undefined, workPlanFieldData: undefined };
+
+  const workPlanMetadata = eligibleWorkPlans.reduce((mostRecent, wp) =>
+    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
+  );
+  const workPlanFieldData = await getReportFieldData(workPlanMetadata);
+  return { workPlanMetadata, workPlanFieldData };
 };
 
 export const getReportYear = (

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -1,20 +1,13 @@
-import { ServerSideEncryption } from "@aws-sdk/client-s3";
-
+/*
+ * These env vars are only used by storage/reports.test.ts,
+ * But they must be set before storage/reports.ts is loaded,
+ * So they live here in setupJest!
+ */
 process.env.WP_REPORT_TABLE_NAME = "local-wp-reports";
 process.env.SAR_REPORT_TABLE_NAME = "local-sar-reports";
 process.env.WP_FORM_BUCKET = "database-local-wp";
 process.env.SAR_FORM_BUCKET = "database-local-sar";
-
-export const mockS3PutObjectCommandOutput = {
-  $metadata: { attempts: 1 },
-  ETag: "some etag value",
-  ServerSideEncryption: ServerSideEncryption.AES256,
-  VersionId: "some version id",
-};
-
-export const mockDynamoPutCommandOutput = {
-  $metadata: { attempts: 1 },
-};
+process.env.FORM_TEMPLATE_TABLE_NAME = "local-form-template-versions";
 
 export const mockReportFieldData = {
   text: "text-input",

--- a/services/app-api/utils/types/other.ts
+++ b/services/app-api/utils/types/other.ts
@@ -141,7 +141,7 @@ export const isState = (state: unknown): state is State => {
   return states.includes(state as State);
 };
 
-export interface FormTemplate {
+export interface FormTemplateVersion {
   md5Hash: string;
   versionNumber: number;
   id: string;

--- a/services/app-api/utils/types/reportContext.ts
+++ b/services/app-api/utils/types/reportContext.ts
@@ -79,5 +79,5 @@ export enum ReportStatus {
 /** The shape of our reports' field data, as stored in S3 */
 export type ReportFieldData = Record<
   string,
-  string | boolean | ReportFieldData[]
+  string | boolean | Choice[] | ReportFieldData[]
 >;

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -5,7 +5,7 @@ import { AnyObject, CustomHtmlElement } from "./other";
 
 export interface ReportJson {
   id?: string;
-  type?: string;
+  type: ReportType;
   name: string;
   basePath: string;
   routes: ReportRoute[];


### PR DESCRIPTION
### Description
This is a continuation of the work in PR #582. There shouldn't be any surprises here; we're just filling out the rest of the helper methods needed for reports. Once it is merged, there will be no direct DynamoDB or S3 access in any of the report handlers.

**Detailed list of moderately-interesting changes**
* create.test - some tests were actually testing "deeply", verifying functionality in copy.ts or formTemplates.ts. Those functions are now mocked, simplifying the tests here. The unit tests in copy.test.s, formTemplates.test.ts, and transformations.test.ts already cover their own functionality.
* create.ts - remove some deprecated parameters when calling helper methods
* update.ts - remove a check that would catch a metadata object without formTemplateId or fieldDataId. These fields are guaranteed to be present by the type system, so the check just ends up adding noise.
* storage/reports.ts - New methods for creating & updating metadata, field data, and form templates. Also new methods for creating & querying form template _verisons_.
   * I made a call here, to create `queryLatestFormTemplateVersionNumber` instead of `queryLatestFormTemplate`. This is an outlier in the file, since every other method deals in whole objects, but the call site in formTemplates.ts isn't interested in the rest of the template, only that number. Putting that property access & the `?? 0` logic in here means that this is the only function in the file that requires two unit tests. Was this a good choice?
* constants.ts - Moved a few constants to reports.ts, since they are only used there. Some maps have more specific type annotations, so that TS can help us more if/when the report types ever change.
* formTemplates.ts - rework formTemplateForReportType to briefer & hide more. Removed error logging S3 & dynamo interaction - it would be redundant with the logging in the AWS clients.
* copy.ts - a bit stronger typing in here, but more to do later. But that will require more code changes & deserves its own PR.
* utils/other.test.ts - 60% whitespace changes, sorry. The other 40% are for functionality previously covered in reports/create.test.ts.
* utils/other.ts - Remove `lastCreatedWorkPlan` in favor of a `.filter` and a `.reduce`. Also, `getLastCreatedWorkPlan` is significantly simplified now that it uses storage helpers.
* setupJest.ts - Remove some mock data previously used when testing report handlers
* types/other.ts - Rename `FormTemplate` interface - these objects only contain versioning information. Now we have `FormTemplateVersion` and `ReportFormTemplate` for our function names, and `FormTemplateVersion` and `ReportJson` are the corresponding type names. Maybe someday, rename the `ReportJson` interface to `ReportFormTemplate`? But not today.
* types/reportContext.ts - Explicitly add `Choice[]` to the `ReportFieldData` type. In a lot of ways we can get away with treating choice arrays as entities, but I feel it'll be clearer to make the distinction whenever we can. This sets us up to do so going forward - notably, in copy.ts.
* types/reports.ts - `ReportJson.type` is always present, and it is always a `ReportType`. Marking it as such allows `putFormTemplateVersion` to take only a single parameter; otherwise we would need to pass `reportType` through separately.


### Related ticket(s)
n/a

---
### How to test
As usual, there should be no observable behavioral changes. But since every endpoint was touched, a regression test of the entire app is appropriate.

---
### Pre-review checklist
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
