### PR TITLE
[CMDCT-3693] - Update getLastCreatedWorkPlan to return the oldest workplan thats eligible

### DIFF
--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
 import * as authFunctions from "../../utils/auth/authorization";
-import { getLastCreatedWorkPlan } from "../../utils/other/other";
+import { getEligbleWorkPlan } from "../../utils/other/other";
 import { putReportMetadata, putReportFieldData } from "../../storage/reports";
 // types
 import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
@@ -25,7 +25,7 @@ jest.mock("../../storage/reports", () => ({
 
 jest.mock("../../utils/other/other", () => ({
   ...jest.requireActual("../../utils/other/other"),
-  getLastCreatedWorkPlan: jest.fn(),
+  getEligbleWorkPlan: jest.fn(),
 }));
 
 jest.mock("../../utils/other/copy", () => ({
@@ -218,13 +218,13 @@ describe("Test createReport API method", () => {
   });
 
   test("If no WP given when creating a SAR, return 404", async () => {
-    (getLastCreatedWorkPlan as jest.Mock).mockResolvedValue({});
+    (getEligbleWorkPlan as jest.Mock).mockResolvedValue({});
     const res = await createReport(sarCreationEvent, null);
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
   });
 
   test("Test successful run of sar report creation, not copied", async () => {
-    (getLastCreatedWorkPlan as jest.Mock).mockResolvedValue({
+    (getEligbleWorkPlan as jest.Mock).mockResolvedValue({
       workPlanMetadata: mockWPMetadata,
       workPlanFieldData: mockWPFieldData,
     });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
 import * as authFunctions from "../../utils/auth/authorization";
-import { getEligbleWorkPlan } from "../../utils/other/other";
+import { getEligibleWorkPlan } from "../../utils/other/other";
 import { putReportMetadata, putReportFieldData } from "../../storage/reports";
 // types
 import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
@@ -25,7 +25,7 @@ jest.mock("../../storage/reports", () => ({
 
 jest.mock("../../utils/other/other", () => ({
   ...jest.requireActual("../../utils/other/other"),
-  getEligbleWorkPlan: jest.fn(),
+  getEligibleWorkPlan: jest.fn(),
 }));
 
 jest.mock("../../utils/other/copy", () => ({
@@ -218,13 +218,13 @@ describe("Test createReport API method", () => {
   });
 
   test("If no WP given when creating a SAR, return 404", async () => {
-    (getEligbleWorkPlan as jest.Mock).mockResolvedValue({});
+    (getEligibleWorkPlan as jest.Mock).mockResolvedValue({});
     const res = await createReport(sarCreationEvent, null);
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
   });
 
   test("Test successful run of sar report creation, not copied", async () => {
-    (getEligbleWorkPlan as jest.Mock).mockResolvedValue({
+    (getEligibleWorkPlan as jest.Mock).mockResolvedValue({
       workPlanMetadata: mockWPMetadata,
       workPlanFieldData: mockWPFieldData,
     });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -16,7 +16,7 @@ import {
 } from "../../utils/time/time";
 import {
   createReportName,
-  getEligbleWorkPlan,
+  getEligibleWorkPlan,
   getReportPeriod,
   getReportYear,
 } from "../../utils/other/other";
@@ -68,7 +68,7 @@ export const createReport = handler(
       workPlanFieldData?: AnyObject;
     } =
       reportType === ReportType.SAR
-        ? await getEligbleWorkPlan(state)
+        ? await getEligibleWorkPlan(state)
         : { workPlanMetadata: undefined, workPlanFieldData: undefined };
 
     // If we recieved no work plan information and we're trying to create a SAR, return NO_WORKPLANS_FOUND

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -16,7 +16,7 @@ import {
 } from "../../utils/time/time";
 import {
   createReportName,
-  getLastCreatedWorkPlan,
+  getEligbleWorkPlan,
   getReportPeriod,
   getReportYear,
 } from "../../utils/other/other";
@@ -57,7 +57,7 @@ export const createReport = handler(
     const reportTypeExpanded = reportNames[reportType];
 
     /*
-     * Begin Section - If creating a SAR Submission, find the last Work Plan created that hasn't been used
+     * Begin Section - If creating a SAR Submission, find the oldest Work Plan created that hasn't been used
      * to create a different SAR and attach all of its fieldData to the SAR Submissions FieldData
      */
     const {
@@ -68,7 +68,7 @@ export const createReport = handler(
       workPlanFieldData?: AnyObject;
     } =
       reportType === ReportType.SAR
-        ? await getLastCreatedWorkPlan(state)
+        ? await getEligbleWorkPlan(state)
         : { workPlanMetadata: undefined, workPlanFieldData: undefined };
 
     // If we recieved no work plan information and we're trying to create a SAR, return NO_WORKPLANS_FOUND

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -148,7 +148,7 @@ describe("API utility functions", () => {
   });
 
   describe("getEligbleWorkPlan", () => {
-    it("Should retrieve the oldest eligible work plan", async () => {
+    it("Should retrieve the most recent eligible work plan", async () => {
       (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
         {
           status: ReportStatus.IN_PROGRESS,
@@ -166,13 +166,13 @@ describe("API utility functions", () => {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1720000000000,
-          id: "not-oldest",
+          id: "just-right",
         },
         {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1710000000000,
-          id: "just-right",
+          id: "too-old",
         },
         {
           status: ReportStatus.APPROVED,

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -148,7 +148,7 @@ describe("API utility functions", () => {
   });
 
   describe("getEligbleWorkPlan", () => {
-    it("Should retrieve the most recent eligible work plan", async () => {
+    it("Should retrieve the oldest eligible work plan", async () => {
       (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
         {
           status: ReportStatus.IN_PROGRESS,
@@ -166,13 +166,13 @@ describe("API utility functions", () => {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1720000000000,
-          id: "just-right",
+          id: "not-oldest",
         },
         {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1710000000000,
-          id: "too-old",
+          id: "just-right",
         },
         {
           status: ReportStatus.APPROVED,

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -1,8 +1,4 @@
-import {
-  getReportPeriod,
-  getReportYear,
-  getLastCreatedWorkPlan,
-} from "./other";
+import { getReportPeriod, getReportYear, getEligbleWorkPlan } from "./other";
 import {
   getReportFieldData,
   queryReportMetadatasForState,
@@ -151,8 +147,8 @@ describe("API utility functions", () => {
     });
   });
 
-  describe("getLastCreatedWorkPlan", () => {
-    it("Should retrieve the most recent eligible work plan", async () => {
+  describe("getEligbleWorkPlan", () => {
+    it("Should retrieve the oldest eligible work plan", async () => {
       (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
         {
           status: ReportStatus.IN_PROGRESS,
@@ -170,19 +166,19 @@ describe("API utility functions", () => {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1720000000000,
-          id: "just-right",
+          id: "not-oldest",
         },
         {
           status: ReportStatus.APPROVED,
           associatedSar: undefined,
           createdAt: 1710000000000,
-          id: "not-latest",
+          id: "just-right",
         },
       ]);
       const mockFieldData = { id: "just-right-data" };
       (getReportFieldData as jest.Mock).mockResolvedValue(mockFieldData);
 
-      const result = await getLastCreatedWorkPlan("CO");
+      const result = await getEligbleWorkPlan("CO");
 
       expect(result.workPlanMetadata!.id).toBe("just-right");
       expect(result.workPlanFieldData).toBe(mockFieldData);
@@ -204,7 +200,7 @@ describe("API utility functions", () => {
         },
       ]);
 
-      const result = await getLastCreatedWorkPlan("CO");
+      const result = await getEligbleWorkPlan("CO");
 
       expect(result.workPlanMetadata).toBeUndefined();
       expect(result.workPlanFieldData).toBeUndefined();

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -1,4 +1,4 @@
-import { getReportPeriod, getReportYear, getEligbleWorkPlan } from "./other";
+import { getReportPeriod, getReportYear, getEligibleWorkPlan } from "./other";
 import {
   getReportFieldData,
   queryReportMetadatasForState,
@@ -147,7 +147,7 @@ describe("API utility functions", () => {
     });
   });
 
-  describe("getEligbleWorkPlan", () => {
+  describe("getEligibleWorkPlan", () => {
     it("Should retrieve the oldest eligible work plan", async () => {
       (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
         {
@@ -185,7 +185,7 @@ describe("API utility functions", () => {
       const mockFieldData = { id: "just-right-data" };
       (getReportFieldData as jest.Mock).mockResolvedValue(mockFieldData);
 
-      const result = await getEligbleWorkPlan("CO");
+      const result = await getEligibleWorkPlan("CO");
 
       expect(result.workPlanMetadata!.id).toBe("just-right");
       expect(result.workPlanFieldData).toBe(mockFieldData);
@@ -207,7 +207,7 @@ describe("API utility functions", () => {
         },
       ]);
 
-      const result = await getEligbleWorkPlan("CO");
+      const result = await getEligibleWorkPlan("CO");
 
       expect(result.workPlanMetadata).toBeUndefined();
       expect(result.workPlanFieldData).toBeUndefined();

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -174,6 +174,13 @@ describe("API utility functions", () => {
           createdAt: 1710000000000,
           id: "just-right",
         },
+        {
+          status: ReportStatus.APPROVED,
+          archived: true,
+          associatedSar: undefined,
+          createdAt: 1700000000000,
+          id: "is-archived",
+        },
       ]);
       const mockFieldData = { id: "just-right-data" };
       (getReportFieldData as jest.Mock).mockResolvedValue(mockFieldData);

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -44,7 +44,7 @@ export const getEligbleWorkPlan = async (
   }
 
   const workPlanMetadata = eligibleWorkPlans.reduce((mostRecent, wp) =>
-    mostRecent.createdAt < wp.createdAt ? mostRecent : wp
+    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
   );
   const workPlanFieldData = await getReportFieldData(workPlanMetadata);
   return { workPlanMetadata, workPlanFieldData };

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -27,7 +27,7 @@ export const createReportName = (
   return `${fullStateName} MFP ${reportName} ${reportYear} - Period ${period}`;
 };
 
-export const getEligbleWorkPlan = async (
+export const getEligibleWorkPlan = async (
   state: State
 ): Promise<{
   workPlanMetadata?: ReportMetadataShape;

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -27,7 +27,7 @@ export const createReportName = (
   return `${fullStateName} MFP ${reportName} ${reportYear} - Period ${period}`;
 };
 
-export const getLastCreatedWorkPlan = async (
+export const getEligbleWorkPlan = async (
   state: State
 ): Promise<{
   workPlanMetadata?: ReportMetadataShape;
@@ -43,7 +43,7 @@ export const getLastCreatedWorkPlan = async (
   }
 
   const workPlanMetadata = eligibleWorkPlans.reduce((mostRecent, wp) =>
-    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
+    mostRecent.createdAt < wp.createdAt ? mostRecent : wp
   );
   const workPlanFieldData = await getReportFieldData(workPlanMetadata);
   return { workPlanMetadata, workPlanFieldData };

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -44,7 +44,7 @@ export const getEligbleWorkPlan = async (
   }
 
   const workPlanMetadata = eligibleWorkPlans.reduce((mostRecent, wp) =>
-    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
+    mostRecent.createdAt < wp.createdAt ? mostRecent : wp
   );
   const workPlanFieldData = await getReportFieldData(workPlanMetadata);
   return { workPlanMetadata, workPlanFieldData };

--- a/services/app-api/utils/other/other.ts
+++ b/services/app-api/utils/other/other.ts
@@ -35,7 +35,8 @@ export const getEligbleWorkPlan = async (
 }> => {
   const allWorkPlans = await queryReportMetadatasForState(ReportType.WP, state);
   const eligibleWorkPlans = allWorkPlans.filter(
-    (wp) => wp.status === ReportStatus.APPROVED && !wp.associatedSar
+    (wp) =>
+      wp.status === ReportStatus.APPROVED && !wp.associatedSar && !wp?.archived
   );
   if (eligibleWorkPlans.length === 0) {
     // There were no eligible work plans to treat as a base for this SAR

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -14,7 +14,7 @@ import {
   putReport,
   sortReportsOldestToNewest,
   useStore,
-  getEligbleWorkPlan,
+  getEligibleWorkPlan,
 } from "utils";
 import {
   ErrorVerbiage,
@@ -127,7 +127,7 @@ export const ReportProvider = ({ children }: Props) => {
         selectedState
       );
 
-      const workplan = getEligbleWorkPlan(workPlanSubmissions);
+      const workplan = getEligibleWorkPlan(workPlanSubmissions);
 
       if (workplan) {
         const reportKeys = {

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -14,7 +14,7 @@ import {
   putReport,
   sortReportsOldestToNewest,
   useStore,
-  getLastSubmission,
+  getEligbleWorkPlan,
 } from "utils";
 import {
   ErrorVerbiage,
@@ -127,13 +127,13 @@ export const ReportProvider = ({ children }: Props) => {
         selectedState
       );
 
-      const lastFoundSubmission = getLastSubmission(workPlanSubmissions);
+      const workplan = getEligbleWorkPlan(workPlanSubmissions);
 
-      if (lastFoundSubmission) {
+      if (workplan) {
         const reportKeys = {
           reportType: ReportType.WP,
           state: selectedState,
-          id: lastFoundSubmission["id"],
+          id: workplan["id"],
         };
 
         const workPlan = await getReport(reportKeys);

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -40,20 +40,6 @@ describe("Test getEligbleWorkplan function", () => {
   it("should grab the oldest eligble workplan", async () => {
     const submissions: ReportMetadataShape[] = [
       {
-        reportType: "WP",
-        state: "NJ",
-        id: "2Xv4Me4q00ztl41PakEf7nxGPtp",
-        submissionName: "New Jersey Work Plan 2023 - Period 2",
-        status: ReportStatus.APPROVED,
-        createdAt: 1699496172798,
-        lastAltered: 1699496172798,
-        lastAlteredBy: "Anthony Soprano",
-        dueDate: convertDateEtToUtc("11/01/2023"),
-        reportPeriod: 2,
-        reportYear: 2023,
-        locked: false,
-      },
-      {
         submissionName: "New Jersey Work Plan 2023 - Period 2",
         dueDate: convertDateEtToUtc("11/01/2023"),
         lastAlteredBy: "Anthony Soprano",
@@ -63,13 +49,41 @@ describe("Test getEligbleWorkplan function", () => {
         reportYear: 2023,
         lastAltered: 1699496227241,
         state: "NJ",
-        id: "2Xv4TaPFSy9Q0ZGSVB0wuzwtAnA",
+        id: "too-new",
         locked: false,
         status: ReportStatus.APPROVED,
       },
+      {
+        reportType: "WP",
+        state: "NJ",
+        id: "just-right",
+        submissionName: "New Jersey Work Plan 2023 - Period 1",
+        status: ReportStatus.APPROVED,
+        createdAt: 1699496130000,
+        lastAltered: 1699496172798,
+        lastAlteredBy: "Anthony Soprano",
+        dueDate: convertDateEtToUtc("11/01/2023"),
+        reportPeriod: 2,
+        reportYear: 2023,
+        locked: false,
+      },
+      {
+        reportType: "WP",
+        state: "NJ",
+        id: "way-too-new",
+        submissionName: "New Jersey Work Plan 2024 - Period 2",
+        status: ReportStatus.APPROVED,
+        createdAt: 1699496172798,
+        lastAltered: 1699496172798,
+        lastAlteredBy: "Anthony Soprano",
+        dueDate: convertDateEtToUtc("11/01/2023"),
+        reportPeriod: 2,
+        reportYear: 2023,
+        locked: false,
+      },
     ];
 
-    expect(getEligbleWorkPlan(submissions)).toBe(submissions[0]);
+    expect(getEligbleWorkPlan(submissions)).toBe(submissions[1]);
   });
 
   it("should return undefined if not given a submission", async () => {

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,4 +1,4 @@
-import { flattenReportRoutesArray, getLastSubmission } from "./reports";
+import { flattenReportRoutesArray, getEligbleWorkPlan } from "./reports";
 //types
 import { ReportMetadataShape, ReportRoute, ReportStatus } from "types";
 import { convertDateEtToUtc } from "utils/other/time";
@@ -37,7 +37,7 @@ describe("flattenReportRoutesArray", () => {
 });
 
 describe("Test lastFoundSubmission function", () => {
-  it("should grab the last submission based on the time", async () => {
+  it("should grab the most recently created submission", async () => {
     const submissions: ReportMetadataShape[] = [
       {
         reportType: "WP",
@@ -69,15 +69,15 @@ describe("Test lastFoundSubmission function", () => {
       },
     ];
 
-    expect(getLastSubmission(submissions)).toBe(submissions[1]);
+    expect(getEligbleWorkPlan(submissions)).toBe(submissions[1]);
   });
 
   it("should return undefined if not given a submission", async () => {
     const submissions: ReportMetadataShape[] = [];
-    expect(getLastSubmission(submissions)).toBe(undefined);
+    expect(getEligbleWorkPlan(submissions)).toBe(undefined);
   });
 
-  it("should return undefined if given submissions but none are of right type", async () => {
+  it("should return undefined if given submissions but none are eligble", async () => {
     const submissions: ReportMetadataShape[] = [
       {
         reportType: "WP",
@@ -93,7 +93,22 @@ describe("Test lastFoundSubmission function", () => {
         reportYear: 2023,
         locked: false,
       },
+      {
+        reportType: "WP",
+        state: "NJ",
+        id: "2Xv4Me4q00ztl41PakEf7nxGPtp",
+        submissionName: "New Jersey Work Plan 2023 - Period 2",
+        status: ReportStatus.APPROVED,
+        archived: true,
+        createdAt: 1699496172798,
+        lastAltered: 1699496172798,
+        lastAlteredBy: "Anthony Soprano",
+        dueDate: convertDateEtToUtc("11/01/2023"),
+        reportPeriod: 2,
+        reportYear: 2023,
+        locked: false,
+      },
     ];
-    expect(getLastSubmission(submissions)).toBe(undefined);
+    expect(getEligbleWorkPlan(submissions)).toBe(undefined);
   });
 });

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,4 +1,4 @@
-import { flattenReportRoutesArray, getEligbleWorkPlan } from "./reports";
+import { flattenReportRoutesArray, getEligibleWorkPlan } from "./reports";
 //types
 import { ReportMetadataShape, ReportRoute, ReportStatus } from "types";
 import { convertDateEtToUtc } from "utils/other/time";
@@ -36,7 +36,7 @@ describe("flattenReportRoutesArray", () => {
   });
 });
 
-describe("Test getEligbleWorkplan function", () => {
+describe("Test getEligibleWorkPlan function", () => {
   it("should grab the oldest eligble workplan", async () => {
     const submissions: ReportMetadataShape[] = [
       {
@@ -83,12 +83,12 @@ describe("Test getEligbleWorkplan function", () => {
       },
     ];
 
-    expect(getEligbleWorkPlan(submissions)).toBe(submissions[1]);
+    expect(getEligibleWorkPlan(submissions)).toBe(submissions[1]);
   });
 
   it("should return undefined if not given a submission", async () => {
     const submissions: ReportMetadataShape[] = [];
-    expect(getEligbleWorkPlan(submissions)).toBe(undefined);
+    expect(getEligibleWorkPlan(submissions)).toBe(undefined);
   });
 
   it("should return undefined if given submissions but none are eligble", async () => {
@@ -123,6 +123,6 @@ describe("Test getEligbleWorkplan function", () => {
         locked: false,
       },
     ];
-    expect(getEligbleWorkPlan(submissions)).toBe(undefined);
+    expect(getEligibleWorkPlan(submissions)).toBe(undefined);
   });
 });

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -36,8 +36,8 @@ describe("flattenReportRoutesArray", () => {
   });
 });
 
-describe("Test lastFoundSubmission function", () => {
-  it("should grab the most recently created submission", async () => {
+describe("Test getEligbleWorkplan function", () => {
+  it("should grab the oldest eligble workplan", async () => {
     const submissions: ReportMetadataShape[] = [
       {
         reportType: "WP",
@@ -69,7 +69,7 @@ describe("Test lastFoundSubmission function", () => {
       },
     ];
 
-    expect(getEligbleWorkPlan(submissions)).toBe(submissions[1]);
+    expect(getEligbleWorkPlan(submissions)).toBe(submissions[0]);
   });
 
   it("should return undefined if not given a submission", async () => {

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -77,7 +77,8 @@ export const getEligbleWorkPlan = (
     // There were no eligible work plans to treat as a base for this SAR
     return undefined;
   }
+  //Return the oldest eligble workplan
   return eligibleWorkPlans.reduce((mostRecent, wp) =>
-    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
+    mostRecent.createdAt < wp.createdAt ? mostRecent : wp
   );
 };

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -66,24 +66,18 @@ export const compileValidationJsonFromFields = (
   return validationSchema;
 };
 
-export const getLastSubmission = (
+export const getEligbleWorkPlan = (
   workPlanSubmissions: ReportMetadataShape[]
 ) => {
-  let lastFoundSubmission: ReportMetadataShape | undefined = undefined;
-  workPlanSubmissions.forEach((submission: ReportMetadataShape) => {
-    if (
-      submission.status === ReportStatus.APPROVED &&
-      !submission?.associatedSar
-    ) {
-      if (
-        lastFoundSubmission &&
-        submission.createdAt > lastFoundSubmission?.createdAt
-      )
-        lastFoundSubmission = submission;
-      else if (!lastFoundSubmission) {
-        lastFoundSubmission = submission;
-      }
-    }
-  });
-  return lastFoundSubmission;
+  const eligibleWorkPlans = workPlanSubmissions.filter(
+    (wp) =>
+      wp.status === ReportStatus.APPROVED && !wp.associatedSar && !wp?.archived
+  );
+  if (eligibleWorkPlans.length === 0) {
+    // There were no eligible work plans to treat as a base for this SAR
+    return undefined;
+  }
+  return eligibleWorkPlans.reduce((mostRecent, wp) =>
+    mostRecent.createdAt > wp.createdAt ? mostRecent : wp
+  );
 };

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -66,7 +66,7 @@ export const compileValidationJsonFromFields = (
   return validationSchema;
 };
 
-export const getEligbleWorkPlan = (
+export const getEligibleWorkPlan = (
   workPlanSubmissions: ReportMetadataShape[]
 ) => {
   const eligibleWorkPlans = workPlanSubmissions.filter(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

When creating a SAR and associating it with a Work Plan, we will...

**Current:**

1. Find all Eligible Workplans (Ones that are approved and are not associated with a SAR)
2. Pick the newest workplan of that list

**Updated To**:
1. Find all Eligible Workplans (Ones that are approved and are not associated with a SAR **and are not archived**)
2. Pick the **oldest** workplan of that list



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3693

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Create 2 work plans
Fill them both out
Approve them
Create a SAR
See the SAR picked the oldest workplan of the two.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary

