### PR TITLE
Revert deploy.yml and skip e2e tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,38 +108,8 @@ jobs:
           echo "application_endpoint=$APPLICATION_ENDPOINT" >> $GITHUB_OUTPUT
           echo "## Application Endpoint" >> $GITHUB_STEP_SUMMARY
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
-      - id: api_name
-        run: |
-          API_NAME=$(./scripts/output.sh app-api ApiGatewayRestApiName $STAGE_PREFIX$branch_name)
-          echo "api_name=$API_NAME" >> $GITHUB_OUTPUT
-      - id: branch_name
-        run: |
-          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-      - id: cognito_user_pool_client_id
-        run: |
-          COGNITO_USER_POOL_CLIENT_ID=$(./scripts/output.sh ui-auth UserPoolClientId $STAGE_PREFIX$branch_name)
-          echo "cognito_user_pool_client_id=$COGNITO_USER_POOL_CLIENT_ID" >> $GITHUB_OUTPUT
-      - id: cognito_user_pool_id_encrypted
-        run: |
-          COGNITO_USER_POOL_ID=$(./scripts/output.sh ui-auth UserPoolId $STAGE_PREFIX$branch_name)
-          COGNITO_USER_POOL_ID_ENCRYPTED=$(echo -n "$COGNITO_USER_POOL_ID" | openssl enc -e -aes-256-cbc -a -pbkdf2 -iter 10000 -k "${{ secrets.CODE_CLIMATE_ID }}")
-          echo "cognito_user_pool_id_encrypted<<EOF" >> $GITHUB_OUTPUT
-          echo $COGNITO_USER_POOL_ID_ENCRYPTED >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      - id: region_encrypted
-        run: |
-          REGION=$(./scripts/output.sh app-api Region $STAGE_PREFIX$branch_name)
-          REGION_ENCRYPTED=$(echo -n "$REGION" | openssl enc -e -aes-256-cbc -a -pbkdf2 -iter 10000 -k "${{ secrets.CODE_CLIMATE_ID }}")
-          echo "region_encrypted<<EOF" >> $GITHUB_OUTPUT
-          echo $REGION_ENCRYPTED >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
     outputs:
-      api_name: ${{ steps.api_name.outputs.api_name }}
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint }}
-      branch_name: ${{ steps.branch_name.outputs.branch_name }}
-      cognito_user_pool_client_id: ${{ steps.cognito_user_pool_client_id.outputs.cognito_user_pool_client_id }}
-      cognito_user_pool_id_encrypted: ${{ steps.cognito_user_pool_id_encrypted.outputs.cognito_user_pool_id_encrypted }}
-      region_encrypted: ${{ steps.region_encrypted.outputs.region_encrypted }}
       BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}
       BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME }}
 
@@ -320,22 +290,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-      - name: Decrypt cognito_user_pool_id
-        run: |
-          COGNITO_USER_POOL_ID_ENCRYPTED=${{ needs.deploy.outputs.cognito_user_pool_id_encrypted }}
-          COGNITO_USER_POOL_ID_DECRYPTED=$(echo "$COGNITO_USER_POOL_ID_ENCRYPTED" | openssl base64 -d)
-          COGNITO_USER_POOL_ID=$(echo -n "$COGNITO_USER_POOL_ID_DECRYPTED" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 10000 -k "${{ secrets.CODE_CLIMATE_ID }}")
-          echo "cognito_user_pool_id<<EOF" >> $GITHUB_ENV
-          echo $COGNITO_USER_POOL_ID >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - name: Decrypt region
-        run: |
-          REGION_ENCRYPTED=${{ needs.deploy.outputs.region_encrypted }}
-          REGION_DECRYPTED=$(echo "$REGION_ENCRYPTED" | openssl base64 -d)
-          REGION=$(echo -n "$REGION_DECRYPTED" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 10000 -k "${{ secrets.CODE_CLIMATE_ID }}")
-          echo "region<<EOF" >> $GITHUB_ENV
-          echo $REGION >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
       - name: yarn install
         run: yarn install
       - name: Install Playwright Browsers
@@ -344,10 +298,7 @@ jobs:
         run: yarn playwright test
         continue-on-error: true
         env:
-          API_URL: https://${{ needs.deploy.outputs.api_name }}.execute-api.${{ env.region }}.amazonaws.com/${{ needs.deploy.outputs.branch_name }}
           BASE_URL: ${{ needs.deploy.outputs.application_endpoint }}
-          COGNITO_USER_POOL_CLIENT_ID: ${{ needs.deploy.outputs.cognito_user_pool_client_id }}
-          COGNITO_USER_POOL_ID: ${{ env.cognito_user_pool_id }}
           CYPRESS_STATE_USER_EMAIL: ${{ secrets.CYPRESS_STATE_USER_EMAIL }}
           CYPRESS_STATE_USER_PASSWORD: ${{ secrets.CYPRESS_STATE_USER_PASSWORD }}
           CYPRESS_ADMIN_USER_EMAIL: ${{ secrets.CYPRESS_ADMIN_USER_EMAIL }}

--- a/tests/e2e/sar/create.spec.ts
+++ b/tests/e2e/sar/create.spec.ts
@@ -1,22 +1,19 @@
 import { expect, test } from "@playwright/test";
 import { currentYear } from "../../seeds/helpers";
-import { createApprovedWorkPlan } from "../../seeds/options";
 import {
   archiveExistingWPs,
   firstPeriod,
-  loginSeedUsersWithTimeout,
   logInStateUser,
   stateAbbreviation,
   stateName,
 } from "../helpers";
 
-test("State user can create a SAR", async ({ page }) => {
+// TODO: Unskip
+test.skip("State user can create a SAR", async ({ page }) => {
   await archiveExistingWPs(page);
   await logInStateUser(page);
 
-  // Seed WP
-  await loginSeedUsersWithTimeout(page);
-  await createApprovedWorkPlan(currentYear, firstPeriod);
+  // TODO: Seed WP
 
   // View SARs
   await page.getByRole("button", { name: "Enter SAR online" }).click();

--- a/tests/e2e/wp/approve.spec.ts
+++ b/tests/e2e/wp/approve.spec.ts
@@ -1,21 +1,16 @@
 import { expect, test } from "@playwright/test";
-import { currentYear } from "../../seeds/helpers";
-import { createSubmittedWorkPlan } from "../../seeds/options";
 import {
   archiveExistingWPs,
-  firstPeriod,
   logInAdminUser,
-  loginSeedUsersWithTimeout,
   stateAbbreviation,
 } from "../helpers";
 
-test("Admin user can approve a Work Plan submission", async ({ page }) => {
+// TODO: Unskip
+test.skip("Admin user can approve a Work Plan submission", async ({ page }) => {
   await archiveExistingWPs(page);
   await logInAdminUser(page);
 
-  // Seed WP
-  await loginSeedUsersWithTimeout(page);
-  await createSubmittedWorkPlan(currentYear, firstPeriod);
+  // TODO: Seed WP
 
   // View WPs
   await page


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Reverts changes to `deploy.yml` from https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/729
- Skips tests dependent on seeding until we come up with a better solution.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Locally, run `yarn test:e2e` or `yarn test:e2e-ui` for interactive tests
2. Verify all tests pass

<!--### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


<!-- --- -->
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
