### PR TITLE
Format aria labels for PDF table headers

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.test.tsx
@@ -3,6 +3,7 @@ import { axe } from "jest-axe";
 import { useStore } from "utils";
 import {
   mockReportStore,
+  mockReportFieldData,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { ModalDrawerReportPageVerbiage } from "types";
@@ -147,6 +148,33 @@ describe("ExportedModalDrawerReportSection table", () => {
 
     // renders "Not answered" for each quarter given no entity data
     expect(screen.queryAllByText("Not answered").length).toBe(12);
+  });
+
+  test("renders aria labels for target populations with abbreviated names", async () => {
+    const mockReport = {
+      ...mockReportStore,
+      report: {
+        ...mockReportStore.report,
+        fieldData: {
+          ...mockReportFieldData,
+          entityType: [
+            {
+              transitionBenchmarks_targetPopulationName:
+                "A very long target population name",
+              transitionBenchmarks_targetPopulationName_short: "ABC",
+            },
+          ],
+        },
+      },
+    };
+
+    mockedUseStore.mockReturnValue(mockReport);
+    render(tableComponent);
+
+    expect(screen.getByText("ABC")).toBeVisible();
+    expect(
+      screen.getByLabelText("A very long target population name")
+    ).toBeVisible();
   });
 });
 

--- a/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalDrawerReportSection.tsx
@@ -16,16 +16,32 @@ export const ExportedModalDrawerReportSection = ({
   const entities = report?.fieldData?.[entityType];
   const { reportPeriod, reportYear } = report!;
 
-  // if Transition Benchmark Header title has an abbrev. just display that
   const getTableHeaders = () => {
     let headers = [];
-    const quarterHeader = "Pop. by Quarter";
-    const bodyHeaders = entities.map(
-      (entity: EntityShape) =>
-        entity.transitionBenchmarks_targetPopulationName_short ??
-        entity.transitionBenchmarks_targetPopulationName.slice(0, 29)
-    );
-    const totalHeader = "Total by Quarter";
+    let bodyHeaders = [];
+    const quarterHeader = {
+      displayName: "Pop. by Quarter",
+      ariaLabel: "Population by Quarter",
+    };
+
+    const totalHeader = {
+      displayName: "Total by Quarter",
+      ariaLabel: "Total by Quarter",
+    };
+
+    for (const entity of entities) {
+      const shortName = entity.transitionBenchmarks_targetPopulationName_short;
+      const longName = entity.transitionBenchmarks_targetPopulationName.slice(
+        0,
+        29
+      );
+      const ariaLabel = entity.transitionBenchmarks_targetPopulationName;
+
+      bodyHeaders.push({
+        displayName: shortName ?? longName,
+        ariaLabel: ariaLabel,
+      });
+    }
 
     headers.push(quarterHeader, ...bodyHeaders, totalHeader);
     return headers;
@@ -137,10 +153,19 @@ export const ExportedModalDrawerReportSection = ({
     return displayValue;
   };
 
+  const generateHeaderAriaLabels = () => {
+    let ariaHeaders = getTableHeaders().map((obj) => obj.ariaLabel);
+    return {
+      headRow: [...ariaHeaders],
+    };
+  };
+
   const generateMainTable = () => {
     // create new quarter value array
     let newQuarterValueArray = new Array(...quarterValueArray);
-    let tableHeadersArray = new Array(...getTableHeaders());
+
+    let tableHeadersArray = getTableHeaders().map((obj) => obj.displayName);
+
     {
       overflow === true ? tableHeadersArray.pop() : null;
     }
@@ -206,7 +231,7 @@ export const ExportedModalDrawerReportSection = ({
     let overflowQuarterValueArray = newQuarterValueArray.filter(
       (arr: string[]) => newQuarterValueArray.indexOf(arr) > 5
     );
-    let tableHeadersArray = new Array(...getTableHeaders());
+    let tableHeadersArray = getTableHeaders().map((obj) => obj.displayName);
 
     const formatBodyRow = () => {
       let bodyRows = [];
@@ -245,6 +270,7 @@ export const ExportedModalDrawerReportSection = ({
     const formatOverflowTableHeaders = () => {
       const overflowTableHeadersArray = [];
       overflowTableHeadersArray.push(tableHeadersArray[0]);
+
       tableHeadersArray.find((arr) => {
         if (tableHeadersArray.indexOf(arr) > 6) {
           overflowTableHeadersArray.push(arr);
@@ -294,7 +320,11 @@ export const ExportedModalDrawerReportSection = ({
         </>
       )}
       <Box sx={overflow ? sx.overflowStyles : {}}>
-        <Table sx={sx.table} content={generateMainTable()}></Table>
+        <Table
+          sx={sx.table}
+          content={generateMainTable()}
+          ariaOverride={generateHeaderAriaLabels()}
+        ></Table>
         {overflow && (
           <Table sx={sx.table} content={generateOverflowTable()}></Table>
         )}


### PR DESCRIPTION
### Description
Adds aria-labels with full-length entity names for the truncated PDF table headers. Currently only impacts the target population headings for Transition Benchmarks in the Work Plan.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3682

---
### How to test
Link: https://d2yjt98l5zoxbx.cloudfront.net/

- Create a work plan
- Go straight to the Review & Submit section and view the PDF page.
- In the "Transition Benchmark Totals" section, the table headers for default populations should be abbreviated
- Inspect the source code for the table headers. Each `th` should have an `aria-label` attribute and it should contain the full text for the header.

<img width="735" alt="Screenshot 2024-06-14 at 10 36 17 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/6719c0df-fc02-4951-b991-ac866f981005">

<img width="775" alt="Screenshot 2024-06-14 at 10 37 48 AM" src="https://github.com/Enterprise-CMCS/macpro-mdct-mfp/assets/522911/cfcf5379-82d9-481b-ae0e-3cfaf46a763d">

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
