### PR TITLE
remove old react-scripts references

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -11,7 +11,6 @@
     "test": "jest --setupFiles dotenv/config",
     "watchTest": "jest --setupFiles dotenv/config --watch",
     "a11y": "pa11y --runner axe --runner htmlcs",
-    "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/services/ui-src/src/global.d.ts
+++ b/services/ui-src/src/global.d.ts
@@ -1,9 +1,0 @@
-/// <reference types="react-scripts" />
-
-import { RegisterOptions } from "react-hook-form";
-interface ControllerRules {
-  rules?: Omit<
-    RegisterOptions<TFieldValues, TName>, // eslint-disable-line no-undef
-    "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
-  >;
-}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove references to [react-scripts, which has been removed](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/604)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Deployed app works: https://d1se5txk52qcml.cloudfront.net/
- App runs locally
- All tests pass in CI