### PR TITLE
modify internal user role to match idm

### DIFF
--- a/services/app-api/utils/types/users.ts
+++ b/services/app-api/utils/types/users.ts
@@ -3,7 +3,7 @@
 export enum UserRoles {
   ADMIN = "mdctmfp-bor", // "MDCT MFP Business Owner Representative"
   HELP_DESK = "mdctmfp-help-desk", // "MDCT MFP Help Desk"
-  INTERNAL = "mdctmfp-internal-user", // "MDCT MFP Internal User"
+  INTERNAL = "mdctmfp-cms-internal-user", // "MDCT MFP Internal User"
   APPROVER = "mdctmfp-approver", // "MDCT MFP Approver"
   STATE_USER = "mdctmfp-state-user", // "MDCT MFP State User"
 }

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -95,7 +95,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctmfp-internal-user"
+        "Value": "mdctmfp-cms-internal-user"
       }
     ]
   },

--- a/services/ui-src/src/types/users.ts
+++ b/services/ui-src/src/types/users.ts
@@ -4,7 +4,7 @@ export enum UserRoles {
   ADMIN = "mdctmfp-bor", // "MDCT MFP Business Owner Representative"
   APPROVER = "mdctmfp-approver", // "MDCT MFP Approver"
   HELP_DESK = "mdctmfp-help-desk", // "MDCT MFP Help Desk"
-  INTERNAL = "mdctmfp-internal-user", // "MDCT MFP Internal User"
+  INTERNAL = "mdctmfp-cms-internal-user", // "MDCT MFP Internal User"
   STATE_USER = "mdctmfp-state-user", // "MDCT MFP State User"
 }
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
As it turns out, the correct IDM user role for internal users is `mdctmfp-cms-internal-user`, not `mdctmfp-internal-user`. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
n/a for now, but then...

- In dev, get @ntsummers1 to test it with IDM login
- In val, get @BearHanded to test it with IDM login
- In prod, get @jessabean to test it with IDM login

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~~[ ] Design: This work has been reviewed and approved by design, if necessary~~
- ~~[ ] Product: This work has been reviewed and approved by product owner, if necessary~~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~~[ ] These changes are significant enough to require an update to the SIA.~~
- ~~[ ] These changes are significant enough to require a penetration test.~~
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
