### PR TITLE
Add topic destruction to destroy mechanism

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -189,6 +189,29 @@ async function destroy_stage(options: {
     filters: filters,
     verify: options.verify,
   });
+
+  await delete_topics(options);
+}
+
+async function delete_topics(options: { stage: string }) {
+  const runner = new LabeledProcessRunner();
+  await install_deps_for_services(runner);
+  let data = { project: "mfp", stage: options.stage };
+  const deployCmd = [
+    "sls",
+    "invoke",
+    "--stage",
+    "main",
+    "--function",
+    "deleteTopics",
+    "--data",
+    JSON.stringify(data),
+  ];
+  await runner.run_command_and_output(
+    "Remove topics",
+    deployCmd,
+    "services/topics"
+  );
 }
 
 /*
@@ -226,6 +249,14 @@ yargs(process.argv.slice(2))
       verify: { type: "boolean", demandOption: false, default: true },
     },
     destroy_stage
+  )
+  .command(
+    "delete-topics",
+    "delete topics tied to serverless stage",
+    {
+      stage: { type: "string", demandOption: true },
+    },
+    delete_topics
   )
   .command(
     "update-env",


### PR DESCRIPTION
### Description
The purpose of this PR is create a run wrapper that can invoke topic destruction in the topics service.  The wrapper will be invoked in the destroy step and will ensure topics are removed when ephemeral environments are destroyed.  Just like the destroy action, this will always execute against the integration branch, targeting ephems, so while this action has been tested independently, it cannot fully be exercised until it is merged into the integration environment, but I have a high level of confidence it will work as expected.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3797

---
### How to test
To test locally
`./run delete-topics --stage [stage]`

To test in CI, this has to be merged first, and then an ephem can be stood up and destroyed.  


### Notes
Once this is merged in, the topics this branch created will need to be destroyed, and this can be accomplished from a workstation with AWS authorization to the MFP account by executing the following from the integration branch `main`
`./run delete-topics --stage topic-mgmt`


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
