### PR TITLE
Adjust SAR dashboard error logic

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -321,7 +321,7 @@ describe("Test error banner on SAR dashboard", () => {
   });
   test("Check that error banner is enabled in SAR when latest WP IS NOT approved", () => {
     mockedUseStore.mockReturnValue(mockReportStore);
-    render(sarDashboardViewWithReports);
+    render(sarDashboardWithNoReports);
     const errorBannerText = screen.queryByText(
       "You must have an approved MFP Work Plan not previously used in a MFP Semi-Annual Progress Report (SAR) in order to add a new MFP SAR"
     );

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable multiline-comment-style */
 import { useContext, useEffect, useState } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { States } from "../../../constants";
@@ -92,6 +91,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   const [selectedReport, setSelectedReport] = useState<AnyObject | undefined>(
     undefined
   );
+  const [showSarAlert, setShowSarAlert] = useState<boolean>(false);
 
   const dashboardVerbiageMap: any = {
     WP: wpVerbiage,
@@ -108,8 +108,22 @@ export const DashboardPage = ({ reportType }: Props) => {
   const activeState =
     userIsAdmin || userIsReadOnly ? adminSelectedState : userState;
 
-  const showSarAlert =
-    reportType === ReportType.SAR && !workPlanToCopyFrom && reportsToDisplay;
+  useEffect(() => {
+    const activeSarList =
+      reportsToDisplay &&
+      reportsToDisplay.filter((report: ReportMetadataShape) => {
+        return (
+          report.reportType === ReportType.SAR &&
+          report.status !== ReportStatus.SUBMITTED &&
+          report?.archived !== true
+        );
+      });
+    const shouldShowAlert =
+      reportType === ReportType.SAR &&
+      !workPlanToCopyFrom &&
+      activeSarList?.length === 0;
+    setShowSarAlert(shouldShowAlert);
+  }, [reportsToDisplay, workPlanToCopyFrom]);
 
   useEffect(() => {
     // if no activeState, go to homepage

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -109,20 +109,20 @@ export const DashboardPage = ({ reportType }: Props) => {
     userIsAdmin || userIsReadOnly ? adminSelectedState : userState;
 
   useEffect(() => {
-    const activeSarList =
-      reportsToDisplay &&
-      reportsToDisplay.filter((report: ReportMetadataShape) => {
-        return (
-          report.reportType === ReportType.SAR &&
-          report.status !== ReportStatus.SUBMITTED &&
-          report?.archived !== true
-        );
-      });
-    const shouldShowAlert =
-      reportType === ReportType.SAR &&
-      !workPlanToCopyFrom &&
-      activeSarList?.length === 0;
-    setShowSarAlert(shouldShowAlert);
+    let showAlert = false;
+    if (reportType === ReportType.SAR) {
+      const activeSarList = reportsToDisplay?.filter(
+        (report: ReportMetadataShape) => {
+          return (
+            report.reportType === ReportType.SAR &&
+            report.status !== ReportStatus.SUBMITTED &&
+            report?.archived !== true
+          );
+        }
+      );
+      showAlert = !workPlanToCopyFrom && activeSarList?.length === 0;
+    }
+    setShowSarAlert(showAlert);
   }, [reportsToDisplay, workPlanToCopyFrom]);
 
   useEffect(() => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Ensure SAR error alert only shows up under the following conditions
- You are on the SAR dashboard
&&
- There is no WP ready to be associated with a SAR (meaning there is no approved WP at all, or none that are not already associated with a SAR)
&&
- There is no existing SAR that is incomplete (incomplete meaning it is not submitted or archived)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3647

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Test locally
- Log in as `stateuser@test.com` and go to the SAR dashboard
- Use the `yarn db:seed` script to generate an approved WP
- Refresh the SAR dashboard and verify the error message disappears
- Create a SAR
- Verify there is still no error message
- Fill out and submit the SAR
- Verify the error message shows up on the dashboard again

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment