### PR TITLE
archived program should be text, not disabled button

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -224,7 +224,7 @@ describe("<DashboardPage />", () => {
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[3];
+      const unlockButton = screen.getAllByRole("button", { name: "Unlock" })[3];
       expect(unlockButton).toBeEnabled();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
@@ -245,7 +245,9 @@ describe("<DashboardPage />", () => {
     });
 
     test("Clicking 'Archive' button will open the archive modal", async () => {
-      const archiveButton = screen.getAllByText("Archive")[0];
+      const archiveButton = screen.getAllByRole("button", {
+        name: "Archive",
+      })[0];
       expect(archiveButton).toBeVisible();
       await userEvent.click(archiveButton);
       await expect(
@@ -254,8 +256,8 @@ describe("<DashboardPage />", () => {
     });
 
     test("Cannot unarchive a WP", async () => {
-      const archivedText = screen.getAllByText("Archived")[1];
-      expect(archivedText).toBeInTheDocument();
+      const lastCell = screen.getAllByRole("gridcell").pop();
+      expect(lastCell).toHaveTextContent("Archived");
     });
 
     test("Can still view all WPs", async () => {
@@ -279,7 +281,7 @@ describe("<DashboardPage />", () => {
     });
 
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[1];
+      const unlockButton = screen.getAllByRole("button", { name: "Unlock" })[1];
       expect(unlockButton).toBeEnabled();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
@@ -290,15 +292,17 @@ describe("<DashboardPage />", () => {
     });
 
     test("Clicking 'Archive' button will open the archive modal", async () => {
-      const archiveButton = screen.getAllByText("Archive")[1];
+      const archiveButton = screen.getAllByRole("button", {
+        name: "Archive",
+      })[1];
       expect(archiveButton).toBeVisible();
       await userEvent.click(archiveButton);
       expect(screen.getByText(wpVerbiage.modalArchive.heading)).toBeVisible();
     });
 
     test("Cannot unarchive a WP", async () => {
-      const archivedText = screen.getAllByText("Archived")[1];
-      expect(archivedText).toBeInTheDocument();
+      const archivedText = screen.getByTestId("archived");
+      expect(archivedText).toBeVisible();
     });
 
     test("Can still view all WPs", async () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -86,6 +86,9 @@ const sarDashboardViewWithReports = (
 );
 
 describe("<DashboardPage />", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   describe("Test Report Dashboard view (Desktop)", () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -255,6 +258,11 @@ describe("<DashboardPage />", () => {
       expect(archivedText).toBeInTheDocument();
     });
 
+    test("Can still view all WPs", async () => {
+      const viewButtons = screen.getAllByRole("button", { name: "View" });
+      viewButtons.forEach((button) => expect(button).not.toBeDisabled());
+    });
+
     testA11y(wpDashboardViewWithReports, () => {
       mockMakeMediaQueryClasses.mockReturnValue("desktop");
     });
@@ -269,9 +277,10 @@ describe("<DashboardPage />", () => {
       mockedUseStore.mockReturnValue(mockUseAdminStore);
       render(wpDashboardViewWithReports);
     });
+
     test("Clicking 'Unlock' button opens the unlock modal", async () => {
-      const unlockButton = screen.getAllByText("Unlock")[3];
-      expect(unlockButton).toBeVisible();
+      const unlockButton = screen.getAllByText("Unlock")[1];
+      expect(unlockButton).toBeEnabled();
       await userEvent.click(unlockButton);
       await expect(mockWpReportContext.releaseReport).toHaveBeenCalledTimes(1);
       // once for render, once for release
@@ -290,6 +299,11 @@ describe("<DashboardPage />", () => {
     test("Cannot unarchive a WP", async () => {
       const archivedText = screen.getAllByText("Archived")[1];
       expect(archivedText).toBeInTheDocument();
+    });
+
+    test("Can still view all WPs", async () => {
+      const viewButtons = screen.getAllByRole("button", { name: "View" });
+      viewButtons.forEach((button) => expect(button).not.toBeDisabled());
     });
 
     testA11y(wpDashboardViewWithReports, () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -251,10 +251,8 @@ describe("<DashboardPage />", () => {
     });
 
     test("Cannot unarchive a WP", async () => {
-      const archiveButton = screen.getAllByRole("button", {
-        name: "Archived",
-      })[0];
-      expect(archiveButton).toBeDisabled();
+      const archivedText = screen.getAllByText("Archived")[1];
+      expect(archivedText).toBeInTheDocument();
     });
 
     testA11y(wpDashboardViewWithReports, () => {
@@ -290,10 +288,8 @@ describe("<DashboardPage />", () => {
     });
 
     test("Cannot unarchive a WP", async () => {
-      const archiveButton = screen.getAllByRole("button", {
-        name: "Archived",
-      })[0];
-      expect(archiveButton).toBeDisabled();
+      const archivedText = screen.getAllByText("Archived")[1];
+      expect(archivedText).toBeInTheDocument();
     });
 
     testA11y(wpDashboardViewWithReports, () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -76,11 +76,7 @@ export const DashboardTable = ({
         )}
         {/* Action Buttons */}
         <Td sx={sxOverride.editReportButtonCell}>
-          <Button
-            variant="outline"
-            onClick={() => enterSelectedReport(report)}
-            isDisabled={report?.archived}
-          >
+          <Button variant="outline" onClick={() => enterSelectedReport(report)}>
             {entering && reportId == report.id ? (
               <Spinner size="md" />
             ) : isStateLevelUser && !report?.locked ? (

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -261,14 +261,18 @@ const AdminArchiveButton = ({
 }: AdminArchiveButtonProps) => {
   return (
     <Td>
-      <Button
-        variant="link"
-        sx={sxOverride.adminActionButton}
-        onClick={() => archive(report)}
-        disabled={report?.archived}
-      >
-        {report?.archived ? "Archived" : "Archive"}
-      </Button>
+      {report?.archived ? (
+        <Text sx={sx.archivedText}>Archived</Text>
+      ) : (
+        <Button
+          variant="link"
+          sx={sxOverride.adminActionButton}
+          onClick={() => archive(report)}
+          disabled={report?.archived}
+        >
+          Archive
+        </Button>
+      )}
     </Td>
   );
 };
@@ -326,5 +330,8 @@ const sx = {
     fontSize: "xs",
     fontWeight: "300",
     color: "palette.gray_medium",
+  },
+  archivedText: {
+    paddingLeft: 3,
   },
 };

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -209,7 +209,9 @@ const AdminArchiveButton = ({
   return (
     <>
       {report?.archived ? (
-        <Text sx={sx.archivedText}>Archived</Text>
+        <Text data-testid="archived" sx={sx.archivedText}>
+          Archived
+        </Text>
       ) : (
         <Button
           variant="link"

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -208,14 +208,20 @@ const AdminArchiveButton = ({
   sxOverride,
 }: AdminArchiveButtonProps) => {
   return (
-    <Button
-      variant="link"
-      sx={sxOverride.adminActionButton}
-      onClick={() => archive(report)}
-      disabled={report?.archived}
-    >
-      {report?.archived ? "Archived" : "Archive"}
-    </Button>
+    <>
+      {report?.archived ? (
+        <Text sx={sx.archivedText}>Archived</Text>
+      ) : (
+        <Button
+          variant="link"
+          sx={sxOverride.adminActionButton}
+          onClick={() => archive(report)}
+          disabled={report?.archived}
+        >
+          Archive
+        </Button>
+      )}
+    </>
   );
 };
 
@@ -254,5 +260,11 @@ const sx = {
   },
   editDate: {
     marginRight: "3rem",
+  },
+  archivedText: {
+    fontSize: "sm",
+    paddingLeft: 2,
+    display: "flex",
+    alignItems: "center",
   },
 };

--- a/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/MobileDashboardTable.tsx
@@ -86,7 +86,6 @@ export const MobileDashboardTable = ({
             <Button
               variant="outline"
               onClick={() => enterSelectedReport(report)}
-              isDisabled={report?.archived}
             >
               {entering && reportId == report.id ? (
                 <Spinner size="md" />

--- a/services/ui-src/src/verbiage/pages/accordion.ts
+++ b/services/ui-src/src/verbiage/pages/accordion.ts
@@ -36,7 +36,7 @@ export default {
         "To view a state or territory's submission, use “View”.",
         "To allow a state or territory to make corrections or edits to a submission use “Unlock” to release the submission. The status will change to “In revision”.",
         "Submission count is shown in the # column. Submissions started and submitted once have a count of 1. When a state or territory resubmits a previous submission, the count increases by 1.",
-        "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”. You can only archive an MFP Work Plan that is not associated with a MFP Semi-Annual Progress Report and once archived it can’t be unarchived",
+        "To archive a submission and hide it from a state or territory’s dashboard, use “Archive”. You can only archive an MFP Work Plan that is not associated with a MFP Semi-Annual Progress Report and once archived it can’t be unarchived.",
         "To review a submission, go to the “Review & Submit” page. You can review the submission by section, download a PDF, unlock, and find further instructions on approval and next steps.",
         "To approve a submission, go to “Review & Submit” page and select “Approve”. The status will change to “Approved” and the content will be eligible for import into the MFP Semi-Annual Progress Report and will be available for view-only reference.",
       ],

--- a/tests/cypress/e2e/wp/dashboard.cy.js
+++ b/tests/cypress/e2e/wp/dashboard.cy.js
@@ -60,7 +60,7 @@ describe("MFP Work Plan Dashboard Page - Report Creation/Archiving", () => {
       //prompt to confirm and then user can actually archive
       cy.get("input").click().type("Archive");
       cy.get('[data-cy="modal-archive"]').click();
-      cy.contains("button", "Archived").should("be.disabled");
+      cy.contains("Archived")[1];
     });
   });
 });


### PR DESCRIPTION
### Description
Feedback from Kim regarding the changes to `archive`. After archiving, the dashboard should have text that says `Archived`, instead of a disabled outline button. Also missed a period in the accordion verbiage.

Also, not something that was a part of the original PR for CMDCT-3881, but the `View` button should never be disabled for admin.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3881

---
### How to test
Login as admin, seed the db to create a workplan. Archive it and see the `Archived` text in place of the `Archive` button. Make sure styling is the same in mobile view. See that the `View` button is enabled, regardless of the status.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
