### PR TITLE
Only run upload report in lower envs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,10 +317,10 @@ jobs:
           retention-days: 30
 
   upload-reports:
-    name: Uppload Reports
+    name: Upload Reports
     needs:
       - test
-    if: always()
+    if: ${{ always() && github.ref_name != 'production' }}
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.timestampid.outputs.timestamp }}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I noticed an issue where Upload Report for playwright was running and failing in production even though the tests do not run in production. I think it was because of the `if: always()` condition. I modified it to be "always so long as it's not production"

[Production deploy with failed upload](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/9877736178/job/27280595541)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Next time prod deploys it does not fail this step, or run it at all


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment
