### PR TITLE
[CMDCT-3681] - Update SAR Creation Modal to check only applicable populations

### DIFF
--- a/services/ui-src/src/components/modals/CreateSarModal.tsx
+++ b/services/ui-src/src/components/modals/CreateSarModal.tsx
@@ -7,11 +7,7 @@ import sarFormJson from "forms/addEditSarReport/addEditSarReport.json";
 // utils
 import { AnyObject, FormJson, ReportStatus, ReportType } from "types";
 import { States } from "../../constants";
-import {
-  injectFormWithTargetPopulations,
-  removeNotApplicablePopulations,
-  useStore,
-} from "utils";
+import { injectFormWithTargetPopulations, useStore } from "utils";
 
 const reportType = ReportType.SAR;
 
@@ -39,11 +35,9 @@ export const CreateSarModal = ({
     ? selectedReport?.formData?.populations
     : workPlanToCopyFrom?.fieldData?.targetPopulations;
 
-  const filteredDataToInject = removeNotApplicablePopulations(dataToInject);
-
   const form: FormJson = injectFormWithTargetPopulations(
     sarFormJson,
-    filteredDataToInject,
+    dataToInject,
     !!selectedReport?.id
   );
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -41,7 +41,7 @@ import {
 import {
   convertTargetPopulationsFromWPToSAREntity,
   parseCustomHtml,
-  removeNotApplicablePopulations,
+  getApplicablePopulations,
   useBreakpoint,
   useStore,
 } from "utils";
@@ -197,7 +197,7 @@ export const DashboardPage = ({ reportType }: Props) => {
           stateOrTerritory: userState,
           reportPeriod: workPlanToCopyFrom?.reportPeriod,
           populations: convertTargetPopulationsFromWPToSAREntity(
-            removeNotApplicablePopulations(
+            getApplicablePopulations(
               workPlanToCopyFrom?.fieldData?.targetPopulations
             )
           ),

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -5,11 +5,12 @@ import {
   fillEmptyQuarters,
   hydrateFormFields,
   injectFormWithTargetPopulations,
-  removeNotApplicablePopulations,
+  removeNotDefaultAndNotApplicablePopulations,
   resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
   disableCopiedFundingSources,
+  removeNotApplicablePopulations,
 } from "./forms";
 // types
 import { FormField, ReportShape } from "types";
@@ -112,6 +113,34 @@ describe("form utilities", () => {
     });
   });
 
+  describe("Test removeNotDefaultAndNotApplicablePopulations", () => {
+    const exampleTargetPopulations = [
+      mockTargetPopReqButNotApplicable,
+      mockTargetPopReqButApplicable,
+      mockTargetPopReqButApplicableIsUndefined,
+      mockTargetPopButOtherApplicable,
+      mockTargetPopButOtherNotApplicable,
+      mockTargetPopByOtherNotDefined,
+      mockTargetPopDefaultButNotApplicable,
+      mockTargetPopDefaultAndApplicable,
+    ];
+
+    it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration that is not a default population", async () => {
+      const filteredPopulations = removeNotDefaultAndNotApplicablePopulations(
+        exampleTargetPopulations
+      );
+      expect(filteredPopulations.length).toBe(6);
+      expect(filteredPopulations).toEqual([
+        mockTargetPopReqButApplicable,
+        mockTargetPopReqButApplicableIsUndefined,
+        mockTargetPopButOtherApplicable,
+        mockTargetPopByOtherNotDefined,
+        mockTargetPopDefaultButNotApplicable,
+        mockTargetPopDefaultAndApplicable,
+      ]);
+    });
+  });
+
   describe("Test removeNotApplicablePopulations", () => {
     const exampleTargetPopulations = [
       mockTargetPopReqButNotApplicable,
@@ -124,17 +153,14 @@ describe("form utilities", () => {
       mockTargetPopDefaultAndApplicable,
     ];
 
-    it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration", async () => {
+    it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration ", async () => {
       const filteredPopulations = removeNotApplicablePopulations(
         exampleTargetPopulations
       );
-      expect(filteredPopulations.length).toBe(6);
+      expect(filteredPopulations.length).toBe(3);
       expect(filteredPopulations).toEqual([
         mockTargetPopReqButApplicable,
-        mockTargetPopReqButApplicableIsUndefined,
         mockTargetPopButOtherApplicable,
-        mockTargetPopByOtherNotDefined,
-        mockTargetPopDefaultButNotApplicable,
         mockTargetPopDefaultAndApplicable,
       ]);
     });

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -5,12 +5,12 @@ import {
   fillEmptyQuarters,
   hydrateFormFields,
   injectFormWithTargetPopulations,
-  removeNotDefaultAndNotApplicablePopulations,
+  getDefaultAndApplicablePopulations,
   resetClearProp,
   setClearedEntriesToDefaultValue,
   sortFormErrors,
   disableCopiedFundingSources,
-  removeNotApplicablePopulations,
+  getApplicablePopulations,
 } from "./forms";
 // types
 import { FormField, ReportShape } from "types";
@@ -113,7 +113,7 @@ describe("form utilities", () => {
     });
   });
 
-  describe("Test removeNotDefaultAndNotApplicablePopulations", () => {
+  describe("Test getDefaultAndApplicablePopulations", () => {
     const exampleTargetPopulations = [
       mockTargetPopReqButNotApplicable,
       mockTargetPopReqButApplicable,
@@ -126,7 +126,7 @@ describe("form utilities", () => {
     ];
 
     it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration that is not a default population", async () => {
-      const filteredPopulations = removeNotDefaultAndNotApplicablePopulations(
+      const filteredPopulations = getDefaultAndApplicablePopulations(
         exampleTargetPopulations
       );
       expect(filteredPopulations.length).toBe(6);
@@ -141,7 +141,7 @@ describe("form utilities", () => {
     });
   });
 
-  describe("Test removeNotApplicablePopulations", () => {
+  describe("Test getApplicablePopulations", () => {
     const exampleTargetPopulations = [
       mockTargetPopReqButNotApplicable,
       mockTargetPopReqButApplicable,
@@ -154,7 +154,7 @@ describe("form utilities", () => {
     ];
 
     it("should filter out any target population that has a no value for transitionBenchmarks_applicableToMfpDemonstration ", async () => {
-      const filteredPopulations = removeNotApplicablePopulations(
+      const filteredPopulations = getApplicablePopulations(
         exampleTargetPopulations
       );
       expect(filteredPopulations.length).toBe(3);

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -369,7 +369,7 @@ export const updateRenderFields = (
   };
 
   const filteredTargetPopulations =
-    removeNotApplicablePopulations(targetPopulations);
+    removeNotDefaultAndNotApplicablePopulations(targetPopulations);
 
   // This one always has to be at the end for...reasons
   filteredTargetPopulations?.push(hcbsPopulation);
@@ -432,7 +432,7 @@ export const injectFormWithTargetPopulations = (
  * @return {AnyObject[]} Target populations filtered to no long has No answers from
  * transitionBenchmarks_applicableToMfpDemonstration
  */
-export const removeNotApplicablePopulations = (
+export const removeNotDefaultAndNotApplicablePopulations = (
   targetPopulations: AnyObject[]
 ) => {
   const defaultPopulationNames = getDefaultTargetPopulationNames();
@@ -448,6 +448,16 @@ export const removeNotApplicablePopulations = (
   });
   return filteredPopulations;
 };
+
+export const removeNotApplicablePopulations = (
+  targetPopulations: AnyObject[]
+) =>
+  targetPopulations?.filter(
+    (population) =>
+      population?.transitionBenchmarks_applicableToMfpDemonstration &&
+      population?.transitionBenchmarks_applicableToMfpDemonstration?.[0]
+        ?.value !== "No"
+  );
 
 //This function is used to fill out the missing quarters in cards for evaluation plan and funding sources after a copy over
 export const fillEmptyQuarters = (quarters: AnyObject[]) => {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -369,7 +369,7 @@ export const updateRenderFields = (
   };
 
   const filteredTargetPopulations =
-    removeNotDefaultAndNotApplicablePopulations(targetPopulations);
+    getDefaultAndApplicablePopulations(targetPopulations);
 
   // This one always has to be at the end for...reasons
   filteredTargetPopulations?.push(hcbsPopulation);
@@ -432,7 +432,7 @@ export const injectFormWithTargetPopulations = (
  * @return {AnyObject[]} Target populations filtered to no long has No answers from
  * transitionBenchmarks_applicableToMfpDemonstration
  */
-export const removeNotDefaultAndNotApplicablePopulations = (
+export const getDefaultAndApplicablePopulations = (
   targetPopulations: AnyObject[]
 ) => {
   const defaultPopulationNames = getDefaultTargetPopulationNames();
@@ -449,9 +449,7 @@ export const removeNotDefaultAndNotApplicablePopulations = (
   return filteredPopulations;
 };
 
-export const removeNotApplicablePopulations = (
-  targetPopulations: AnyObject[]
-) =>
+export const getApplicablePopulations = (targetPopulations: AnyObject[]) =>
   targetPopulations?.filter(
     (population) =>
       population?.transitionBenchmarks_applicableToMfpDemonstration &&

--- a/services/ui-src/src/utils/testing/mockEntities.tsx
+++ b/services/ui-src/src/utils/testing/mockEntities.tsx
@@ -143,7 +143,7 @@ export const mockTargetPopDefaultButNotApplicable = {
 };
 
 export const mockTargetPopDefaultAndApplicable = {
-  id: "7",
+  id: "8",
   transitionBenchmarks_targetPopulationName: "Older adults",
   isRequired: true,
   transitionBenchmarks_applicableToMfpDemonstration: [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Before:
<img width="530" alt="Screenshot 2024-06-11 at 12 37 19 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/8bdba80e-8915-4c62-bcd0-2e888ed26c3c">

After:
<img width="529" alt="Screenshot 2024-06-11 at 12 36 57 PM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/19439679/5071b723-261a-471e-9aa6-111da3d5be44">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3681

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Fill out, submit and approve a Work plan preferably with an additional other target population
Create a SAR and see in the modal only the populations you checked as applicable are checked.
After you create the SAR see that the dashboard only lists out the populations that were applicable.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
