### PR TITLE
CMDCT-3675: Removing "General Information" from Review & Submit page

### DIFF
--- a/services/ui-src/src/utils/statusing/getRouteStatus.ts
+++ b/services/ui-src/src/utils/statusing/getRouteStatus.ts
@@ -13,9 +13,9 @@ export const getRouteStatus = (report: ReportShape): ReportPageProgress[] => {
     formTemplate: { routes },
   } = report;
   // Filter out the reviewSubmit pageType
-  const validRoutes = routes.filter(
-    (r: ReportRoute) => r.pageType !== "reviewSubmit"
-  );
+  const validRoutes = routes
+    .filter((r: ReportRoute) => r.pageType !== "reviewSubmit")
+    .filter((r: ReportRoute) => r.name !== "General Information");
 
   // Ensure there is a response from the API containing the completion status
   if (!report.completionStatus) {

--- a/services/ui-src/src/utils/statusing/getRouteStatus.ts
+++ b/services/ui-src/src/utils/statusing/getRouteStatus.ts
@@ -13,9 +13,10 @@ export const getRouteStatus = (report: ReportShape): ReportPageProgress[] => {
     formTemplate: { routes },
   } = report;
   // Filter out the reviewSubmit pageType
-  const validRoutes = routes
-    .filter((r: ReportRoute) => r.pageType !== "reviewSubmit")
-    .filter((r: ReportRoute) => r.path !== "/wp/general-information");
+  const validRoutes = routes.filter(
+    (r: ReportRoute) =>
+      r.pageType !== "reviewSubmit" && r.path !== "/wp/general-information"
+  );
 
   // Ensure there is a response from the API containing the completion status
   if (!report.completionStatus) {

--- a/services/ui-src/src/utils/statusing/getRouteStatus.ts
+++ b/services/ui-src/src/utils/statusing/getRouteStatus.ts
@@ -15,7 +15,7 @@ export const getRouteStatus = (report: ReportShape): ReportPageProgress[] => {
   // Filter out the reviewSubmit pageType
   const validRoutes = routes
     .filter((r: ReportRoute) => r.pageType !== "reviewSubmit")
-    .filter((r: ReportRoute) => r.name !== "General Information");
+    .filter((r: ReportRoute) => r.path !== "/wp/general-information");
 
   // Ensure there is a response from the API containing the completion status
   if (!report.completionStatus) {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Currently, we're counting the "General Information" page towards the Work Plan report completion status, but that page doesn't contain any form fields, so we're filtering it out going forward.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3675

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a WP
- Navigate to the Review & submit page

You should not see "General Information" on the status table and you should be able to submit your report without any trouble.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
