### PR TITLE
Improve checks for existing report

### DIFF
--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -96,7 +96,11 @@ export const CreateWorkPlanModal = ({
 
   // reset error state to false upon modal close
   useEffect(() => {
-    if (!modalDisclosure.isOpen) setShowAlert(false);
+    if (!modalDisclosure.isOpen) {
+      setFormPeriodValue(undefined);
+      setFormYearValue(undefined);
+      setShowAlert(false);
+    }
   }, [modalDisclosure.isOpen]);
 
   // used to get the form values to enable/disable alert and submit button


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Frontend:
- Reset all component state on modal closure so that the error triggers properly on re-opening

Backend: 
- Add check to create flow that ensures unarchived report in same year and period does not exist
- Add tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3985

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
(if testing locally, use `yarn db:seed` to create approved WP)

https://d1vtt2axjhiobw.cloudfront.net/
- Log in as stateuser2@test.com
- Go to WP dashboard
- Open "reset" modal
- Verify alert shows as expected (when year and period match existing report)
- Close and re-open the modal multiple times. Make sure it still works as expected
- Open the network tab
- Create a reset report in a different year and period
- Resend the network request and verify it returns a 400

please log in as admin and archive any created reports to make testing easy for other users 😄

Compare to [MFP dev](https://mdctmfpdev.cms.gov/) where the erroring does not happen consistently upon reopening modal, and you can create reports in the same year and period (stateuser2 in MFP dev has an approved WP)

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---
