### PR TITLE
Fixing playwright retention period to 30 days

### DIFF
--- a/.github/workflows/delete-pages.yml
+++ b/.github/workflows/delete-pages.yml
@@ -22,13 +22,13 @@ jobs:
           python-version: 3.9
 
       - name: Run the script
-        run: python rm_old_folders.py --n-days 1 --folder-name '.'
+        run: python rm_old_folders.py --n-days 30 --folder-name '.'
 
       - name: Commit all changed files back to the repository
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: gh-pages
-          commit_message: Delete folders older than 1 days
+          commit_message: Delete folders older than 30 days
 
   #Notify the integrations channel only when a Snyk auto merge fails pr checks
   notify_on_delete_pages_failure:


### PR DESCRIPTION
### Description
I had the [delete pages workflow](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/.github/workflows/delete-pages.yml) set to delete reports older than 1 day just to validate. Now that is working we want to keep 30 days worth of reports.

This is a skipci branch so we'll need to bypass branch protection rules bc no infra is being built.


### Related ticket(s)
n/a

---
### How to test
let the nightly job run and validate tomorrow that no folders get cleaned up in the gh-pages branch. 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
