### PR TITLE
Cmdct 3662 - remove button from inside link

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -177,7 +177,7 @@ const sx = {
   },
   leaveFormText: {
     border: "1px solid",
-    padding: ".5rem 1.5rem",
+    padding: ".5rem 1rem",
     borderRadius: "5px",
     color: "palette.primary",
     fontWeight: "bold",

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -72,11 +72,11 @@ export const Header = ({ handleLogout }: Props) => {
                   as={RouterLink}
                   to={report?.formTemplate.basePath || "/"}
                   sx={sx.leaveFormLink}
-                  variant="unstyled"
+                  variant="outlineButton"
                   tabIndex={-1}
                 >
                   {!isMobile ? (
-                    <Text sx={sx.leaveFormText}>Leave form</Text>
+                    <>Leave form</>
                   ) : (
                     <Image src={closeIcon} alt="Close" sx={sx.closeIcon} />
                   )}
@@ -174,12 +174,5 @@ const sx = {
   },
   closeIcon: {
     width: "2rem",
-  },
-  leaveFormText: {
-    border: "1px solid",
-    padding: ".5rem 1rem",
-    borderRadius: "5px",
-    color: "palette.primary",
-    fontWeight: "bold",
   },
 };

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -2,15 +2,7 @@ import { useContext } from "react";
 import { Link as RouterLink } from "react-router-dom";
 // components
 import { UsaBanner } from "@cmsgov/design-system";
-import {
-  Box,
-  Button,
-  Container,
-  Flex,
-  Image,
-  Link,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Container, Flex, Image, Link, Text } from "@chakra-ui/react";
 import { Menu, MenuOption, ReportContext } from "components";
 // utils
 import { useBreakpoint, useStore } from "utils";
@@ -84,7 +76,7 @@ export const Header = ({ handleLogout }: Props) => {
                   tabIndex={-1}
                 >
                   {!isMobile ? (
-                    <Button variant="outline">Leave form</Button>
+                    <Text sx={sx.leaveFormText}>Leave form</Text>
                   ) : (
                     <Image src={closeIcon} alt="Close" sx={sx.closeIcon} />
                   )}
@@ -182,5 +174,12 @@ const sx = {
   },
   closeIcon: {
     width: "2rem",
+  },
+  leaveFormText: {
+    border: "1px solid",
+    padding: ".5rem 1.5rem",
+    borderRadius: "5px",
+    color: "palette.primary",
+    fontWeight: "bold",
   },
 };

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -274,6 +274,22 @@ const theme = extendTheme({
             textDecoration: "none",
           },
         },
+        outlineButton: {
+          color: "palette.primary",
+          border: "1px solid",
+          padding: ".5rem 1rem",
+          borderRadius: "5px",
+          fontWeight: "bold",
+          textDecoration: "none",
+          _visited: { color: "palette.primary" },
+          ":hover, :visited:hover": {
+            color: "palette.primary_darker",
+            textDecoration: "none",
+          },
+          ".mobile &": {
+            border: "none",
+          },
+        },
       },
       defaultProps: {
         variant: "primary",

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -142,7 +142,7 @@ describe("MFP Work Plan E2E Submission", () => {
 
     cy.contains("Successfully Submitted").should("be.visible");
 
-    cy.get('button:contains("Leave form")').focus().click();
+    cy.get('text:contains("Leave form")').focus().click();
     cy.url().should("include", "/wp");
     cy.contains("2").should("be.visible");
   });

--- a/tests/cypress/e2e/wp/form.cy.js
+++ b/tests/cypress/e2e/wp/form.cy.js
@@ -142,7 +142,7 @@ describe("MFP Work Plan E2E Submission", () => {
 
     cy.contains("Successfully Submitted").should("be.visible");
 
-    cy.get('text:contains("Leave form")').focus().click();
+    cy.get("a:contains('Leave form')").focus().click();
     cy.url().should("include", "/wp");
     cy.contains("2").should("be.visible");
   });


### PR DESCRIPTION
### Description
The "Leave form" call to action should be marked up as a link and there should be no <button> element inside.
The "Leave form" call to action should be styled as an outline button

original:

<img width="390" alt="Screenshot 2024-06-13 at 9 53 17 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/22454493/af82ed18-29a5-4dd1-9859-e6f2373086a5">


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3662

---
### How to test
Login, create WP, enter WP and see that 'Leave form' still looks the same but is no longer a `button`.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
