### PR TITLE
fix API request promises in the playwright test

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { Locator } from "@playwright/test";
+import { Locator, Response } from "@playwright/test";
 
 export async function logInStateUser({ page }) {
   await page.goto("/");
@@ -40,14 +40,14 @@ async function archiveReports(buttons: Locator, page) {
   const archiveButtons = await buttons.all();
   if (archiveButtons.length > 0) {
     const archivePromise = page.waitForResponse(
-      (response) =>
+      (response: Response) =>
         response.url().includes("/reports/archive/WP/PR/") &&
         response.status() == 200
     );
 
     await archiveButtons[0].click();
     await archivePromise;
-    await archiveReports(buttons);
+    await archiveReports(buttons, page);
   }
 }
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -36,14 +36,18 @@ export async function logOut({ page }) {
   await page.goto("/");
 }
 
-/* Recursive function to click any archive buttons that appear on screen. */
 async function archiveReports(buttons: Locator, page) {
   const archiveButtons = await buttons.all();
-
   if (archiveButtons.length > 0) {
+    const archivePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/reports/archive/WP/PR/") &&
+        response.status() == 200
+    );
+
     await archiveButtons[0].click();
-    await page.waitForResponse("**/reports/archive/WP/PR/**");
-    await archiveReports(buttons, page);
+    await archivePromise;
+    await archiveReports(buttons);
   }
 }
 
@@ -58,13 +62,11 @@ export async function archiveExistingWPs({ page }) {
 
   await page.getByLabel("MFP Work Plan").click();
   await page.getByRole("button", { name: "Go to Report Dashboard" }).click();
-  await page.waitForResponse("**/reports/WP/PR");
-
-  const archiveButtons = await page.getByRole("button", { name: "Archive" });
-
-  if (archiveButtons) {
-    await archiveReports(archiveButtons, page);
-  }
-
+  const reportsPromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/reports/WP/PR") && response.status() == 200
+  );
+  await reportsPromise;
+  await archiveReports(page.getByRole("button", { name: "Archive" }), page);
   await logOut({ page });
 }

--- a/tests/e2e/wp.spec.ts
+++ b/tests/e2e/wp.spec.ts
@@ -18,7 +18,7 @@ test("State user can create a work plan", async ({ page }) => {
   await page.getByRole("button", { name: "Enter Work Plan online" }).click();
 
   expect(page).toHaveURL("/wp");
-  await page.getByRole("table");
+  page.waitForResponse("**/reports/WP/PR");
 
   const createButton = await page.getByRole("button", {
     name: "Start MFP Work Plan",


### PR DESCRIPTION
### Description
Fixes an issue where the archive existing WPs function would time out occasionally, resulting in a flaky e2e test for the work plan.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3842

---
### How to test
1. _In the project root_, run `yarn test:e2e tests/e2e/wp.spec.ts`
2. Try it a bunch of times
3. Nothing should fail
4. Check the build for this PR and everything should be passing
