### PR TITLE
Refactor calculate due date for Work Plans 2024 - Period 2

### DIFF
--- a/services/app-api/utils/time/time.test.ts
+++ b/services/app-api/utils/time/time.test.ts
@@ -69,12 +69,6 @@ describe("calculateDueDate()", () => {
       });
     });
 
-    test("returns WP due date in 2024 as 9/1", () => {
-      const currentYear = 2024;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("09/01/2024");
-    });
-
     test("returns SAR due date as 8/29", () => {
       const currentYear = 2022;
       reportType = ReportType.SAR;
@@ -95,12 +89,6 @@ describe("calculateDueDate()", () => {
       });
     });
 
-    test("returns WP due date in 2024 as 9/3", () => {
-      const currentYear = 2024;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("09/03/2024");
-    });
-
     test("returns SAR due date as 3/1", () => {
       const currentYear = 2022;
       reportType = ReportType.SAR;
@@ -113,6 +101,29 @@ describe("calculateDueDate()", () => {
       reportType = ReportType.SAR;
       const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
       expect(dueDate).toBe("02/29/2024");
+    });
+  });
+
+  describe("Calculate due dates for 2024", () => {
+    const currentYear = 2024;
+    const reportType = ReportType.WP;
+
+    describe("Period 1", () => {
+      const reportPeriod = 1;
+
+      test("returns WP due date in 2024 as 9/1", () => {
+        const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+        expect(dueDate).toBe("09/01/2024");
+      });
+    });
+
+    describe("Period 2", () => {
+      const reportPeriod = 2;
+
+      test("returns WP due date in 2024 as 9/3", () => {
+        const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+        expect(dueDate).toBe(`09/03/2024`);
+      });
     });
   });
 });

--- a/services/app-api/utils/time/time.test.ts
+++ b/services/app-api/utils/time/time.test.ts
@@ -61,22 +61,18 @@ describe("calculateDueDate()", () => {
     const reportPeriod = 1;
     let reportType = ReportType.WP;
 
-    test("returns WP due date in 2022 as 5/1", () => {
-      const currentYear = 2022;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("05/01/2022");
+    test("returns WP due date as 5/1", () => {
+      const years = [2022, 2023, 2025];
+      years.forEach((currentYear) => {
+        const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+        expect(dueDate).toBe(`05/01/${currentYear}`);
+      });
     });
 
     test("returns WP due date in 2024 as 9/1", () => {
       const currentYear = 2024;
       const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
       expect(dueDate).toBe("09/01/2024");
-    });
-
-    test("returns WP due date in 2025 as 5/1", () => {
-      const currentYear = 2025;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("05/01/2025");
     });
 
     test("returns SAR due date as 8/29", () => {
@@ -91,22 +87,18 @@ describe("calculateDueDate()", () => {
     const reportPeriod = 2;
     let reportType = ReportType.WP;
 
-    test("returns WP due date in 2022 as 11/1", () => {
-      const currentYear = 2022;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("11/01/2022");
+    test("returns WP due date as 11/1", () => {
+      const years = [2022, 2023, 2025];
+      years.forEach((currentYear) => {
+        const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+        expect(dueDate).toBe(`11/01/${currentYear}`);
+      });
     });
 
     test("returns WP due date in 2024 as 9/3", () => {
       const currentYear = 2024;
       const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
       expect(dueDate).toBe("09/03/2024");
-    });
-
-    test("returns WP due date in 2025 as 11/1", () => {
-      const currentYear = 2025;
-      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-      expect(dueDate).toBe("11/01/2025");
     });
 
     test("returns SAR due date as 3/1", () => {

--- a/services/app-api/utils/time/time.test.ts
+++ b/services/app-api/utils/time/time.test.ts
@@ -56,44 +56,71 @@ describe("Test calculate isLeapYear", () => {
   });
 });
 
-describe("Test calculateDueDate", () => {
-  it("calculateDueDate for WP report with creation date 01/01/2022", () => {
-    const currentYear = 2022;
+describe("calculateDueDate()", () => {
+  describe("Period 1", () => {
     const reportPeriod = 1;
-    const reportType = ReportType.WP;
-    const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-    expect(dueDate).toBe("09/01/2022");
+    let reportType = ReportType.WP;
+
+    test("returns WP due date in 2022 as 5/1", () => {
+      const currentYear = 2022;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("05/01/2022");
+    });
+
+    test("returns WP due date in 2024 as 9/1", () => {
+      const currentYear = 2024;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("09/01/2024");
+    });
+
+    test("returns WP due date in 2025 as 5/1", () => {
+      const currentYear = 2025;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("05/01/2025");
+    });
+
+    test("returns SAR due date as 8/29", () => {
+      const currentYear = 2022;
+      reportType = ReportType.SAR;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("08/29/2022");
+    });
   });
 
-  it("calculateDueDate for WP report with creation date as 08/01/2022", () => {
-    const currentYear = 2022;
+  describe("Period 2", () => {
     const reportPeriod = 2;
-    const reportType = ReportType.WP;
-    const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-    expect(dueDate).toBe("11/01/2022");
-  });
+    let reportType = ReportType.WP;
 
-  it("calculateDueDate for SAR report created in 2022 with period 2", () => {
-    const currentYear = 2022;
-    const reportPeriod = 1;
-    const reportType = ReportType.SAR;
-    const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-    expect(dueDate).toBe("08/29/2022");
-  });
+    test("returns WP due date in 2022 as 11/1", () => {
+      const currentYear = 2022;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("11/01/2022");
+    });
 
-  it("calculateDueDate for SAR report created in 2022 with period 2", () => {
-    const currentYear = 2022;
-    const reportPeriod = 2;
-    const reportType = ReportType.SAR;
-    const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-    expect(dueDate).toBe("03/01/2023");
-  });
+    test("returns WP due date in 2024 as 9/3", () => {
+      const currentYear = 2024;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("09/03/2024");
+    });
 
-  it("calculateDueDate for SAR report which is due during a leap year", () => {
-    const currentYear = 2023;
-    const reportPeriod = 2;
-    const reportType = ReportType.SAR;
-    const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
-    expect(dueDate).toBe("02/29/2024");
+    test("returns WP due date in 2025 as 11/1", () => {
+      const currentYear = 2025;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("11/01/2025");
+    });
+
+    test("returns SAR due date as 3/1", () => {
+      const currentYear = 2022;
+      reportType = ReportType.SAR;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("03/01/2023");
+    });
+
+    test("returns SAR due date in a leap year as 2/29", () => {
+      const currentYear = 2023;
+      reportType = ReportType.SAR;
+      const dueDate = calculateDueDate(currentYear, reportPeriod, reportType);
+      expect(dueDate).toBe("02/29/2024");
+    });
   });
 });

--- a/services/app-api/utils/time/time.ts
+++ b/services/app-api/utils/time/time.ts
@@ -67,23 +67,33 @@ export const calculateDueDate = (
   reportPeriod: number,
   reportType: ReportType
 ) => {
-  let date = new Date();
+  // Use regular due dates after the 2024 reporting periods
+  const customYear = 2024;
+  let dueDate = "5/1";
+  let year = currentYear;
 
-  // Revert due date back to month index 4 after the 2024 reporting periods
   if (reportType === ReportType.WP) {
-    reportPeriod === 1
-      ? (date = new Date(currentYear, 8, 1))
-      : (date = new Date(currentYear, 10, 1));
-  }
-  if (reportType === ReportType.SAR) {
+    if (year === customYear) {
+      dueDate = "9/1";
+    }
+
     if (reportPeriod === 2) {
-      isLeapYear(currentYear + 1)
-        ? (date = new Date(currentYear + 1, 1, 29))
-        : (date = new Date(currentYear + 1, 2, 1));
-    } else {
-      date = new Date(currentYear, 7, 29);
+      dueDate = year === customYear ? "9/3" : "11/1";
     }
   }
+
+  if (reportType === ReportType.SAR) {
+    dueDate = "8/29";
+
+    if (reportPeriod === 2) {
+      year++;
+      dueDate = isLeapYear(year) ? "2/29" : "3/1";
+    }
+  }
+
+  const [month, day] = dueDate.split("/").map((i) => parseInt(i, 10));
+  const date = new Date(year, month - 1, day);
+
   return convertToFormattedDate(date);
 };
 

--- a/services/app-api/utils/time/time.ts
+++ b/services/app-api/utils/time/time.ts
@@ -67,19 +67,16 @@ export const calculateDueDate = (
   reportPeriod: number,
   reportType: ReportType
 ) => {
-  // Use regular due dates after the 2024 reporting periods
-  const customYear = 2024;
   let dueDate = "5/1";
   let year = currentYear;
 
-  if (reportType === ReportType.WP) {
-    if (year === customYear) {
-      dueDate = "9/1";
-    }
+  if (reportPeriod === 2) {
+    dueDate = "11/1";
+  }
 
-    if (reportPeriod === 2) {
-      dueDate = year === customYear ? "9/3" : "11/1";
-    }
+  // TODO: Remove this block in 2025
+  if (reportType === ReportType.WP && year === 2024) {
+    dueDate = reportPeriod === 1 ? "9/1" : "9/3";
   }
 
   if (reportType === ReportType.SAR) {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Use 9/3/24 as due date for Work Plans for 2024 - Period 2
- Refactor method to use more readable date strings
- Refactor to revert changes made in https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/498 past the needed time period
- Reorganize/add unit tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3771

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MFP locally
2. Run `yarn db:seed` to quickly create a work plan. Since the seeder chooses a random year and reporting period, you may not get a 2024R2 on the first try.
3. Verify that the due date for a WP for 2024R2 is 9/3/24

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

![Screenshot 2024-07-12 at 11 29 38 AM](https://github.com/user-attachments/assets/3c748b50-d7e9-453b-a3f6-b9466644c640)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
