### PR TITLE
[CMDCT-3595] Refactor ReportPageIntro

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -14,7 +14,7 @@
       "verbiage": {
         "intro": {
           "section": "",
-          "subsection": "General Information",
+          "subsection": "General Information"
         },
         "praDisclosure": [
           {

--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -15,7 +15,6 @@
         "intro": {
           "section": "",
           "subsection": "General Information",
-          "hint": ""
         },
         "praDisclosure": [
           {
@@ -179,26 +178,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of people who signed an MFP informed consent form in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of people who signed an MFP informed consent form in the reporting period"
@@ -236,26 +238,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of MFP transitions in the reporting period"
@@ -318,26 +323,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions from qualified institutions in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of MFP transitions from qualified institutions in the reporting period"
@@ -454,26 +462,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions to qualified residences in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of MFP transitions to qualified residences in the reporting period"
@@ -572,26 +583,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Total number of active MFP participants in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Total number of active MFP participants in the reporting period"
@@ -629,26 +643,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP participants completing the program in the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of MFP participants completing the program in the reporting period"
@@ -686,26 +703,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of people re-enrolled in MFP during the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of people re-enrolled in MFP during the reporting period"
@@ -743,26 +763,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP participants disenrolled from the program during the reporting period",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of MFP participants disenrolled from the program during the reporting period"
@@ -954,26 +977,29 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of HCBS participants (including MFP participants) admitted to a facility from the community, by length of stay and age group",
-              "hint": [
-                {
-                  "type": "html",
-                  "content": "In this section, provide information for the specified period. For more information see the "
-                },
-                {
-                  "type": "externalLink",
-                  "content": "User Guide and Help File",
-                  "props": {
-                    "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
-                    "target": "_blank",
-                    "aria-label": "User Guide and Help File (Link opens in new tab)"
-                  }
-                },
-                {
-                  "type": "html",
-                  "content": "."
-                }
-              ],
               "info": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "html",
+                      "content": "In this section, provide information for the specified period. For more information see the "
+                    },
+                    {
+                      "type": "externalLink",
+                      "content": "User Guide and Help File",
+                      "props": {
+                        "href": "https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-438/subpart-A/section-438.8#p-438.8(k)",
+                        "target": "_blank",
+                        "aria-label": "User Guide and Help File (Link opens in new tab)"
+                      }
+                    },
+                    {
+                      "type": "html",
+                      "content": "."
+                    }
+                  ]
+                },
                 {
                   "type": "h3",
                   "content": "Number of HCBS participants (including MFP participants) admitted to a facility from the community, by length of stay and age group in the reporting period (optional)"
@@ -1144,37 +1170,57 @@
       "verbiage": {
         "intro": {
           "section": "",
-          "subsection": "State or Territory-Specific Initiatives"
-        },
-        "accordion": {
-          "buttonLabel": "Instructions",
-          "intro": [
-            {
-              "type": "html",
-              "content": "This section requests information on current, new, or expanded initiatives implemented under the MFP demonstration. These initiatives can be funded using one or more of these funding sources:"
-            }
-          ],
-          "list": [
-            "MFP cooperative agreement funds for:",
-            [
-              "Qualified home and community-based services (HCBS) and demonstration services",
-              "Supplemental services",
-              "Administrative activities",
-              "Capacity building initiatives"
+          "subsection": "State or Territory-Specific Initiatives",
+          "introAccordion": {
+            "buttonLabel": "Instructions",
+            "intro": [
+              {
+                "type": "html",
+                "content": "This section requests information on current, new, or expanded initiatives implemented under the MFP demonstration. These initiatives can be funded using one or more of these funding sources:"
+              }
             ],
-            "State/Territory equivalent funds attributable to the MFP-enhanced match"
-          ],
-          "text": [
+            "list": [
+              "MFP cooperative agreement funds for:",
+              [
+                "Qualified home and community-based services (HCBS) and demonstration services",
+                "Supplemental services",
+                "Administrative activities",
+                "Capacity building initiatives"
+              ],
+              "State/Territory equivalent funds attributable to the MFP-enhanced match"
+            ],
+            "text": [
+              {
+                "type": "html",
+                "content": "State or territory-specific initiatives are a distinct set of activities designed to increase the use of HCBS rather than institutional long-term services and supports (LTSS). These initiatives are specified in your MFP Work Plan and imported into the form below."
+              }
+            ]
+          },
+          "info": [
             {
-              "type": "html",
-              "content": "State or territory-specific initiatives are a distinct set of activities designed to increase the use of HCBS rather than institutional long-term services and supports (LTSS). These initiatives are specified in your MFP Work Plan and imported into the form below."
+              "type": "h3",
+              "content": "Report progress for each initiative"
+            },
+            {
+              "type": "p",
+              "content": "Your initiatives are auto-populated from your most recent approved MFP Work Plan."
+            },
+            {
+              "type": "p",
+              "content": "Recipients must report on the progress of initiatives that were ongoing during the current reporting period. For each initiative, enter information on expenditures and activities, whether continuing from prior reporting periods or initiated during this reporting period."
+            },
+            {
+              "type": "p",
+              "content": "For each initiative, recipients must report on the progress toward achieving the objective(s) identified in the initiative’s evaluation plan, as described in the MFP Work Plan. Progress toward these objectives indicates the state or territory’s greater ability to provide HCBS instead of services in institutional settings."
+            },
+            {
+              "type": "p",
+              "content": "If your state or territory has not achieved the targets for performance measures or expected time frames for deliverables set in the initiative’s evaluation plan, use the following questions to explain the barriers or challenges that have hindered progress and describe plans to address them."
             }
           ]
         },
         "enterEntityDetailsButtonText": "Edit",
         "readOnlyEntityDetailsButtonText": "View",
-        "dashboardTitle": "Report progress for each initiative",
-        "dashboardSubtitle": "Your initiatives are auto-populated from your most recent approved MFP Work Plan.<br><br>Recipients must report on the progress of initiatives that were ongoing during the current reporting period. For each initiative, enter information on expenditures and activities, whether continuing from prior reporting periods or initiated during this reporting period.<br><br>For each initiative, recipients must report on the progress toward achieving the objective(s) identified in the initiative’s evaluation plan, as described in the MFP Work Plan. Progress toward these objectives indicates the state or territory’s greater ability to provide HCBS instead of services in institutional settings.<br><br>If your state or territory has not achieved the targets for performance measures or expected time frames for deliverables set in the initiative’s evaluation plan, use the following questions to explain the barriers or challenges that have hindered progress and describe plans to address them.",
         "tableHeader": "Initiative name <br/> MFP Work Plan topic",
         "countEntitiesInTitle": false
       },
@@ -1207,15 +1253,18 @@
                 "section": "State or Territory-Specific Initiatives",
                 "info": [
                   {
-                    "type": "html",
+                    "type": "h3",
+                    "content": "Objectives progress"
+                  },
+                  {
+                    "type": "p",
                     "content": "Report progress for each objective by selecting the button for each."
                   },
                   {
-                    "type": "html",
-                    "content": "<br>Objectives are framed as SMART goals and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. Recipients define objectives in your MFP Work Plan’s evaluation plan."
+                    "type": "p",
+                    "content": "Objectives are framed as SMART goals and set associated performance measures or indicators to monitor progress toward each objective and evaluate success. Recipients define objectives in your MFP Work Plan’s evaluation plan."
                   }
-                ],
-                "dashboardTitle": "Objectives progress"
+                ]
               },
               "accordion": {
                 "buttonLabel": "About SMART goals",
@@ -1330,11 +1379,18 @@
                 "section": "State or Territory-Specific Initiatives",
                 "info": [
                   {
-                    "type": "html",
-                    "content": "Report progress for this initiative during this reporting period.<br><br>Report key accomplishments or challenges for this initiative that are not otherwise mentioned under the objective(s). Recipients can document whether they are considering changes to objective(s) or the initiative based on the developments to date, including collaborations that may be under consideration or occurring with external parties to assist with running the initiative or achieving objectives."
+                    "type": "h3",
+                    "content": "Initiative progress"
+                  },
+                  {
+                    "type": "p",
+                    "content": "Report progress for this initiative during this reporting period."
+                  },
+                  {
+                    "type": "p",
+                    "content": "Report key accomplishments or challenges for this initiative that are not otherwise mentioned under the objective(s). Recipients can document whether they are considering changes to objective(s) or the initiative based on the developments to date, including collaborations that may be under consideration or occurring with external parties to assist with running the initiative or achieving objectives."
                   }
-                ],
-                "title": "Initiative progress"
+                ]
               },
               "enterEntityDetailsButtonText": "Edit",
               "readOnlyEntityDetailsButtonText": "View",
@@ -1385,11 +1441,18 @@
                 "section": "State or Territory-Specific Initiatives",
                 "info": [
                   {
-                    "type": "html",
-                    "content": "Report initiative expenditures by quarter and funding source. Report actual spending for each quarter for this initiative. Recipients plan quarterly expenditure targets in your MFP Work Plan’s funding sources. Recipients with discrepancies between projected and actual spending due solely to lag time between incurring costs and disbursing funds will have the option to note those cases in this section.<br></br>Funding sources and projected spending are auto-populated from your associated MFP Work Plan."
+                    "type": "h3",
+                    "content": "Expenditures"
+                  },
+                  {
+                    "type": "p",
+                    "content": "Report initiative expenditures by quarter and funding source. Report actual spending for each quarter for this initiative. Recipients plan quarterly expenditure targets in your MFP Work Plan’s funding sources. Recipients with discrepancies between projected and actual spending due solely to lag time between incurring costs and disbursing funds will have the option to note those cases in this section."
+                  },
+                  {
+                    "type": "p",
+                    "content": "Funding sources and projected spending are auto-populated from your associated MFP Work Plan."
                   }
-                ],
-                "title": "Expenditures"
+                ]
               },
               "enterEntityDetailsButtonText": "Edit",
               "readOnlyEntityDetailsButtonText": "View",
@@ -1615,8 +1678,11 @@
         "intro": {
           "section": "",
           "subsection": "Additional Achievements",
-          "hint": "Use this section to describe any additional achievements or promising practices that have contributed to the effective operation of the demonstration and successful transitions during the reporting period. Achievements or topics discussed in previous sections do not need to be reiterated here. Use the topics below as a guide, but note other important updates.",
           "info": [
+            {
+              "type": "p",
+              "content": "Use this section to describe any additional achievements or promising practices that have contributed to the effective operation of the demonstration and successful transitions during the reporting period. Achievements or topics discussed in previous sections do not need to be reiterated here. Use the topics below as a guide, but note other important updates."
+            },
             {
               "type": "ul",
               "props": {

--- a/services/ui-src/src/components/accordions/AccordionItem.tsx
+++ b/services/ui-src/src/components/accordions/AccordionItem.tsx
@@ -5,7 +5,6 @@ import {
   AccordionItem as AccordionItemRoot,
   AccordionPanel,
   Image,
-  Text,
 } from "@chakra-ui/react";
 // assets
 import plusIcon from "assets/icons/icon_plus.png";
@@ -21,7 +20,7 @@ export const AccordionItem = ({ label, children, ...props }: Props) => {
             aria-label={label}
             title="accordion-button"
           >
-            <Text flex="1">{label}</Text>
+            {label}
             <Image
               src={isExpanded ? minusIcon : plusIcon}
               alt={isExpanded ? "Collapse" : "Expand"}
@@ -57,5 +56,6 @@ const sx = {
   },
   accordionIcon: {
     width: "1rem",
+    marginLeft: "auto",
   },
 };

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlay.tsx
@@ -235,7 +235,6 @@ export const EntityDetailsOverlay = ({
           initiativeName={reportPageTitle}
         />
       )}
-      {verbiage.intro.title && <Box sx={sx.title}>{verbiage.intro.title}</Box>}
       {verbiage.intro.subtitle && (
         <Box sx={sx.infoTextBox}>
           {parseCustomHtml(verbiage.intro.subtitle)}
@@ -367,13 +366,6 @@ const sx = {
   },
   warningIcon: {
     width: "1.375rem",
-  },
-  title: {
-    paddingTop: "1rem",
-    paddingBottom: "0",
-    fontWeight: "bold",
-    fontSize: "2xl",
-    color: "palette.gray_medium_dark",
   },
   subsectionHeading: {
     fontWeight: "normal",

--- a/services/ui-src/src/components/reports/DynamicModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/DynamicModalOverlayReportPage.tsx
@@ -62,10 +62,7 @@ export const DynamicModalOverlayReportPage = ({
 
   const showAlert =
     report && errorMessage ? getWPAlertStatus(report, entityType) : false;
-
-  const dashTitle = verbiage.dashboardTitle
-    ? `${verbiage.dashboardTitle}`
-    : null;
+  const dashTitle = verbiage?.dashboardTitle;
   const dashSubTitle = parseCustomHtml(
     (verbiage as AnyObject)?.dashboardSubtitle
   );

--- a/services/ui-src/src/components/reports/DynamicModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/DynamicModalOverlayReportPage.tsx
@@ -63,7 +63,9 @@ export const DynamicModalOverlayReportPage = ({
   const showAlert =
     report && errorMessage ? getWPAlertStatus(report, entityType) : false;
 
-  const dashTitle = `${verbiage.dashboardTitle}`;
+  const dashTitle = verbiage.dashboardTitle
+    ? `${verbiage.dashboardTitle}`
+    : null;
   const dashSubTitle = parseCustomHtml(
     (verbiage as AnyObject)?.dashboardSubtitle
   );

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -3,7 +3,7 @@ import { Box, Heading } from "@chakra-ui/react";
 import { InstructionsAccordion } from "components";
 // utils
 import { parseCustomHtml } from "utils";
-import { AnyObject, OverlayModalStepTypes } from "types";
+import { AnyObject } from "types";
 import { ReportPeriod } from "./ReportPeriod";
 
 export const ReportPageIntro = ({
@@ -14,57 +14,43 @@ export const ReportPageIntro = ({
   reportYear,
   ...props
 }: Props) => {
-  const { section, subsection, hint, info } = text;
+  const { section, subsection, info, introAccordion } = text;
 
-  if (section && (subsection || initiativeName)) {
+  const isSubsectionPage = section && (subsection || initiativeName);
+
+  const header = () => {
     return (
-      <Box sx={sx.introBox} {...props}>
+      <Heading as="h1" sx={sx.largeHeading}>
+        {subsection}
+      </Heading>
+    );
+  };
+
+  const headerSubsection = () => {
+    return (
+      <>
         <Heading as="h1" sx={sx.smallHeading}>
           {section}
         </Heading>
         <Heading as="h2" sx={sx.largeHeading}>
           {initiativeName ? initiativeName : subsection}
         </Heading>
-        {hint && <Box sx={sx.hintTextBox}>{parseCustomHtml(hint)}</Box>}
-        {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
-          <InstructionsAccordion verbiage={accordion} />
-        )}
-        {OverlayModalStepTypes.OBJECTIVE_PROGRESS && text.dashboardTitle && (
-          <Heading as="h3" sx={sx.subTitle}>
-            {text.dashboardTitle}
-          </Heading>
-        )}
-        {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-        {accordion && OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
-          <InstructionsAccordion verbiage={accordion} />
-        )}
-        <ReportPeriod
-          text={text}
-          reportPeriod={reportPeriod}
-          reportYear={reportYear}
-        />
-      </Box>
+      </>
     );
-  }
+  };
 
   return (
     <Box sx={sx.introBox} {...props}>
-      <Heading as="h1" sx={sx.largeHeading}>
-        {subsection}
-      </Heading>
-      {hint && <Box sx={sx.hintTextBox}>{parseCustomHtml(hint)}</Box>}
-      {accordion && !OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
-        <InstructionsAccordion verbiage={accordion} />
-      )}
-      {OverlayModalStepTypes.OBJECTIVE_PROGRESS && text.dashboardTitle && (
-        <Heading as="h3" sx={sx.subTitle}>
-          {text.dashboardTitle}
-        </Heading>
-      )}
+      {isSubsectionPage ? headerSubsection() : header()}
+
+      {/* accordion specifically nested in the intro verbiage */}
+      {introAccordion && <InstructionsAccordion verbiage={introAccordion} />}
+
       {info && <Box sx={sx.infoTextBox}>{parseCustomHtml(info)}</Box>}
-      {accordion && OverlayModalStepTypes.OBJECTIVE_PROGRESS && (
-        <InstructionsAccordion verbiage={accordion} />
-      )}
+
+      {accordion && <InstructionsAccordion verbiage={accordion} />}
+
+      {/* SAR Reporting Period section */}
       <ReportPeriod
         text={text}
         reportPeriod={reportPeriod}
@@ -86,6 +72,11 @@ interface Props {
 const sx = {
   introBox: {
     marginBottom: "1rem",
+
+    p: {
+      marginBottom: "1rem",
+      marginTop: "0",
+    },
   },
   smallHeading: {
     color: "palette.gray",

--- a/services/ui-src/src/components/reports/ReportPageIntro.tsx
+++ b/services/ui-src/src/components/reports/ReportPageIntro.tsx
@@ -33,7 +33,7 @@ export const ReportPageIntro = ({
           {section}
         </Heading>
         <Heading as="h2" sx={sx.largeHeading}>
-          {initiativeName ? initiativeName : subsection}
+          {initiativeName ?? subsection}
         </Heading>
       </>
     );


### PR DESCRIPTION
### Description
This story started with the intention of moving one line of text above some paragraphs...and evolved into a full-fledged refactor of how text is structured on our report page intros. As you do.

I am sorry this PR looks scary.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3595

---
### How to test
**Cloudfront link:** https://d2z5kjhukpisg4.cloudfront.net/
**User:** `stateuser@test.com`

This refactor ends up touching every page of WP and SAR, honestly. BUT it's pretty quick to visually review.

1. Look at each page of WP (the intro text before any forms) and nothing should look weird.
2. Look at each page of the SAR (the intro text before any forms) and nothing should look weird.
3. In the SAR, go to State or Territory-Specific Initiatives, click into a specific initiative, and view each step (Objectives progress, Initiatives progress, Expenditures). 
    - On each page, the heading (Objectives progress, Initiatives progress, Expenditures) should be above the paragraph text


### Notes
Some snapshots of the before/after effects of this PR:

| Before | After |
| ----- | ----- |
| <img width="1534" alt="Screenshot 2024-05-17 at 9 14 16 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/0aa2d659-5c3f-4699-9ea1-f08e27abcc10">  |  <img width="1525" alt="Screenshot 2024-05-17 at 9 15 49 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/9bce4d35-9867-4845-8e10-dec2629e3de5"> |
|  <img width="1522" alt="Screenshot 2024-05-17 at 9 16 45 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/cd8738ba-9401-49a4-a080-213fb584c0d4"> | <img width="1537" alt="Screenshot 2024-05-17 at 9 17 35 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/ff011b58-7c2c-4e49-a7b6-155e7d89d573">  |
|  <img width="1534" alt="Screenshot 2024-05-17 at 9 20 07 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/623aa6bd-52ca-498b-90ce-b1832db15db9"> |  <img width="1534" alt="Screenshot 2024-05-17 at 9 20 56 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/dcb080c7-9e81-43de-a2d0-a965a9e29ceb"> |
|  <img width="1532" alt="Screenshot 2024-05-17 at 9 22 34 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/5ff9e00d-1919-4394-a688-3da76544ee5e"> |  <img width="1538" alt="Screenshot 2024-05-17 at 9 22 51 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/1abaa0c2-337c-41d7-8af3-294ad3f689f4"> |



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
