### PR TITLE
Organize theme files

### DIFF
--- a/services/ui-src/src/components/cards/EntityStepCard.tsx
+++ b/services/ui-src/src/components/cards/EntityStepCard.tsx
@@ -10,7 +10,6 @@ import {
   ReportType,
 } from "types";
 // assets
-import { svgFilters } from "styles/theme";
 import completedIcon from "assets/icons/icon_check_circle.png";
 import deleteIcon from "assets/icons/icon_cancel_x_circle.png";
 import editIcon from "assets/icons/icon_edit.png";
@@ -19,6 +18,7 @@ import { fillEmptyQuarters, useStore } from "utils";
 import { ObjectiveProgressEntity } from "./ObjectiveProgressEntity";
 import { EvaluationPlanEntity } from "./EvaluationPlanEntity";
 import { FundingSourcesEntity } from "./FundingSourcesEntity";
+import { svgFilters } from "styles/foundations/filters";
 
 export const EntityStepCard = ({
   entity,

--- a/services/ui-src/src/components/cards/TemplateCard.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.tsx
@@ -55,7 +55,7 @@ export const TemplateCard = ({
           <Flex sx={sx.actionsFlex}>
             {verbiage.downloadText && (
               <Button
-                variant="link"
+                variant="transparent"
                 sx={sx.templateDownloadButton}
                 leftIcon={
                   <Image

--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -44,7 +44,7 @@ export const Drawer = ({
           <Button
             sx={sx.drawerCloseButton}
             leftIcon={<CloseIcon />}
-            variant="link"
+            variant="transparent"
             onClick={onClose as MouseEventHandler}
           >
             Close

--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -47,7 +47,7 @@ export const Modal = ({
           <Button
             sx={sx.modalClose}
             leftIcon={<Image src={closeIcon} alt="Close" sx={sx.closeIcon} />}
-            variant="link"
+            variant="transparent"
             onClick={modalDisclosure.onClose}
           >
             Close
@@ -79,7 +79,7 @@ export const Modal = ({
             )}
             <Button
               sx={sx.close}
-              variant="link"
+              variant="transparent"
               onClick={modalDisclosure.onClose}
             >
               {content.closeButtonText}

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -242,7 +242,7 @@ const AdminReleaseButton = ({
   return (
     <Td>
       <Button
-        variant="link"
+        variant="transparent"
         disabled={isDisabled}
         sx={sxOverride.adminActionButton}
         onClick={() => releaseReport!(report)}
@@ -262,7 +262,7 @@ const AdminArchiveButton = ({
   return (
     <Td>
       <Button
-        variant="link"
+        variant="transparent"
         sx={sxOverride.adminActionButton}
         onClick={() => archive(report)}
         disabled={report?.archived}

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -192,7 +192,7 @@ const AdminReleaseButton = ({
 
   return (
     <Button
-      variant="link"
+      variant="transparent"
       disabled={isDisabled}
       sx={sxOverride.adminActionButton}
       onClick={() => releaseReport!(report)}
@@ -209,7 +209,7 @@ const AdminArchiveButton = ({
 }: AdminArchiveButtonProps) => {
   return (
     <Button
-      variant="link"
+      variant="transparent"
       sx={sxOverride.adminActionButton}
       onClick={() => archive(report)}
       disabled={report?.archived}

--- a/services/ui-src/src/styles/components/button.ts
+++ b/services/ui-src/src/styles/components/button.ts
@@ -1,0 +1,106 @@
+import { ComponentStyleConfig } from "@chakra-ui/react";
+
+const baseStyles = {
+  transition: "all 0.3s ease",
+  borderRadius: "0.25rem",
+  px: "1.5em",
+  py: "0.5em",
+  fontWeight: "bold",
+  width: "fit-content",
+  "&:disabled, &:disabled:hover": {
+    color: "palette.gray",
+    backgroundColor: "palette.gray_lighter",
+  },
+};
+
+const primaryVariant = {
+  backgroundColor: "palette.primary",
+  color: "palette.white",
+  "&:hover": {
+    backgroundColor: "palette.primary_darker",
+  },
+  "&:visited, &:visited:hover": {
+    backgroundColor: "palette.primary",
+    color: "palette.white",
+  },
+  "&:disabled, &:disabled:hover": {
+    color: "palette.gray",
+    backgroundColor: "palette.gray_lighter",
+  },
+};
+
+const outlineVariant = {
+  backgroundColor: "transparent",
+  border: "1px solid",
+  borderColor: "palette.primary",
+  color: "palette.primary",
+  textDecoration: "none",
+  "&:hover": {
+    backgroundColor: "transparent",
+    color: "palette.primary_darker",
+  },
+  "&:visited, &:visited:hover": {
+    backgroundColor: "transparent",
+    color: "palette.primary",
+  },
+  "&:disabled, &:disabled:hover": {
+    color: "palette.gray_lighter",
+    borderColor: "palette.gray_lighter",
+  },
+};
+
+const transparentVariant = {
+  backgroundColor: "transparent",
+  color: "palette.primary",
+  textDecoration: "underline",
+  padding: "0",
+  "&:hover": {
+    backgroundColor: "transparent",
+    color: "palette.primary_darker",
+  },
+  "&:visited, &:visited:hover": {
+    backgroundColor: "transparent",
+    color: "palette.primary",
+  },
+  "&:disabled, &:disabled:hover": {
+    color: "palette.gray_lighter",
+  },
+};
+
+const variants = {
+  primary: primaryVariant,
+  outline: outlineVariant,
+  transparent: transparentVariant,
+};
+
+const sizes = {
+  sm: {
+    fontSize: "sm",
+    fontWeight: "400",
+    px: "0.5em",
+    py: "0.25em",
+  },
+  md: {
+    fontSize: "md",
+    fontWeight: "700",
+    px: "1.5em",
+    py: "0.5em",
+  },
+  lg: {
+    fontSize: "lg",
+    px: "1.5em",
+    py: "1em",
+  },
+};
+
+const buttonTheme: ComponentStyleConfig = {
+  baseStyle: baseStyles,
+  sizes: sizes,
+  variants: variants,
+  defaultProps: {
+    variant: "primary",
+    size: "md",
+  },
+};
+
+export default buttonTheme;

--- a/services/ui-src/src/styles/components/button.ts
+++ b/services/ui-src/src/styles/components/button.ts
@@ -46,6 +46,7 @@ const outlineVariant = {
   "&:disabled, &:disabled:hover": {
     color: "palette.gray_lighter",
     borderColor: "palette.gray_lighter",
+    backgroundColor: "transparent",
   },
 };
 

--- a/services/ui-src/src/styles/components/button.ts
+++ b/services/ui-src/src/styles/components/button.ts
@@ -64,6 +64,7 @@ const transparentVariant = {
   },
   "&:disabled, &:disabled:hover": {
     color: "palette.gray_lighter",
+    backgroundColor: "transparent",
   },
 };
 

--- a/services/ui-src/src/styles/components/index.ts
+++ b/services/ui-src/src/styles/components/index.ts
@@ -1,0 +1,7 @@
+import buttonTheme from "./button";
+import linkTheme from "./link";
+
+export const components = {
+  Button: buttonTheme,
+  Link: linkTheme,
+};

--- a/services/ui-src/src/styles/components/link.ts
+++ b/services/ui-src/src/styles/components/link.ts
@@ -5,7 +5,7 @@ const baseStyles = {
   transition: "all 0.3s ease",
 };
 
-const primaryVarian = {
+const primaryVariant = {
   color: "palette.primary",
   _visited: {
     color: "palette.primary",

--- a/services/ui-src/src/styles/components/link.ts
+++ b/services/ui-src/src/styles/components/link.ts
@@ -1,0 +1,71 @@
+import { ComponentStyleConfig } from "@chakra-ui/react";
+
+const baseStyles = {
+  textDecoration: "underline",
+  transition: "all 0.3s ease",
+};
+
+const primaryVarian = {
+  color: "palette.primary",
+  _visited: {
+    color: "palette.primary",
+    textDecorationColor: "palette.primary",
+  },
+  ":hover, :visited:hover": {
+    color: "palette.primary_darker",
+    textDecorationColor: "palette.primary_darker",
+  },
+};
+
+const inverseVariant = {
+  color: "palette.white",
+  _visited: {
+    color: "palette.white",
+    textDecorationColor: "palette.white",
+  },
+  ":hover, :visited:hover": {
+    color: "palette.gray_lighter",
+    textDecorationColor: "palette.gray_lighter",
+  },
+};
+
+const unstyledVariant = {
+  textDecoration: "none",
+  ":focus, :focus-visible, :hover, :visited, :visited:hover": {
+    textDecoration: "none",
+  },
+};
+
+const unstyledButtonVariant = {
+  color: "palette.primary",
+  border: "1px solid",
+  padding: ".5rem 1rem",
+  borderRadius: "5px",
+  fontWeight: "bold",
+  textDecoration: "none",
+  _visited: { color: "palette.primary" },
+  ":hover, :visited:hover": {
+    color: "palette.primary_darker",
+    textDecoration: "none",
+  },
+  ".mobile &": {
+    border: "none",
+  },
+};
+
+const variants = {
+  primary: primaryVarian,
+  inverse: inverseVariant,
+  unstyled: unstyledVariant,
+  outlineButton: unstyledButtonVariant,
+};
+
+const linkTheme: ComponentStyleConfig = {
+  baseStyle: baseStyles,
+  variants: variants,
+  defaultProps: {
+    variant: "primary",
+  },
+};
+
+export default linkTheme;

--- a/services/ui-src/src/styles/components/link.ts
+++ b/services/ui-src/src/styles/components/link.ts
@@ -54,7 +54,7 @@ const unstyledButtonVariant = {
 };
 
 const variants = {
-  primary: primaryVarian,
+  primary: primaryVariant,
   inverse: inverseVariant,
   unstyled: unstyledVariant,
   outlineButton: unstyledButtonVariant,

--- a/services/ui-src/src/styles/foundations/breakpoints.ts
+++ b/services/ui-src/src/styles/foundations/breakpoints.ts
@@ -1,0 +1,8 @@
+export const breakpoints = {
+  // read this: https://bit.ly/3xSWnDt
+  base: "0em", // mobile (<=35em|560px)
+  sm: "35em", // tablet (>35em|560px and <=55em|880px)
+  md: "55em", // desktop, small (>55em|880px and <=75em|1200px)
+  lg: "75em", // desktop, large (>75em|1200px and <=100em|1600px)
+  xl: "100em", // desktop, ultrawide (>100em|1600px)
+};

--- a/services/ui-src/src/styles/foundations/colors.ts
+++ b/services/ui-src/src/styles/foundations/colors.ts
@@ -1,0 +1,59 @@
+export const colors = {
+  palette: {
+    // primary
+    primary: "#0071bc",
+    primary_darker: "#004f84",
+    primary_darkest: "#00395e",
+    // secondary
+    secondary_lightest: "#e6f9fd",
+    secondary_lighter: "#b3ecf8",
+    secondary_light: "#4ed2ee",
+    secondary: "#02bfe7",
+    secondary_dark: "#02acd0",
+    secondary_darker: "#0186a2",
+    secondary_darkest: "#016074",
+    // status: success
+    success_lightest: "#e7f3e7",
+    success_lighter: "#89c487",
+    success_light: "#2a9526",
+    success: "#12890e",
+    success_dark: "#107b0d",
+    success_darker: "#0d600a",
+    success_darkest: "#094507",
+    // status: warn
+    warn_lightest: "#fef9e9",
+    warn_lighter: "#fce28f",
+    warn_light: "#f9ca35",
+    warn: "#f8c41f",
+    warn_dark: "#dfb01c",
+    warn_darker: "#ae8916",
+    warn_darkest: "#7c6210",
+    // status: error
+    error_lightest: "#fce8ec",
+    error_lighter: "#f7bbc5",
+    error_light: "#f18e9e",
+    error: "#e31c3d",
+    error_dark: "#cc1937",
+    error_darker: "#9f142b",
+    error_darkest: "#720e1f",
+    // neutrals
+    white: "#ffffff",
+    gray_lightest: "#f2f2f2",
+    gray_lighter: "#d9d9d9",
+    gray_light: "#a6a6a6",
+    gray: "#5a5a5a",
+    gray_dark: "#404040",
+    base: "#262626",
+    black: "#000000",
+    // other
+    focus_light: "#ffffff",
+    focus_dark: "#bd13b8",
+    muted: "#e9ecf1",
+    // custom
+    gray_lightest_highlight: "#f8f8f8",
+    gray_medium: "#71767a",
+    gray_medium_dark: "#5B616B",
+    spreadsheet: "#1d6f42",
+    spreadsheet_dark: "#174320",
+  },
+};

--- a/services/ui-src/src/styles/foundations/filters.ts
+++ b/services/ui-src/src/styles/foundations/filters.ts
@@ -1,0 +1,10 @@
+export const svgFilters = {
+  primary:
+    "brightness(0) saturate(100%) invert(30%) sepia(93%) saturate(1282%) hue-rotate(181deg) brightness(91%) contrast(101%)",
+  primary_darker:
+    "brightness(0) saturate(100%) invert(19%) sepia(43%) saturate(3547%) hue-rotate(185deg) brightness(97%) contrast(101%)",
+  white:
+    "brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(7500%) hue-rotate(142deg) brightness(115%) contrast(115%);",
+  gray_lighter:
+    "brightness(0) saturate(100%) invert(91%) sepia(0%) saturate(89%) hue-rotate(162deg) brightness(97%) contrast(93%);",
+};

--- a/services/ui-src/src/styles/foundations/fonts.ts
+++ b/services/ui-src/src/styles/foundations/fonts.ts
@@ -1,0 +1,4 @@
+export const fonts = {
+  heading: "Open Sans",
+  body: "Open Sans",
+};

--- a/services/ui-src/src/styles/foundations/index.ts
+++ b/services/ui-src/src/styles/foundations/index.ts
@@ -1,9 +1,13 @@
 import { breakpoints } from "./breakpoints";
 import { fonts } from "./fonts";
 import { lineHeights } from "./lineHeights";
+import { colors } from "./colors";
+import { sizes } from "./sizes";
 
 export const foundations = {
   breakpoints: breakpoints,
+  colors: colors,
   fonts: fonts,
   lineHeights: lineHeights,
+  sizes: sizes,
 };

--- a/services/ui-src/src/styles/foundations/index.ts
+++ b/services/ui-src/src/styles/foundations/index.ts
@@ -1,0 +1,9 @@
+import { breakpoints } from "./breakpoints";
+import { fonts } from "./fonts";
+import { lineHeights } from "./lineHeights";
+
+export const foundations = {
+  breakpoints: breakpoints,
+  fonts: fonts,
+  lineHeights: lineHeights,
+};

--- a/services/ui-src/src/styles/foundations/lineHeights.ts
+++ b/services/ui-src/src/styles/foundations/lineHeights.ts
@@ -1,0 +1,8 @@
+export const lineHeights = {
+  // https://design.cms.gov/utilities/line-height/
+  normal: "normal",
+  reset: 1,
+  heading: 1.3,
+  base: 1.5,
+  lead: 1.7,
+};

--- a/services/ui-src/src/styles/foundations/sizes.ts
+++ b/services/ui-src/src/styles/foundations/sizes.ts
@@ -1,0 +1,16 @@
+export const sizes = {
+  appMax: "100vw",
+  basicPageWidth: "46rem",
+  reportPageWidth: "46rem",
+  // font sizes: https://design.cms.gov/utilities/font-size/
+  xs: "0.75rem", // 12px
+  sm: "0.875rem", // 14px
+  md: "1rem", // 16px
+  lg: "1.125rem", // 18px
+  xl: "1.3125rem", // 21px
+  "2xl": "1.5rem", // 24px
+  "3xl": "1.875rem", // 30px
+  "4xl": "2.25rem", // 36px
+  "5xl": "3rem", // 48px
+  "6xl": "3.75rem", // 60px
+};

--- a/services/ui-src/src/styles/styles.ts
+++ b/services/ui-src/src/styles/styles.ts
@@ -1,0 +1,7 @@
+export const styles = {
+  global: {
+    body: {
+      color: "palette.base",
+    },
+  },
+};

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -10,10 +10,8 @@ import { foundations } from "./foundations";
 // Component style overrides
 import { components } from "./components";
 
-// Component style overrides
-
 const theme = extendTheme({
-  foundations,
+  ...foundations,
   components,
   styles,
 });

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -5,10 +5,7 @@ import { extendTheme } from "@chakra-ui/react";
 import { styles } from "./styles";
 
 // Foundational style overrides
-import { breakpoints } from "./foundations/breakpoints";
-import { lineHeights } from "./foundations/lineHeights";
-import { fonts } from "./foundations/fonts";
-import { colors } from "./foundations/colors";
+import { foundations } from "./foundations";
 
 // Component style overrides
 import { components } from "./components";
@@ -16,26 +13,7 @@ import { components } from "./components";
 // Component style overrides
 
 const theme = extendTheme({
-  sizes: {
-    appMax: "100vw",
-    basicPageWidth: "46rem",
-    reportPageWidth: "46rem",
-    // font sizes: https://design.cms.gov/utilities/font-size/
-    xs: "0.75rem", // 12px
-    sm: "0.875rem", // 14px
-    md: "1rem", // 16px
-    lg: "1.125rem", // 18px
-    xl: "1.3125rem", // 21px
-    "2xl": "1.5rem", // 24px
-    "3xl": "1.875rem", // 30px
-    "4xl": "2.25rem", // 36px
-    "5xl": "3rem", // 48px
-    "6xl": "3.75rem", // 60px
-  },
-  breakpoints,
-  fonts,
-  lineHeights,
-  colors,
+  foundations,
   components,
   styles,
 });

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -1,16 +1,19 @@
 // Chakra UI theme info: https://chakra-ui.com/docs/styled-system/theming/theme
 import { extendTheme } from "@chakra-ui/react";
 
-export const svgFilters = {
-  primary:
-    "brightness(0) saturate(100%) invert(30%) sepia(93%) saturate(1282%) hue-rotate(181deg) brightness(91%) contrast(101%)",
-  primary_darker:
-    "brightness(0) saturate(100%) invert(19%) sepia(43%) saturate(3547%) hue-rotate(185deg) brightness(97%) contrast(101%)",
-  white:
-    "brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(7500%) hue-rotate(142deg) brightness(115%) contrast(115%);",
-  gray_lighter:
-    "brightness(0) saturate(100%) invert(91%) sepia(0%) saturate(89%) hue-rotate(162deg) brightness(97%) contrast(93%);",
-};
+// Global style overrides
+import { styles } from "./styles";
+
+// Foundational style overrides
+import { breakpoints } from "./foundations/breakpoints";
+import { lineHeights } from "./foundations/lineHeights";
+import { fonts } from "./foundations/fonts";
+import { colors } from "./foundations/colors";
+
+// Component style overrides
+import { components } from "./components";
+
+// Component style overrides
 
 const theme = extendTheme({
   sizes: {
@@ -29,286 +32,12 @@ const theme = extendTheme({
     "5xl": "3rem", // 48px
     "6xl": "3.75rem", // 60px
   },
-  breakpoints: {
-    // read this: https://bit.ly/3xSWnDt
-    base: "0em", // mobile (<=35em|560px)
-    sm: "35em", // tablet (>35em|560px and <=55em|880px)
-    md: "55em", // desktop, small (>55em|880px and <=75em|1200px)
-    lg: "75em", // desktop, large (>75em|1200px and <=100em|1600px)
-    xl: "100em", // desktop, ultrawide (>100em|1600px)
-  },
-  fonts: {
-    heading: "Open Sans",
-    body: "Open Sans",
-  },
-  lineHeights: {
-    // https://design.cms.gov/utilities/line-height/
-    normal: "normal",
-    reset: 1,
-    heading: 1.3,
-    base: 1.5,
-    lead: 1.7,
-  },
-  colors: {
-    palette: {
-      // primary
-      primary: "#0071bc",
-      primary_darker: "#004f84",
-      primary_darkest: "#00395e",
-      // secondary
-      secondary_lightest: "#e6f9fd",
-      secondary_lighter: "#b3ecf8",
-      secondary_light: "#4ed2ee",
-      secondary: "#02bfe7",
-      secondary_dark: "#02acd0",
-      secondary_darker: "#0186a2",
-      secondary_darkest: "#016074",
-      // status: success
-      success_lightest: "#e7f3e7",
-      success_lighter: "#89c487",
-      success_light: "#2a9526",
-      success: "#12890e",
-      success_dark: "#107b0d",
-      success_darker: "#0d600a",
-      success_darkest: "#094507",
-      // status: warn
-      warn_lightest: "#fef9e9",
-      warn_lighter: "#fce28f",
-      warn_light: "#f9ca35",
-      warn: "#f8c41f",
-      warn_dark: "#dfb01c",
-      warn_darker: "#ae8916",
-      warn_darkest: "#7c6210",
-      // status: error
-      error_lightest: "#fce8ec",
-      error_lighter: "#f7bbc5",
-      error_light: "#f18e9e",
-      error: "#e31c3d",
-      error_dark: "#cc1937",
-      error_darker: "#9f142b",
-      error_darkest: "#720e1f",
-      // neutrals
-      white: "#ffffff",
-      gray_lightest: "#f2f2f2",
-      gray_lighter: "#d9d9d9",
-      gray_light: "#a6a6a6",
-      gray: "#5a5a5a",
-      gray_dark: "#404040",
-      base: "#262626",
-      black: "#000000",
-      // other
-      focus_light: "#ffffff",
-      focus_dark: "#bd13b8",
-      muted: "#e9ecf1",
-      // custom
-      gray_lightest_highlight: "#f8f8f8",
-      gray_medium: "#71767a",
-      gray_medium_dark: "#5B616B",
-      spreadsheet: "#1d6f42",
-      spreadsheet_dark: "#174320",
-    },
-  },
-  components: {
-    Accordion: {
-      baseStyle: {
-        borderStyle: "none",
-      },
-    },
-    Button: {
-      baseStyle: {
-        transition: "all 0.3s ease",
-        width: "fit-content",
-        borderRadius: "0.25rem",
-        fontWeight: "bold",
-        ".mobile &": {
-          fontSize: "sm",
-        },
-      },
-      variants: {
-        // primary variants
-        primary: {
-          backgroundColor: "palette.primary",
-          color: "palette.white",
-          "&:hover": {
-            backgroundColor: "palette.primary_darker",
-          },
-          "&:disabled, &:disabled:hover": {
-            color: "palette.gray",
-            backgroundColor: "palette.gray_lighter",
-          },
-        },
-        transparent: {
-          color: "palette.primary",
-          backgroundColor: "transparent",
-          _hover: {
-            color: "palette.primary_darker",
-            backgroundColor: "transparent",
-            span: {
-              filter: svgFilters.primary_darker,
-            },
-          },
-        },
-        outline: () => ({
-          ...theme.components.Button.variants.transparent,
-          border: "1px solid",
-          borderColor: "palette.primary",
-          textDecoration: "none",
-          "&:disabled, &:disabled:hover": {
-            color: "palette.gray",
-            borderColor: "palette.gray",
-          },
-          _hover: {
-            ...theme.components.Button.variants.transparent._hover,
-            borderColor: "palette.primary_darker",
-            span: {
-              filter: svgFilters.primary_darker,
-            },
-          },
-          _visited: {
-            color: "palette.primary",
-          },
-          ":hover, :visited:hover": {
-            color: "palette.primary_darker",
-          },
-          _focus: {
-            textDecoration: "none",
-          },
-        }),
-        link: () => ({
-          ...theme.components.Button.variants.transparent,
-          textDecoration: "underline",
-        }),
-        // inverse variants
-        inverse: {
-          backgroundColor: "palette.white",
-          color: "palette.primary",
-          _hover: {
-            color: "palette.primary_darker",
-            span: {
-              filter: svgFilters.primary_darker,
-            },
-          },
-        },
-        inverse_transparent: {
-          color: "palette.white",
-          backgroundColor: "transparent",
-          span: {
-            filter: svgFilters.white,
-          },
-          _hover: {
-            color: "palette.gray_lighter",
-            backgroundColor: "transparent",
-            span: {
-              filter: svgFilters.gray_lighter,
-            },
-          },
-        },
-        inverse_outline: () => ({
-          ...theme.components.Button.variants.inverse_transparent,
-          border: "1px solid",
-          borderColor: "palette.white",
-          span: {
-            filter: svgFilters.white,
-          },
-          _hover: {
-            ...theme.components.Button.variants.transparent._hover,
-            borderColor: "palette.gray_lighter",
-            span: {
-              filter: svgFilters.gray_lighter,
-            },
-          },
-        }),
-        inverse_link: () => ({
-          ...theme.components.Button.variants.inverse_transparent,
-          textDecoration: "underline",
-        }),
-        // other
-        danger: {
-          backgroundColor: "palette.error_dark",
-          color: "palette.white",
-          _hover: {
-            backgroundColor: "palette.error_darker",
-          },
-        },
-      },
-      defaultProps: {
-        variant: "primary",
-      },
-    },
-    Heading: {
-      baseStyle: {
-        color: "palette.base",
-      },
-    },
-    Link: {
-      baseStyle: {
-        textDecoration: "underline",
-        transition: "all 0.3s ease",
-      },
-      variants: {
-        primary: {
-          color: "palette.primary",
-          _visited: {
-            color: "palette.primary",
-            textDecorationColor: "palette.primary",
-          },
-          ":hover, :visited:hover": {
-            color: "palette.primary_darker",
-            textDecorationColor: "palette.primary_darker",
-          },
-        },
-        inverse: {
-          color: "palette.white",
-          _visited: {
-            color: "palette.white",
-            textDecorationColor: "palette.white",
-          },
-          ":hover, :visited:hover": {
-            color: "palette.gray_lighter",
-            textDecorationColor: "palette.gray_lighter",
-          },
-        },
-        unstyled: {
-          textDecoration: "none",
-          ":focus, :focus-visible, :hover, :visited, :visited:hover": {
-            textDecoration: "none",
-          },
-        },
-        outlineButton: {
-          color: "palette.primary",
-          border: "1px solid",
-          padding: ".5rem 1rem",
-          borderRadius: "5px",
-          fontWeight: "bold",
-          textDecoration: "none",
-          _visited: { color: "palette.primary" },
-          ":hover, :visited:hover": {
-            color: "palette.primary_darker",
-            textDecoration: "none",
-          },
-          ".mobile &": {
-            border: "none",
-          },
-        },
-      },
-      defaultProps: {
-        variant: "primary",
-      },
-    },
-    Text: {
-      baseStyle: {
-        color: "palette.base",
-        transition: "all 0.3s ease",
-      },
-    },
-  },
-  styles: {
-    global: {
-      body: {
-        color: "palette.base",
-      },
-    },
-  },
+  breakpoints,
+  fonts,
+  lineHeights,
+  colors,
+  components,
+  styles,
 });
 
 export default theme;


### PR DESCRIPTION
### Description
[RFC](https://docs.google.com/document/d/1zyHGfboYyhncV0MXnoCNipn1xWoD8IfAS_oVK5-FExk/edit#heading=h.rz1wnztilpui)

Proposed organization of theme files. Breaking up main theme file into more atomic pieces that include foundation styles and component styles, along with their variants.

### To Test
- This kind of touches every part of the app (ugh, sorry), so it will require looking around at all the pages
- Everything should look mostly the same and nothing obviously broken
