### PR TITLE
Move reset button to dashboard

### DIFF
--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -110,9 +110,6 @@ export const createReport = handler(
     const reportYear = getReportYear(reportData, overrideCopyOver);
     const reportPeriod = getReportPeriod(reportData, overrideCopyOver);
 
-    // If this Work Plan is a reset, the reporting period is the upcoming one
-    const isReset = unvalidatedMetadata?.isReset;
-
     // Begin Section - Getting/Creating newest Form Template based on reportType
     let formTemplate, formTemplateVersion;
     try {
@@ -169,7 +166,7 @@ export const createReport = handler(
       generalInformation_resubmissionInformation: "N/A",
     };
 
-    if (unvalidatedMetadata.copyReport && !isReset) {
+    if (unvalidatedMetadata.copyReport) {
       const reportPeriod = calculatePeriod(Date.now(), workPlanMetadata);
       const isCurrentPeriod =
         calculateCurrentYear() === unvalidatedMetadata.copyReport.reportYear &&

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -32,7 +32,6 @@ const mockUnvalidatedMetadata = {
   createdAt: 1699496172798,
   lastAlteredBy: "Anthony Soprano",
   locked: false,
-  isReset: false,
 };
 
 describe("API utility functions", () => {

--- a/services/ui-src/src/components/export/ExportEntityDetailsTable.test.tsx
+++ b/services/ui-src/src/components/export/ExportEntityDetailsTable.test.tsx
@@ -72,10 +72,10 @@ describe("<ExportEntityDetailsTable />", () => {
         formatHeaderLabel("expenditures", label, mockSARFullReport)
       );
       expect(formattedHeaderLabels).toStrictEqual([
-        "Actual spending 2023 Q1",
-        "Projected spending 2023 Q1",
-        "Actual spending 2023 Q2",
-        "Projected spending 2023 Q2",
+        "Actual spending 2024 Q1",
+        "Projected spending 2024 Q1",
+        "Actual spending 2024 Q2",
+        "Projected spending 2024 Q2",
       ]);
     });
 

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.test.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.test.tsx
@@ -24,6 +24,7 @@ const mockedReportContext = {
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseStore);
 
 const modalComponent = (
   <RouterWrappedComponent>
@@ -219,7 +220,6 @@ describe("<CreateWorkPlanModal />", () => {
     };
 
     test("Error shows when selected data matches existing report", async () => {
-      mockedUseStore.mockReturnValue(mockUseStore);
       await act(async () => {
         await render(modalComponentForResetReport);
       });

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -86,7 +86,8 @@ export const CreateWorkPlanModal = ({
     for (const report of reportsByState) {
       if (
         report.reportPeriod === formPeriodValue &&
-        report.reportYear === formYearValue
+        report.reportYear === formYearValue &&
+        !report.archived
       ) {
         setShowAlert(true);
       }

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -1,17 +1,30 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 // components
 import { Button } from "@chakra-ui/react";
-import { Form, Modal, ReportContext } from "components";
+import { Alert, Form, Modal, ReportContext } from "components";
 // forms
 import copyWPFormJson from "forms/addEditWpReport/addEditWpReport.json";
 import newWPFormJson from "forms/addEditWpReport/newWpReport.json";
+import resetWPFormJson from "forms/addEditWpReport/resetWpReport.json";
 // utils
-import { AnyObject, FormJson, ReportStatus, ReportType } from "types";
+import {
+  AlertTypes,
+  AnyObject,
+  FormJson,
+  ReportStatus,
+  ReportType,
+} from "types";
 import { useStore } from "utils";
 import { States, DEFAULT_TARGET_POPULATIONS } from "../../constants";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
 const reportType = ReportType.WP;
+
+const resetAlertText = {
+  title: "A MFP Work Plan for this Reporting Period already exists",
+  description:
+    "To avoid duplication, select a different Year or Reporting Period; or select “Cancel” and select “Continue MFP Work Plan for next Period”.",
+};
 
 /**
  * @function: Generate report year choices
@@ -32,20 +45,31 @@ const generateReportYearChoices = () => {
 };
 
 export const CreateWorkPlanModal = ({
+  isResetting,
   activeState,
   previousReport,
   modalDisclosure,
 }: Props) => {
   const { createReport, fetchReportsByState } = useContext(ReportContext);
+  const { reportsByState } = useStore();
   const { full_name } = useStore().user ?? {};
+  const [formPeriodValue, setFormPeriodValue] = useState<number>();
+  const [formYearValue, setFormYearValue] = useState<number>();
+  const [showAlert, setShowAlert] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
 
   // temporary flag for testing copyover
   const isCopyOverTest = useFlags()?.isCopyOverTest;
 
-  const form: FormJson = !previousReport ? newWPFormJson : copyWPFormJson;
+  const form: FormJson = !previousReport
+    ? newWPFormJson
+    : isResetting
+    ? resetWPFormJson
+    : copyWPFormJson;
 
-  if (!previousReport) {
+  const notCopyingReport = !previousReport || isResetting;
+
+  if (notCopyingReport) {
     for (let field of form.fields) {
       if (field.id.match("reportPeriodYear")) {
         field.props = {
@@ -56,12 +80,34 @@ export const CreateWorkPlanModal = ({
     }
   }
 
-  /**
-   * @function: Prepare WP payload
-   * @param wpReset: (optional) determine whether the user would like to continue a Work Plan for next period,
-   * but clear / reset any existing data from the previous period
-   */
-  const prepareWpPayload = (formData: any, wpReset?: boolean) => {
+  // set alert to show if selected period and year match any existing report
+  useEffect(() => {
+    if (!reportsByState) return;
+    for (const report of reportsByState) {
+      if (
+        report.reportPeriod === formPeriodValue &&
+        report.reportYear === formYearValue
+      ) {
+        setShowAlert(true);
+      }
+    }
+  }, [formPeriodValue, formYearValue]);
+
+  // reset error state to false upon modal close
+  useEffect(() => {
+    if (!modalDisclosure.isOpen) setShowAlert(false);
+  }, [modalDisclosure.isOpen]);
+
+  // used to get the form values to enable/disable alert and submit button
+  const onChange = (formProvider: AnyObject) => {
+    if (formProvider.target.name === "reportPeriod")
+      setFormPeriodValue(formProvider.target.id === "reportPeriod-1" ? 1 : 2);
+    if (formProvider.target.name === "reportPeriodYear")
+      setFormYearValue(Number(formProvider.target.value));
+    setShowAlert(false);
+  };
+
+  const prepareWpPayload = (formData: AnyObject) => {
     const submissionName = "Work Plan";
 
     const wpPayload: AnyObject = {
@@ -77,7 +123,7 @@ export const CreateWorkPlanModal = ({
       },
     };
 
-    if (!previousReport) {
+    if (notCopyingReport) {
       const formattedReportYear = Number(formData.reportPeriodYear[0].value);
       const formattedReportPeriod =
         formData.reportPeriod[0].key === "reportPeriod-1" ? 1 : 2;
@@ -91,22 +137,17 @@ export const CreateWorkPlanModal = ({
       wpPayload.metadata = {
         ...wpPayload.metadata,
         copyReport: previousReport,
-        isReset: wpReset,
       };
     }
 
     return wpPayload;
   };
 
-  /**
-   * @param wpReset: (optional) determine whether the user would like to continue a Work Plan for next period,
-   * but clear / reset any existing data from the previous period
-   */
-  const writeReport = async (formData: any, wpReset?: boolean) => {
+  const writeReport = async (formData: AnyObject) => {
     setSubmitting(true);
     const submitButton = document.querySelector("[form=" + form.id + "]");
     submitButton?.setAttribute("disabled", "true");
-    const dataToWrite = prepareWpPayload(formData, wpReset);
+    const dataToWrite = prepareWpPayload(formData);
 
     await createReport(reportType, activeState, {
       ...dataToWrite,
@@ -128,14 +169,9 @@ export const CreateWorkPlanModal = ({
     setSubmitting(false);
   };
 
-  const resetReport = (formData: any) => {
-    writeReport(formData, true);
-    modalDisclosure.onClose();
-  };
-
   const isCopyDisabled = () => {
     //if no previous report or the previous report is not approve, disable copy button
-    return !previousReport || previousReport?.status !== "Approved";
+    return notCopyingReport || previousReport?.status !== "Approved";
   };
 
   return (
@@ -144,14 +180,14 @@ export const CreateWorkPlanModal = ({
       formId={form.id}
       modalDisclosure={modalDisclosure}
       submitting={submitting}
-      submitButtonDisabled={submitting}
+      submitButtonDisabled={submitting || showAlert}
       content={{
         heading: !isCopyDisabled() ? form.heading?.edit : form.heading?.add,
         subheading: !isCopyDisabled()
           ? form.heading?.subheadingEdit
           : form.heading?.subheading,
-        actionButtonText: !previousReport ? "Start new" : "",
-        closeButtonText: !previousReport ? "Cancel" : "",
+        actionButtonText: notCopyingReport ? "Start new" : "",
+        closeButtonText: notCopyingReport ? "Cancel" : "",
       }}
     >
       <Form
@@ -162,35 +198,31 @@ export const CreateWorkPlanModal = ({
         onSubmit={writeReport}
         validateOnRender={false}
         dontReset={true}
+        onChange={onChange}
       />
-      {previousReport && (
-        <>
-          <Button
-            sx={sx.copyBtn}
-            disabled={isCopyDisabled() || submitting}
-            onClick={writeReport}
-            type="submit"
-          >
-            Continue from previous period
-          </Button>
-          {!isCopyDisabled() && (
-            <Button
-              sx={sx.resetBtn}
-              onClick={resetReport}
-              disabled={submitting}
-              type="submit"
-              variant="outline"
-            >
-              Reset Work Plan
-            </Button>
-          )}
-        </>
+      {showAlert && (
+        <Alert
+          title={resetAlertText.title}
+          status={AlertTypes.ERROR}
+          description={resetAlertText.description}
+        />
+      )}
+      {!notCopyingReport && (
+        <Button
+          sx={sx.copyBtn}
+          disabled={isCopyDisabled() || submitting}
+          onClick={writeReport}
+          type="submit"
+        >
+          Continue from previous period
+        </Button>
       )}
     </Modal>
   );
 };
 
 interface Props {
+  isResetting: boolean;
   modalDisclosure: {
     isOpen: boolean;
     onClose: any;
@@ -215,12 +247,5 @@ const sx = {
     ".mobile &": {
       fontSize: "sm",
     },
-  },
-  resetBtn: {
-    border: "none",
-    marginTop: "1rem",
-    fontWeight: "none",
-    textDecoration: "underline",
-    fontSize: "0.875rem",
   },
 };

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -126,7 +126,7 @@ describe("<DashboardPage />", () => {
     test("Show copied from verbiage on report versions 2 or higher", () => {
       mockedUseStore.mockReturnValue(mockUseStore);
       render(wpDashboardViewWithReports);
-      const subText = screen.getByText("copied from 2023 - Period 1");
+      const subText = screen.getByText("copied from 2024 - Period 1");
       expect(subText).toBeInTheDocument();
     });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -88,6 +88,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   const [reportId, setReportId] = useState<string | undefined>(undefined);
   const [entering, setEntering] = useState<boolean>(false);
   const [releasing, setReleasing] = useState<boolean>(false);
+  const [isResetting, setIsResetting] = useState<boolean>(false);
   const [selectedReport, setSelectedReport] = useState<AnyObject | undefined>(
     undefined
   );
@@ -229,6 +230,12 @@ export const DashboardPage = ({ reportType }: Props) => {
     }
   };
 
+  const openResetWorkPlanModal = () => {
+    setSelectedReport(undefined);
+    setIsResetting(true);
+    createWorkPlanModalOnOpenHandler();
+  };
+
   const openArchiveModal = (report: ReportMetadataShape) => {
     setReportId(report?.id);
     confirmArchiveModalOnOpenHandler();
@@ -265,6 +272,11 @@ export const DashboardPage = ({ reportType }: Props) => {
       default:
         return true;
     }
+  };
+
+  const closeWorkPlanModal = () => {
+    setIsResetting(false);
+    createWorkPlanModalOnCloseHandler();
   };
 
   // new work plan modal disclosure
@@ -388,15 +400,25 @@ export const DashboardPage = ({ reportType }: Props) => {
                 ? body.callToAction
                 : body.callToActionAdditions}
             </Button>
+            <Button
+              sx={sx.resetBtn}
+              onClick={openResetWorkPlanModal}
+              disabled={isAddSubmissionDisabled()}
+              type="submit"
+              variant="outline"
+            >
+              Reset MFP Work Plan
+            </Button>
           </Box>
         )}
       </Box>
       <CreateWorkPlanModal
+        isResetting={isResetting}
         activeState={activeState!}
         previousReport={previousReport}
         modalDisclosure={{
           isOpen: createWorkPlanModalIsOpen,
-          onClose: createWorkPlanModalOnCloseHandler,
+          onClose: closeWorkPlanModal,
         }}
       />
       <CreateSarModal
@@ -505,8 +527,10 @@ const sx = {
     textAlign: "center",
   },
   callToActionContainer: {
-    marginTop: "2.5rem",
-    textAlign: "center",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    marginTop: "2rem",
   },
   spinnerContainer: {
     alignItems: "center",
@@ -525,6 +549,13 @@ const sx = {
   },
   errorMessage: {
     paddingTop: "1rem",
+  },
+  resetBtn: {
+    border: "none",
+    marginTop: "1rem",
+    fontWeight: "none",
+    textDecoration: "underline",
+    fontSize: "0.875rem",
   },
 };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -400,15 +400,17 @@ export const DashboardPage = ({ reportType }: Props) => {
                 ? body.callToAction
                 : body.callToActionAdditions}
             </Button>
-            <Button
-              sx={sx.resetBtn}
-              onClick={openResetWorkPlanModal}
-              disabled={isAddSubmissionDisabled()}
-              type="submit"
-              variant="outline"
-            >
-              Reset MFP Work Plan
-            </Button>
+            {previousReport && (
+              <Button
+                sx={sx.resetBtn}
+                onClick={openResetWorkPlanModal}
+                disabled={isAddSubmissionDisabled()}
+                type="submit"
+                variant="outline"
+              >
+                Reset MFP Work Plan
+              </Button>
+            )}
           </Box>
         )}
       </Box>

--- a/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
+++ b/services/ui-src/src/forms/addEditWpReport/addEditWpReport.json
@@ -7,7 +7,7 @@
     "edit": "Continue MFP Work Plan",
     "add": "Add new MFP Work Plan",
     "subheading": "Start a new MFP Work Plan for the reporting period. Once you complete this MFP Work Plan and CMS approves it, you’ll be able to continue updating it by selecting “Continue from previous period” or completely reset your MFP program information and start from a blank form. You will be able to view all MFP Work Plans from previous periods.",
-    "subheadingEdit": "Update your Work Plan for the next period, starting from the information in your last approved Work Plan by selecting <i>Continue from previous period</i>. Use <i>Reset Work Plan</i> only when you want to completely reset your MFP program information and start from a blank form. You will still be able to view the Work Plans from all previous periods."
+    "subheadingEdit": "Update your MFP Work Plan for the next period, starting from the information in your last approved MFP Work Plan by selecting “Continue from previous period”. “Cancel” and use “Reset MFP Work Plan” only when you want to completely reset your MFP program information and start from a blank form. You will still be able to view the MFP Work Plans from all previous periods."
   },
   "fields": [
     {

--- a/services/ui-src/src/forms/addEditWpReport/resetWpReport.json
+++ b/services/ui-src/src/forms/addEditWpReport/resetWpReport.json
@@ -1,0 +1,47 @@
+{
+  "id": "rwp",
+  "options": {
+    "mode": "onChange"
+  },
+  "heading": {
+    "add": "Are you sure you want to start a blank new Work Plan?",
+    "subheading": "This action can’t be undone. Once the new blank MFP Work Plan is started, you will not be able to use information entered for the previous MFP Work Plan. “Reset MFP Work Plan” is best suited for states or territories who are completely reworking their MFP programs, and in most cases it’s recommended to cancel this action, select “Continue MFP Work Plan for next Period”."
+  },
+  "fields": [
+    {
+      "id": "reportPeriodYear",
+      "type": "radio",
+      "validation": "radio",
+      "props": {
+        "label": "Reporting Period Year",
+        "hint": "Select the reporting period year.",
+        "choices": [],
+        "clear": true
+      }
+    },
+    {
+      "id": "reportPeriod",
+      "type": "radio",
+      "validation": "radio",
+      "props": {
+        "label": "Reporting Period",
+        "hint": "Select the reporting period.",
+        "clear": true,
+        "choices": [
+          {
+            "id": "reportPeriod-1",
+            "label": "First reporting period (January 1 - June 30)",
+            "name": "1",
+            "value": "1"
+          },
+          {
+            "id": "reportPeriod-2",
+            "label": "Second reporting period (July 1 - December 31)",
+            "name": "2",
+            "value": "2"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -11,7 +11,7 @@ import {
 } from "./mockForm";
 
 export const mockReportPeriod = 1;
-export const mockReportYear = 2023;
+export const mockReportYear = 2024;
 export const mockStateName = "Puerto Rico";
 
 export const mockReportRoutes = [


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Move the reset work plan button from the continue modal to the dashboard page
See ticket for more details

Dev choices:
- Removed reset logic from app-api (did I miss anything?) and had the frontend treat new and reset the same (both let you control the year and period)
- Gave reset modal the same form ids as create, but passed in `"clear": true` prop so that it would not try to hydrate the modal
- Changed test year to 2024 so I could test error alert

[Figma](https://www.figma.com/design/oOJMUZerbafZefLQQ33GwI/MFP_Playground?node-id=0-1&node-type=CANVAS&t=tpiSjk0ZXRgiHqiI-0)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3882

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://dmprc1ij4x0jj.cloudfront.net/

I’ve set up three state users so you can see different scenarios:
1. `stateuser@test.com` existing report, not complete
2. `stateuser1@test.com` no existing reports
3. `stateuser2@test.com` existing approved report

For scenario 3
- Click “Reset MFP Work Plan”
- Select 2024 period 1
- Verify the error message pops up
- Verify it goes away if you select another year or period
- Verify you can create a reset report

If you archive the created report as an admin you can run through this flow again, or use the continue flow, etc.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
I tried adding tests for reset to `DashboardPage.test.tsx` but it caused the unlock tests to fail 🤔 
Coverage dropped on that file so if anyone has ideas let me know! I will keep trying.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---