### PR TITLE
cmdct-3684 - add missing intro text to closeout section

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -1176,7 +1176,12 @@
               "verbiage": {
                 "intro": {
                   "section": "State or Territory-Specific Initiatives: IV. Initiative close-out information",
-                  "hint": "Complete the section below for initiatives with an end date during the upcoming semi-annual reporting period."
+                  "info": [
+                    {
+                      "type": "html",
+                      "content": "Complete the section below for initiatives with an end date during the upcoming semi-annual reporting period."
+                    }
+                  ]
                 },
                 "closeOutWarning": {
                   "title": "Warning",


### PR DESCRIPTION
### Description

Added the missing text from close-out section:
<img width="1006" alt="Screenshot 2024-06-04 at 1 04 01 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/391938f7-bea1-47c7-99c1-cc8de15b7ba5">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3684

---
### How to test
Go into a WP that was copied over, to Transition Benchmarks, to Close-Out section, see that the text is on the page.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
