### PR TITLE
add missing territories to state enum

### DIFF
--- a/services/app-api/utils/types/other.ts
+++ b/services/app-api/utils/types/other.ts
@@ -84,6 +84,7 @@ export interface ErrorVerbiage {
 const states = [
   "AL",
   "AK",
+  "AS", // American Samoa
   "AZ",
   "AR",
   "CA",
@@ -92,7 +93,9 @@ const states = [
   "DE",
   "DC",
   "FL",
+  "FM", // Federated States of Micronesia
   "GA",
+  "GU", // Guam
   "HI",
   "ID",
   "IL",
@@ -102,12 +105,14 @@ const states = [
   "KY",
   "LA",
   "ME",
+  "MH", // Marshall Islands
   "MD",
   "MA",
   "MI",
   "MN",
   "MS",
   "MO",
+  "MP", // Northern Mariana Islands
   "MT",
   "NE",
   "NV",
@@ -122,6 +127,7 @@ const states = [
   "OR",
   "PA",
   "PR",
+  "PW", // Palau
   "RI",
   "SC",
   "SD",
@@ -130,6 +136,7 @@ const states = [
   "UT",
   "VT",
   "VA",
+  "VI", // Virgin Islands
   "WA",
   "WV",
   "WI",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add remaining US territories to backend list

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3830

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://dfjaxidlcbkne.cloudfront.net/
- Log in as an admin user
- Attempt to go to the dashboard for any of the territories added
- Verify it loads and the reports fetch in the network tab returns a 200 (even if empty)

Go to MFP dev
- Repeat the above steps and verify it throws an error (400) when you attempt a territory that was added in this Pull Request

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
The frontend already has a full list (which is what generates the admin dropdown). I just made sure the backend had the same list.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary