### PR TITLE
[Bug Fix] Persist Report in Zustand Store

### DIFF
--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 // types
 import {
   MfpUserState,
@@ -129,12 +129,18 @@ const entityStore = (set: Function) => ({
 
 export const useStore = create(
   // devtools is being used for debugging state
-  devtools<MfpUserState & AdminBannerState & MfpReportState & MfpEntityState>(
-    (set) => ({
-      ...userStore(set),
-      ...bannerStore(set),
-      ...reportStore(set),
-      ...entityStore(set),
-    })
+  persist(
+    devtools<MfpUserState & AdminBannerState & MfpReportState & MfpEntityState>(
+      (set) => ({
+        ...userStore(set),
+        ...bannerStore(set),
+        ...reportStore(set),
+        ...entityStore(set),
+      })
+    ),
+    {
+      name: "mfp-store",
+      partialize: (state) => ({ report: state.report }),
+    }
   )
 );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
In this PR: https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/653, the `persist` middleware was removed from the Zustand store to fix a user authentication bug. However, it's caused an issue where upon exporting a report, the report object is no longer in the store and a PDF is not able to generate properly. Here we're partializing the store to allow the report to persist across tabs.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in as a state user
- Create a report
- Export as PDF

It should load correctly for you.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
