### PR TITLE
Fix WP test to start from clean slate

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import dotenv from "dotenv";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-dotenv.config();
+dotenv.config({ path: "./.env" });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -57,7 +57,7 @@ export async function archiveExistingWPs({ page }) {
 
   await page.getByLabel("MFP Work Plan").click();
   await page.getByRole("button", { name: "Go to Report Dashboard" }).click();
-  await page.waitForResponse(`${process.env.API_URL}/reports/WP/PR`);
+  await page.waitForResponse(process.env.API_URL + "/reports/WP/PR");
 
   const archiveButtons = await page.getByRole("button", { name: "Archive" });
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,3 +1,5 @@
+import { Locator } from "@playwright/test";
+
 export async function logInStateUser({ page }) {
   await page.goto("/");
 
@@ -32,4 +34,36 @@ export async function logOut({ page }) {
   await logoutButton.click();
   await page.evaluate(() => window.localStorage.clear());
   await page.goto("/");
+}
+
+/* Recursive function to click any archive buttons that appear on screen. */
+async function archiveReports(buttons: Locator) {
+  const archiveButtons = await buttons.all();
+
+  if (archiveButtons.length > 0) {
+    await archiveButtons[0].click();
+    await archiveReports(buttons);
+  }
+}
+
+export async function archiveExistingWPs({ page }) {
+  await logInAdminUser({ page });
+
+  await page
+    .getByRole("combobox", {
+      name: "List of states, including District of Columbia and Puerto Rico",
+    })
+    .selectOption("Puerto Rico");
+
+  await page.getByLabel("MFP Work Plan").click();
+  await page.getByRole("button", { name: "Go to Report Dashboard" }).click();
+  await page.waitForResponse(`${process.env.API_URL}/reports/WP/PR`);
+
+  const archiveButtons = await page.getByRole("button", { name: "Archive" });
+
+  if (archiveButtons) {
+    await archiveReports(archiveButtons);
+  }
+
+  await logOut({ page });
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -57,7 +57,7 @@ export async function archiveExistingWPs({ page }) {
 
   await page.getByLabel("MFP Work Plan").click();
   await page.getByRole("button", { name: "Go to Report Dashboard" }).click();
-  await page.waitForResponse(process.env.API_URL + "/reports/WP/PR");
+  await page.waitForResponse(`**/reports/WP/PR`);
 
   const archiveButtons = await page.getByRole("button", { name: "Archive" });
 

--- a/tests/e2e/wp.spec.ts
+++ b/tests/e2e/wp.spec.ts
@@ -1,39 +1,10 @@
-import { test, expect, Locator } from "@playwright/test";
-import { logInStateUser, logInAdminUser, logOut } from "./helpers";
+import { test, expect } from "@playwright/test";
+import { logInStateUser, archiveExistingWPs } from "./helpers";
 
 const currentYear = new Date().getFullYear();
 
-/* Recursive function to click any archive buttons that appear on screen. */
-async function archiveReports(buttons: Locator) {
-  const archiveButtons = await buttons.all();
-
-  if (archiveButtons.length > 0) {
-    await archiveButtons[0].click();
-    await archiveReports(buttons);
-  }
-}
-
-/* There is almost certainly a better way to do this via the API? */
-test.beforeEach(async ({ page }) => {
-  await logInAdminUser({ page });
-
-  await page.getByRole("combobox").selectOption("Puerto Rico");
-  await page.getByLabel("MFP Work Plan").click();
-  await page.getByRole("button", { name: "Go to Report Dashboard" }).click();
-
-  expect(page).toHaveURL("/wp");
-  await expect(page.getByRole("table")).toBeVisible();
-
-  const archiveButtons = await page.getByRole("button", { name: "Archive" });
-
-  if (archiveButtons) {
-    await archiveReports(archiveButtons);
-  }
-
-  await logOut({ page });
-});
-
 test("State user can create a work plan", async ({ page }) => {
+  await archiveExistingWPs({ page });
   await logInStateUser({ page });
 
   await expect(
@@ -47,11 +18,14 @@ test("State user can create a work plan", async ({ page }) => {
   await page.getByRole("button", { name: "Enter Work Plan online" }).click();
 
   expect(page).toHaveURL("/wp");
+  await page.getByRole("table");
 
-  await expect(
-    page.getByRole("button", { name: "Start MFP Work Plan" })
-  ).toBeVisible();
-  await page.getByRole("button", { name: "Start MFP Work Plan" }).click();
+  const createButton = await page.getByRole("button", {
+    name: "Start MFP Work Plan",
+  });
+
+  expect(createButton).toBeVisible();
+  await createButton.click();
 
   await expect(page.getByRole("dialog")).toBeVisible();
   await expect(page.getByRole("dialog")).toContainText("Add new MFP Work Plan");


### PR DESCRIPTION
Added helper function to archive work plans before starting the state user test