### PR TITLE
remove implementations of momentjs

### DIFF
--- a/services/ui-src/src/components/layout/Timeout.tsx
+++ b/services/ui-src/src/components/layout/Timeout.tsx
@@ -17,7 +17,7 @@ import {
   UserContext,
 } from "utils";
 import { PROMPT_AT, IDLE_WINDOW } from "../../constants";
-import moment from "moment";
+import { add } from "date-fns";
 
 export const Timeout = () => {
   const context = useContext(UserContext);
@@ -43,7 +43,7 @@ export const Timeout = () => {
   }, [location]);
 
   const setTimer = () => {
-    const expiration = moment().add(IDLE_WINDOW, "milliseconds");
+    const expiration = add(Date.now(), { seconds: IDLE_WINDOW / 1000 });
     if (timeoutPromptId) {
       clearTimers();
     }

--- a/services/ui-src/src/utils/auth/authLifecycle.test.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.test.tsx
@@ -1,13 +1,13 @@
 import { initAuthManager, updateTimeout, getExpiration } from "utils";
 import { refreshCredentials } from "./authLifecycle";
-import moment from "moment";
+import { sub } from "date-fns";
 import { Hub } from "aws-amplify";
 
 describe("utils/auth", () => {
   describe("Test AuthManager Init", () => {
-    test("Initiallizing when past expiration will require a new login", async () => {
+    test("Initializing when past expiration will require a new login", async () => {
       // Set an initial time, because jest runs too fast to have different timestamps
-      const expired = moment().subtract(5, "days").format().toString();
+      const expired = sub(Date.now(), { days: 5 }).toString();
       localStorage.setItem("mdctmfp_session_exp", expired);
 
       initAuthManager();
@@ -25,20 +25,19 @@ describe("utils/auth", () => {
     });
 
     test("Test updateTimeout", () => {
-      const currentTime = moment();
+      const currentTime = Date.now();
       updateTimeout();
       jest.runAllTimers(); // Dodge 2 second debounce, get the updated timestamp
 
       const savedTime = localStorage.getItem("mdctmfp_session_exp");
-      expect(moment(savedTime).isSameOrAfter(currentTime)).toBeTruthy();
+      expect(new Date(savedTime!).valueOf()).toBeGreaterThanOrEqual(
+        new Date(currentTime).valueOf()
+      );
     });
 
     test("Test getExpiration and refreshCredentials", async () => {
       // Set an initial time, because jest runs too fast to have different timestamps
-      const initialExpiration = moment()
-        .subtract(5, "seconds")
-        .format()
-        .toString();
+      const initialExpiration = sub(Date.now(), { seconds: 5 }).toString();
       localStorage.setItem("mdctmfp_session_exp", initialExpiration);
       await refreshCredentials();
       jest.runAllTimers(); // Dodge 2 second debounce, get the updated timestamp
@@ -46,7 +45,9 @@ describe("utils/auth", () => {
       // Check that the new timestamp is updated
       const storedExpiration = getExpiration();
       expect(storedExpiration).not.toEqual(initialExpiration);
-      expect(moment(storedExpiration).isAfter(initialExpiration)).toBeTruthy();
+      expect(new Date(storedExpiration!).valueOf()).toBeGreaterThan(
+        new Date(initialExpiration).valueOf()
+      );
     });
     test("Test getExpiration returns an empty string if nothing is set", async () => {
       localStorage.removeItem("mdctmfp_session_exp");
@@ -73,7 +74,7 @@ describe("utils/auth", () => {
     });
 
     test("Ignore unrelated auth events", () => {
-      const currentTime = moment();
+      const currentTime = Date.now();
       Hub.listen = jest
         .fn()
         .mockImplementation((channel: string, callback: any) => {
@@ -81,7 +82,9 @@ describe("utils/auth", () => {
         });
       initAuthManager();
       const savedTime = localStorage.getItem("mdctmfp_session_exp");
-      expect(moment(savedTime).isSameOrAfter(currentTime)).toBeTruthy();
+      expect(new Date(savedTime!).valueOf()).toBeGreaterThanOrEqual(
+        new Date(currentTime).valueOf()
+      );
       expect(localStorage.setItem).not.toHaveBeenCalled();
     });
   });

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -13,7 +13,7 @@ class AuthManager {
 
   constructor() {
     // Force users with stale tokens greater than the timeout to log in for a fresh session
-    const expiration = localStorage.getItem("mdctmcr_session_exp");
+    const expiration = localStorage.getItem("mdctmfp_session_exp");
     const isExpired =
       expiration && new Date(expiration).valueOf() < Date.now().valueOf();
     if (isExpired) {

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -12,7 +12,7 @@ class AuthManager {
   updateTimeout = debounce(() => this.setTimer());
 
   constructor() {
-    // Force users with stale tokens > then the timeout to log in for a fresh session
+    // Force users with stale tokens greater than the timeout to log in for a fresh session
     const expiration = localStorage.getItem("mdctmcr_session_exp");
     const isExpired =
       expiration && new Date(expiration).valueOf() < Date.now().valueOf();

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -1,5 +1,5 @@
 import { Auth, Hub } from "aws-amplify";
-import moment from "moment";
+import { add } from "date-fns";
 import { IDLE_WINDOW } from "../../constants";
 
 let authManager: AuthManager;
@@ -13,8 +13,10 @@ class AuthManager {
 
   constructor() {
     // Force users with stale tokens > then the timeout to log in for a fresh session
-    const exp = localStorage.getItem("mdctmfp_session_exp");
-    if (exp && moment(exp).isBefore()) {
+    const expiration = localStorage.getItem("mdctmcr_session_exp");
+    const isExpired =
+      expiration && new Date(expiration).valueOf() < Date.now().valueOf();
+    if (isExpired) {
       localStorage.removeItem("mdctmfp_session_exp");
       Auth.signOut().then(() => {
         window.location.href = "/";
@@ -53,10 +55,9 @@ class AuthManager {
    * Timer function for idle timeout, keeps track of an idle timer that triggers a forced logout timer if not reset.
    */
   setTimer = () => {
-    const expiration = moment()
-      .add(IDLE_WINDOW, "milliseconds")
-      .format()
-      .toString();
+    const expiration = add(Date.now(), {
+      seconds: IDLE_WINDOW / 1000,
+    }).toString();
     localStorage.setItem("mdctmfp_session_exp", expiration);
   };
 }

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -1,6 +1,5 @@
 import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 import { DateShape, TimeShape } from "types";
-import moment from "moment";
 
 export const midnight: TimeShape = { hour: 0, minute: 0, second: 0 };
 export const oneSecondToMidnight: TimeShape = {
@@ -146,7 +145,7 @@ export const checkDateRangeStatus = (
  */
 export const calculateRemainingSeconds = (expiresAt?: any) => {
   if (!expiresAt) return 0;
-  return moment(expiresAt).diff(moment()) / 1000;
+  return (new Date(expiresAt).valueOf() - Date.now()) / 1000;
 };
 
 export const displayLongformPeriod = (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
see title

date-fns is a package we already had installed, and is a recommended swap for momentjs.

the moment package is a sub-dependency of `serverless-bundle`. we cannot remove it from yarn.lock, but hopefully this still resolves the issue.

References:
[Security issue](https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/version-disclosure-momentjs/)
[MomentJS recommends using alternatives](https://momentjs.com/docs/#/-project-status/)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3910

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Tests pass

- Modify the values for `IDLE_WINDOW` and `PROMPT_AT` in the src/constants.ts file to be shorter (change leading values to 1 and 0.5 or something)
- Run locally
- Let the app sit until the timeout hits
  - Ensure the prompt shows up as expected
  - Ensure the prompt still does the correct actions when you click on them
  - Ensure if you don't do anything it logs you out

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
