### PR TITLE
ensure fields have disabled prop for non-state users

### DIFF
--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -123,6 +123,9 @@ export const DateField = ({
   const labelText =
     label && styleAsOptional ? labelTextWithOptional(label) : label;
 
+  const { autoComplete, disabled } = props ?? {};
+  const additionalProps = { autoComplete, disabled };
+
   return (
     <Box
       sx={{ ...sx, ...sxOverride }}
@@ -136,6 +139,7 @@ export const DateField = ({
         value={displayValue}
         hint={parsedHint}
         errorMessage={errorMessage}
+        {...additionalProps}
       />
     </Box>
   );

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -149,6 +149,9 @@ export const NumberField = ({
     label && styleAsOptional ? labelTextWithOptional(label) : label;
   const nestedChildClasses = nested ? "nested ds-c-choice__checkedChild" : "";
 
+  const { autoComplete, disabled } = props ?? {};
+  const additionalProps = { autoComplete, disabled };
+
   return (
     <Box sx={{ ...sx, ...sxOverride }} className={`${nestedChildClasses}`}>
       <Box sx={sx.numberFieldContainer} className={maskClass}>
@@ -162,6 +165,7 @@ export const NumberField = ({
           onBlur={onBlurHandler}
           value={displayValue}
           errorMessage={errorMessage}
+          {...additionalProps}
         />
         <SymbolOverlay
           fieldMask={mask}

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -28,7 +28,6 @@ export const TextField = ({
   heading,
   ...props
 }: Props) => {
-  const { rows, multiline } = props;
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
 
@@ -122,6 +121,9 @@ export const TextField = ({
   const labelText =
     label && styleAsOptional ? labelTextWithOptional(label) : label;
 
+  const { autoComplete, disabled, multiline, rows } = props ?? {};
+  const additionalProps = { autoComplete, disabled, multiline, rows };
+
   return (
     <Box sx={sxOverride} className={`${nestedChildClasses} ${labelClass}`}>
       {/* SAR field sections */}
@@ -136,8 +138,7 @@ export const TextField = ({
         onBlur={(e) => onBlurHandler(e)}
         errorMessage={errorMessage}
         value={displayValue}
-        rows={rows}
-        multiline={multiline}
+        {...additionalProps}
       />
     </Box>
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In this [PR eliminating console errors](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/580/files#diff-b5bb9d5fd923df504028e2ba652e8d21568c4c273d8156111f9d8693e96783d3) we ended up removing some properties we needed, like disabled! 

This pulls out the properties we see getting to the components when props are spread, and ensures those make it
Date field with spread:
<img width="515" alt="Screenshot 2024-05-15 at 12 55 50 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/6f450686-2d87-4d9d-ade7-728de1315267">
Date field without spread:
<img width="521" alt="Screenshot 2024-05-15 at 12 55 56 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/a4e770d3-60dd-45ab-a248-08cf43ff46c0">

Number field with spread:
<img width="613" alt="Screenshot 2024-05-15 at 12 49 41 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/84ca6d8c-2e11-4802-9ad4-2eb357b62728">
Number field without spread:
<img width="610" alt="Screenshot 2024-05-15 at 12 49 48 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/57802560/a54dca6b-8598-4b5f-aa69-66e460ddf4de">




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3646

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed url: https://d17paipffuuz1g.cloudfront.net/
- Login as `adminuser@test.com` in the deploy environment
- For Puerto Rico, verify the WP and SAR fields are disabled
  - The last initiative has the maximum fields displayed (like nested ones) if you want to verify those

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
