### PR TITLE
CMDCT-3679: Fix error alert on Transition page from showing all the time

### DIFF
--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -21,6 +21,12 @@ import {
   useStore,
 } from "utils";
 
+const alertVerbiage: ErrorVerbiage = {
+  title: "Error",
+  description:
+    'This target population was already added. To avoid duplication, add a different target population name or select "Cancel".',
+};
+
 export const AddEditEntityModal = ({
   entityType,
   entityName,
@@ -49,11 +55,9 @@ export const AddEditEntityModal = ({
           otherPopulation.transitionBenchmarks_targetPopulationName === input
       )
     ) {
-      setError(
-        'This target population was already added. To avoid duplication, add a different target population name or select "Cancel".'
-      );
+      setError(alertVerbiage);
     } else {
-      setError("");
+      setError(undefined);
     }
   };
 

--- a/services/ui-src/src/components/modals/AddEditEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditEntityModal.tsx
@@ -21,7 +21,7 @@ import {
   useStore,
 } from "utils";
 
-const alertVerbiage: ErrorVerbiage = {
+export const alertVerbiage: ErrorVerbiage = {
   title: "Error",
   description:
     'This target population was already added. To avoid duplication, add a different target population name or select "Cancel".',

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -10,9 +10,9 @@ import {
 } from "@chakra-ui/react";
 import {
   AddEditEntityModal,
-  Alert,
   DeleteEntityModal,
   EntityRow,
+  ErrorAlert,
   PrintButton,
   ReportContext,
   ReportDrawer,
@@ -31,7 +31,6 @@ import {
   ReportStatus,
   isFieldElement,
   ErrorVerbiage,
-  AlertTypes,
 } from "types";
 // utils
 import {
@@ -46,7 +45,7 @@ import {
 } from "utils";
 import { getDefaultTargetPopulationNames } from "../../constants";
 
-const alertVerbiage = {
+const alertVerbiage: ErrorVerbiage = {
   title:
     "You must have at least one default target population applicable to your MFP Demonstration",
   description:
@@ -67,9 +66,8 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
   const [selectedEntity, setSelectedEntity] = useState<EntityShape | undefined>(
     undefined
   );
-  const [error, setError] = useState<ErrorVerbiage>();
-  const [invalidEntry, setInvalidEntry] = useState<boolean>(false);
-
+  const [pageError, setPageError] = useState<ErrorVerbiage>();
+  const [modalError, setModalError] = useState<ErrorVerbiage>();
   const { report } = useStore();
   const { updateReport } = useContext(ReportContext);
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
@@ -95,7 +93,7 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
 
   const closeAddEditEntityModal = () => {
     setSelectedEntity(undefined);
-    setError({ title: "", description: "" });
+    setModalError(undefined);
     addEditEntityModalOnCloseHandler();
   };
 
@@ -208,27 +206,18 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
   useEffect(() => {
     if (entityType === "targetPopulations") {
       if (defaultsPopsNotSelected(reportFieldDataEntities)) {
-        setInvalidEntry(true);
+        setPageError(alertVerbiage);
       } else {
-        setInvalidEntry(false);
+        setPageError(undefined);
       }
     }
   }, [reportFieldDataEntities]);
-
   return (
     <Box>
       {verbiage.intro && (
         <ReportPageIntro text={verbiage.intro} accordion={verbiage.accordion} />
       )}
-      {invalidEntry && (
-        <Box>
-          <Alert
-            title={alertVerbiage.title}
-            status={AlertTypes.ERROR}
-            description={alertVerbiage.description}
-          />
-        </Box>
-      )}
+      <ErrorAlert error={pageError} sxOverride={sx.pageErrorAlert} />
       <Box>
         <Heading as="h3" sx={sx.dashboardTitle}>
           {verbiage.dashboardTitle}
@@ -269,8 +258,8 @@ export const ModalDrawerReportPage = ({ route, validateOnRender }: Props) => {
           selectedEntity={selectedEntity}
           verbiage={verbiage}
           form={modalForm}
-          error={error}
-          setError={setError}
+          error={modalError}
+          setError={setModalError}
           modalDisclosure={{
             isOpen: addEditEntityModalIsOpen,
             onClose: closeAddEditEntityModal,
@@ -348,6 +337,9 @@ const sx = {
         width: "260px",
       },
     },
+  },
+  pageErrorAlert: {
+    marginBottom: "1.5rem",
   },
   reviewPdfHint: {
     color: "palette.gray_medium",

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -87,6 +87,15 @@ export const mockNestedFormField = {
   },
 };
 
+export const mockTransitionBenchmarkFormField = {
+  id: "transitionBenchmarks_targetPopulationName",
+  type: "text",
+  validation: "text",
+  props: {
+    label: "mock text field",
+  },
+};
+
 export const mockFundingSourceFormField = {
   id: "fundingSources_wpTopic",
   type: "radio",
@@ -122,6 +131,11 @@ export const mockForm = {
 export const mockModalForm = {
   id: "mock-modal-form-id",
   fields: [mockModalFormField],
+};
+
+export const mockTransitionBenchmarkModalForm = {
+  id: "mock-transition-benchmark-modal-form-id",
+  fields: [mockTransitionBenchmarkFormField],
 };
 
 export const mockDrawerForm = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Before:

<img width="826" alt="Screenshot 2024-06-07 at 11 54 39 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/22605393-3cc6-4606-a60f-468d153c037e">


**After:**

<img width="840" alt="Screenshot 2024-06-07 at 11 55 09 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/e30cebd7-7fac-4043-bc47-b371ccd30d6c">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3679

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Load up a WP
Enter the Transition Benchmarks
Mark all the defaults as a no
See the error above the benchmarks
Add a new benchmark, call it 'a'
Attempt to another add a new benchmark called 'a'
See the error appears in the modal at the same time as the one on the main page with different text.
Close the modal
Reopen and see the errors gone in the modal unless you type 'a' again.
Mark a default benchmark as a yes and see the original alert on the page is gone.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

