### PR TITLE
remove br tags from add sar modal

### DIFF
--- a/services/ui-src/src/forms/addEditSarReport/addEditSarReport.json
+++ b/services/ui-src/src/forms/addEditSarReport/addEditSarReport.json
@@ -15,7 +15,14 @@
       "props": {
         "disabled": true,
         "label": "Associated MFP Work Plan",
-        "hint": "Auto-populates from your last approved MFP Work Plan. <br/> Note: Your MFP SAR will be created for the same year and reporting period as your MFP Work Plan."
+        "hint": [
+          {
+            "content": "Auto-populates from your last approved MFP Work Plan."
+          },
+          {
+            "content": "Note: Your MFP SAR will be created for the same year and reporting period as your MFP Work Plan."
+          }
+        ]
       }
     },
     {
@@ -35,7 +42,17 @@
       "props": {
         "disabled": true,
         "label": "Reporting period",
-        "hint": "Auto-populates from your last approved MFP Work Plan. <br/> (1) First reporting period (January-June) <br /> (2) Second reporting period (July-December)"
+        "hint": [
+          {
+            "content": "Auto-populates from your last approved MFP Work Plan."
+          },
+          {
+            "content": "(1) First reporting period (January-June)"
+          },
+          {
+            "content": "(2) Second reporting period (July-December)"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Remove break tags from modal field hint text

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3611

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deployed env: https://d1y6xdxhkaqfwq.cloudfront.net/
- Log in as `stateuser@test.com`
- Go to the SAR dashboard
- Click on the create modal and inspect the hint text for "Associated MFP Work Plan" and "Reporting period"
- Verify these are newlined via paragraph instead of break tags
- DO NOT create a SAR so it's easy for others to review :)


If you test locally you can enable the SAR modal right away by commenting out the [disabler in the dashboard component](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx#L376)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
