### PR TITLE
Remove client certificates and fix run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.4.1",
     "serverless": "^3.38.0",
-    "serverless-api-client-certificate": "^1.0.2",
     "serverless-bundle": "^6.0.0",
     "serverless-dotenv-plugin": "^3.0.0",
     "serverless-iam-helper": "github:Enterprise-CMCS/serverless-iam-helper",

--- a/run
+++ b/run
@@ -75,4 +75,4 @@ fi
 
 # build and run dev.ts
 # tsc is configured to build what we expect in tsconfig.json
-./node_modules/.bin/tsc && node ./build_dev/run.js "${ARGS[@]}"
+./node_modules/.bin/tsc && node ./build_dev/run.js "${ARGS[@]-}"

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -13,7 +13,6 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-iam-helper
   - serverless-s3-bucket-helper
-  - serverless-api-client-certificate
   - serverless-offline
   - "@enterprise-cmcs/serverless-waf-plugin"
 
@@ -59,13 +58,6 @@ custom:
     - ${env:VPC_SUBNET_A, ssm:/configuration/${self:custom.stage}/vpc/subnets/private/a/id, ssm:/configuration/default/vpc/subnets/private/a/id}
     - ${env:VPC_SUBNET_B, ssm:/configuration/${self:custom.stage}/vpc/subnets/private/b/id, ssm:/configuration/default/vpc/subnets/private/b/id}
     - ${env:VPC_SUBNET_C, ssm:/configuration/${self:custom.stage}/vpc/subnets/private/c/id, ssm:/configuration/default/vpc/subnets/private/c/id}
-  serverlessApiClientCertificate:
-    rotateCerts: true
-    daysLeft: 30
-  authValue:
-    main: aws_iam
-    val: aws_iam
-    production: aws_iam
 params:
   main:
     topicNamespace: ""
@@ -149,7 +141,7 @@ functions:
           path: banners/{bannerId}
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -161,7 +153,7 @@ functions:
           path: banners/{bannerId}
           method: delete
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -173,7 +165,7 @@ functions:
           path: banners/{bannerId}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -185,7 +177,7 @@ functions:
           path: templates/{templateName}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -197,7 +189,7 @@ functions:
           path: reports/archive/{reportType}/{state}/{id}
           method: put
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -211,7 +203,7 @@ functions:
           path: reports/{reportType}/{state}
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -224,7 +216,7 @@ functions:
           path: reports/{reportType}/{state}/{id}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -238,7 +230,7 @@ functions:
           path: reports/{reportType}/{state}
           method: get
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -251,7 +243,7 @@ functions:
           path: reports/release/{reportType}/{state}/{id}
           method: put
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -266,7 +258,7 @@ functions:
           path: reports/submit/{reportType}/{state}/{id}
           method: post
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -282,7 +274,7 @@ functions:
           path: reports/{reportType}/{state}/{id}
           method: put
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:
@@ -298,7 +290,7 @@ functions:
           path: reports/approve/{reportType}/{state}/{id}
           method: put
           cors: true
-          authorizer: ${self:custom.authValue.${self:custom.stage}, ""}
+          authorizer: aws_iam
           request:
             parameters:
               paths:

--- a/src/run.ts
+++ b/src/run.ts
@@ -193,4 +193,5 @@ yargs(process.argv.slice(2))
     }
   )
   .scriptName("run")
+  .strict()
   .demandCommand(1, "").argv; // this prints out the help if you don't call a subcommand

--- a/yarn.lock
+++ b/yarn.lock
@@ -11133,11 +11133,6 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serverless-api-client-certificate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/serverless-api-client-certificate/-/serverless-api-client-certificate-1.0.2.tgz#9113f3ad3862faf8615a37733ca09a1409ced8dd"
-  integrity sha512-snlEA1129NpZGYc0ra1eae17dKPYOXrju7cN+ku8roo6XOSMvNPe4XmEf0vVojoVHburXmI+Yx7y8DgJYeM2Fg==
-
 serverless-bundle@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serverless-bundle/-/serverless-bundle-6.0.0.tgz#c2d3b6bb8fd1e0a49043af3a022673f7a03c8011"


### PR DESCRIPTION
### Description
It was noticed after the destroy action modifications, that AwsApiGateway Client Certificates were leaking and not being cleaned up.  Our previous destroy script had a specific action item to clean these certificates up, but because they had been leaking, the quota was overrun which was causing deployment issues.  

The initial effort to resolve included exploring the following:
- modifying the serverless stage destroyer to clean up certs;  this was abandonded when it was found that certs are not tagged and would have to be collected by namespace
- adding a custom resource that would be triggered by a Cloudformation stack event to clean them up

But after additional digging, it was appearing that the plugin used to manage the certs was in fact causing leaks, as each ephem would have two certs, with only one being bound to the Cloudformation template.  After even more digging, it didn't seem like they were even being used.  Additionally any SecHub findings would be addressed by simply not leaving the authorizer blank for ephem environments.  

This PR does two things:
- remove the client cert plugin from the yaml, remove it from the dependencies, and remove the switching for environments for Lambda authorizer, setting it to aws_iam to assert iam authentication between the api gateway and the function
- Fix the run script to ensure it can take no arguments, and will return all options when no arguments are supplied.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3744

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Simply click through the ephem to ensure it works as expected.  Issuing `run local` to test locally as well.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Nothing should materially change.  The certs will need to be cleaned up manually at some point.  No new certs will be created.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
