### PR TITLE
New API response pattern

### DIFF
--- a/services/app-api/handlers/banners/create.test.ts
+++ b/services/app-api/handlers/banners/create.test.ts
@@ -2,10 +2,11 @@ import { createBanner } from "./create";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
 // utils
 import { error } from "../../utils/constants/constants";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
@@ -33,7 +34,7 @@ describe("Test createBanner API method", () => {
   test("Test unauthorized banner creation throws 403 error", async () => {
     const res = await createBanner(testEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -42,7 +43,7 @@ describe("Test createBanner API method", () => {
     dynamoClientMock.on(PutCommand).callsFake(mockPut);
     const res = await createBanner(testEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(res.body).toContain("test banner");
     expect(res.body).toContain("test description");
     expect(mockPut).toHaveBeenCalled();
@@ -54,8 +55,7 @@ describe("Test createBanner API method", () => {
       pathParameters: {},
     };
     const res = await createBanner(noKeyEvent, null);
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -65,8 +65,7 @@ describe("Test createBanner API method", () => {
       pathParameters: { bannerId: "" },
     };
     const res = await createBanner(noKeyEvent, null);
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/create.test.ts
+++ b/services/app-api/handlers/banners/create.test.ts
@@ -11,7 +11,7 @@ import { StatusCodes } from "../../utils/responses/response-lib";
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValueOnce(false).mockReturnValue(true),
 }));
 

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -30,12 +30,13 @@ export const createBanner = handler(async (event, _context) => {
       endDate: number().required(),
     });
 
-    const validatedPayload = await validateData(
-      validationSchema,
-      unvalidatedPayload
-    );
-
-    if (!validatedPayload) {
+    let validatedPayload;
+    try {
+      validatedPayload = await validateData(
+        validationSchema,
+        unvalidatedPayload
+      );
+    } catch {
       return badRequest(error.INVALID_DATA);
     }
 

--- a/services/app-api/handlers/banners/delete.test.ts
+++ b/services/app-api/handlers/banners/delete.test.ts
@@ -5,7 +5,8 @@ import { mockClient } from "aws-sdk-client-mock";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { error } from "../../utils/constants/constants";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
@@ -33,7 +34,7 @@ describe("Test deleteBanner API method", () => {
     const res = await deleteBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -43,8 +44,7 @@ describe("Test deleteBanner API method", () => {
     const res = await deleteBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-    expect(res.body).toContain("testKey");
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(mockDelete).toHaveBeenCalled();
   });
 
@@ -55,8 +55,7 @@ describe("Test deleteBanner API method", () => {
     };
     const res = await deleteBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -67,8 +66,7 @@ describe("Test deleteBanner API method", () => {
     };
     const res = await deleteBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/delete.test.ts
+++ b/services/app-api/handlers/banners/delete.test.ts
@@ -11,7 +11,7 @@ import { StatusCodes } from "../../utils/responses/response-lib";
 const dynamoClientMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValueOnce(false).mockReturnValue(true),
 }));
 

--- a/services/app-api/handlers/banners/delete.ts
+++ b/services/app-api/handlers/banners/delete.ts
@@ -4,19 +4,17 @@ import { hasPermissions } from "../../utils/auth/authorization";
 import { error } from "../../utils/constants/constants";
 import { deleteBanner as deleteBannerById } from "../../storage/banners";
 // types
-import { StatusCodes, UserRoles } from "../../utils/types";
+import { UserRoles } from "../../utils/types";
+import { badRequest, forbidden, ok } from "../../utils/responses/response-lib";
 
 export const deleteBanner = handler(async (event, _context) => {
   if (!hasPermissions(event, [UserRoles.ADMIN])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   } else if (!event?.pathParameters?.bannerId!) {
-    throw new Error(error.NO_KEY);
+    return badRequest(error.NO_KEY);
   } else {
     const bannerId = event?.pathParameters?.bannerId!;
     await deleteBannerById(bannerId);
-    return { status: StatusCodes.SUCCESS, body: { Key: bannerId } };
+    return ok();
   }
 });

--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -5,7 +5,8 @@ import { error } from "../../utils/constants/constants";
 import { mockBannerResponse } from "../../utils/testing/setupJest";
 import { getBanner } from "../../storage/banners";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../utils/auth/authorization", () => ({
   isAuthorized: jest.fn().mockReturnValue(true),
@@ -41,7 +42,7 @@ describe("Test fetchBanner API method", () => {
     const res = await fetchBanner(testEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("testDesc");
     expect(res.body).toContain("testTitle");
   });
@@ -52,7 +53,7 @@ describe("Test fetchBanner API method", () => {
 
     expect(consoleSpy.debug).toHaveBeenCalled();
     expect(res.body).not.toBeDefined();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
   });
 
   test("Test bannerKey not provided throws 500 error", async () => {
@@ -63,7 +64,7 @@ describe("Test fetchBanner API method", () => {
     const res = await fetchBanner(noKeyEvent, null);
 
     expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -75,7 +76,7 @@ describe("Test fetchBanner API method", () => {
     const res = await fetchBanner(noKeyEvent, null);
 
     expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -63,8 +63,7 @@ describe("Test fetchBanner API method", () => {
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -75,8 +74,7 @@ describe("Test fetchBanner API method", () => {
     };
     const res = await fetchBanner(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -9,7 +9,7 @@ import { APIGatewayProxyEvent } from "../../utils/types";
 import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock("../../storage/banners", () => ({

--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -2,11 +2,11 @@ import handler from "../handler-lib";
 // utils
 import { error } from "../../utils/constants/constants";
 import { getBanner } from "../../storage/banners";
-import { ok } from "../../utils/responses/response-lib";
+import { badRequest, ok } from "../../utils/responses/response-lib";
 
 export const fetchBanner = handler(async (event, _context) => {
   if (!event?.pathParameters?.bannerId!) {
-    throw new Error(error.NO_KEY);
+    return badRequest(error.NO_KEY);
   }
   const bannerId = event?.pathParameters?.bannerId!;
   const banner = await getBanner(bannerId);

--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -1,9 +1,8 @@
 import handler from "../handler-lib";
-// types
-import { StatusCodes } from "../../utils/types";
 // utils
 import { error } from "../../utils/constants/constants";
 import { getBanner } from "../../storage/banners";
+import { ok } from "../../utils/responses/response-lib";
 
 export const fetchBanner = handler(async (event, _context) => {
   if (!event?.pathParameters?.bannerId!) {
@@ -11,5 +10,5 @@ export const fetchBanner = handler(async (event, _context) => {
   }
   const bannerId = event?.pathParameters?.bannerId!;
   const banner = await getBanner(bannerId);
-  return { status: StatusCodes.SUCCESS, body: banner };
+  return ok(banner);
 });

--- a/services/app-api/handlers/handler-lib.test.ts
+++ b/services/app-api/handlers/handler-lib.test.ts
@@ -12,7 +12,7 @@ jest.mock("../utils/debugging/debug-lib", () => ({
 }));
 
 jest.mock("../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn(),
+  isAuthenticated: jest.fn(),
 }));
 
 describe("Test Lambda Handler Lib", () => {

--- a/services/app-api/handlers/handler-lib.test.ts
+++ b/services/app-api/handlers/handler-lib.test.ts
@@ -1,6 +1,6 @@
 import handlerLib from "./handler-lib";
 import { proxyEvent } from "../utils/testing/proxyEvent";
-import { isAuthorized } from "../utils/auth/authorization";
+import { isAuthenticated } from "../utils/auth/authorization";
 import * as logger from "../utils/debugging/debug-lib";
 import { ok, StatusCodes } from "../utils/responses/response-lib";
 
@@ -20,7 +20,7 @@ describe("Test Lambda Handler Lib", () => {
     const testFunc = jest.fn().mockReturnValue(ok("test"));
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(true);
+    (isAuthenticated as jest.Mock).mockReturnValue(true);
     const res = await handler(proxyEvent, null);
 
     expect(res.statusCode).toBe(StatusCodes.Ok);
@@ -42,10 +42,10 @@ describe("Test Lambda Handler Lib", () => {
     const testFunc = jest.fn();
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(false);
+    (isAuthenticated as jest.Mock).mockReturnValue(false);
     const res = await handler(proxyEvent, null);
 
-    expect(res.statusCode).toBe(StatusCodes.Unauthorized);
+    expect(res.statusCode).toBe(StatusCodes.Unauthenticated);
     expect(res.body).toStrictEqual(
       '"User is not authorized to access this resource."'
     );
@@ -58,7 +58,7 @@ describe("Test Lambda Handler Lib", () => {
     });
     const handler = handlerLib(testFunc);
 
-    (isAuthorized as jest.Mock).mockReturnValue(true);
+    (isAuthenticated as jest.Mock).mockReturnValue(true);
     const res = await handler(proxyEvent, null);
 
     expect(testFunc).toHaveBeenCalledWith(proxyEvent, null);

--- a/services/app-api/handlers/handler-lib.ts
+++ b/services/app-api/handlers/handler-lib.ts
@@ -2,18 +2,19 @@
 import * as logger from "../utils/debugging/debug-lib";
 import { isAuthorized } from "../utils/auth/authorization";
 import {
+  HttpResponse,
   internalServerError,
-  buildResponse,
+  unauthorized,
 } from "../utils/responses/response-lib";
 import { error } from "../utils/constants/constants";
 import { sanitizeObject } from "../utils/sanitize/sanitize";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../utils/types";
+import { APIGatewayProxyEvent } from "../utils/types";
 
 type LambdaFunction = (
   event: APIGatewayProxyEvent, // eslint-disable-line no-unused-vars
   context: any // eslint-disable-line no-unused-vars
-) => Promise<any>;
+) => Promise<HttpResponse>;
 
 export default function handler(lambda: LambdaFunction) {
   return async function (event: APIGatewayProxyEvent, context: any) {
@@ -30,11 +31,8 @@ export default function handler(lambda: LambdaFunction) {
           const newEventBody = sanitizeObject(JSON.parse(event.body));
           event.body = JSON.stringify(newEventBody);
         }
-        // Run the Lambda
-        const { status, body } = await lambda(event, context);
-        return buildResponse(status, body);
+        return await lambda(event, context);
       } catch (error: any) {
-        // Print debug messages
         logger.error("Error: %O", error);
 
         const body = { error: error.message };
@@ -43,8 +41,7 @@ export default function handler(lambda: LambdaFunction) {
         logger.flush();
       }
     } else {
-      const body = { error: error.UNAUTHORIZED };
-      return buildResponse(StatusCodes.UNAUTHORIZED, body);
+      return unauthorized(error.UNAUTHORIZED);
     }
   };
 }

--- a/services/app-api/handlers/handler-lib.ts
+++ b/services/app-api/handlers/handler-lib.ts
@@ -1,10 +1,10 @@
 // utils
 import * as logger from "../utils/debugging/debug-lib";
-import { isAuthorized } from "../utils/auth/authorization";
+import { isAuthenticated } from "../utils/auth/authorization";
 import {
   HttpResponse,
   internalServerError,
-  unauthorized,
+  unauthenticated,
 } from "../utils/responses/response-lib";
 import { error } from "../utils/constants/constants";
 import { sanitizeObject } from "../utils/sanitize/sanitize";
@@ -25,7 +25,7 @@ export default function handler(lambda: LambdaFunction) {
       pathParameters: event.pathParameters,
       queryStringParameters: event.queryStringParameters,
     });
-    if (await isAuthorized(event)) {
+    if (await isAuthenticated(event)) {
       try {
         if (event.body) {
           const newEventBody = sanitizeObject(JSON.parse(event.body));
@@ -41,7 +41,7 @@ export default function handler(lambda: LambdaFunction) {
         logger.flush();
       }
     } else {
-      return unauthorized(error.UNAUTHORIZED);
+      return unauthenticated(error.UNAUTHORIZED);
     }
   };
 }

--- a/services/app-api/handlers/reports/approve.test.ts
+++ b/services/app-api/handlers/reports/approve.test.ts
@@ -5,7 +5,8 @@ import { mockWPReport } from "../../utils/testing/setupJest";
 import { error } from "../../utils/constants/constants";
 import { getReportMetadata, putReportMetadata } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   getReportMetadata: jest.fn(),
@@ -51,7 +52,7 @@ describe("Test approveReport method", () => {
     const res: any = await approveReport(approveEvent, null);
     const body = JSON.parse(res.body);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.status).toBe("Approved");
     expect(putReportMetadata).toHaveBeenCalled();
   });
@@ -61,7 +62,7 @@ describe("Test approveReport method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await approveReport(approveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
@@ -70,7 +71,7 @@ describe("Test approveReport method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await approveReport(approveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 });

--- a/services/app-api/handlers/reports/approve.test.ts
+++ b/services/app-api/handlers/reports/approve.test.ts
@@ -14,7 +14,7 @@ jest.mock("../../storage/reports", () => ({
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
 

--- a/services/app-api/handlers/reports/approve.ts
+++ b/services/app-api/handlers/reports/approve.ts
@@ -5,33 +5,31 @@ import { hasPermissions } from "../../utils/auth/authorization";
 import { parseSpecificReportParameters } from "../../utils/auth/parameters";
 import { getReportMetadata, putReportMetadata } from "../../storage/reports";
 // types
-import { ReportStatus, StatusCodes, UserRoles } from "../../utils/types";
+import { ReportStatus, UserRoles } from "../../utils/types";
+import {
+  badRequest,
+  forbidden,
+  internalServerError,
+  notFound,
+  ok,
+} from "../../utils/responses/response-lib";
 
 export const approveReport = handler(async (event) => {
   const { allParamsValid, reportType, state, id } =
     parseSpecificReportParameters(event);
   if (!allParamsValid) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   // Return a 403 status if the user is not an admin.
   if (!hasPermissions(event, [UserRoles.ADMIN, UserRoles.APPROVER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
 
   const currentReport = await getReportMetadata(reportType, state, id);
 
   if (!currentReport) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
   const updatedReport = {
@@ -44,14 +42,8 @@ export const approveReport = handler(async (event) => {
   try {
     await putReportMetadata(updatedReport);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.DYNAMO_UPDATE_ERROR,
-    };
+    return internalServerError(error.DYNAMO_UPDATE_ERROR);
   }
 
-  return {
-    status: StatusCodes.SUCCESS,
-    body: updatedReport,
-  };
+  return ok(updatedReport);
 });

--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -17,7 +17,7 @@ jest.mock("../../storage/reports", () => ({
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
 

--- a/services/app-api/handlers/reports/archive.test.ts
+++ b/services/app-api/handlers/reports/archive.test.ts
@@ -8,7 +8,8 @@ import {
 import { error } from "../../utils/constants/constants";
 import { getReportMetadata, putReportMetadata } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   getReportMetadata: jest.fn(),
@@ -55,7 +56,7 @@ describe("Test archiveReport method", () => {
     const body = JSON.parse(res.body);
     expect(consoleSpy.debug).toHaveBeenCalled();
     expect(putReportMetadata).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.archived).toBe(true);
   });
 
@@ -64,7 +65,7 @@ describe("Test archiveReport method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await archiveReport(archiveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
@@ -73,7 +74,7 @@ describe("Test archiveReport method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await archiveReport(archiveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -84,7 +85,7 @@ describe("Test archiveReport method", () => {
     );
     const res = await archiveReport(archiveEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.INVALID_DATA);
   });
 });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -162,7 +162,7 @@ describe("Test createReport API method", () => {
   test("Test unauthorized report creation throws 401 error", async () => {
     jest.spyOn(authFunctions, "isAuthorized").mockResolvedValueOnce(false);
     const res = await createReport(wpCreationEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.Unauthorized);
+    expect(res.statusCode).toBe(StatusCodes.Unauthenticated);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -18,9 +18,10 @@ import {
   putReportFieldData,
 } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
 import { copyFieldDataFromSource } from "../../utils/other/copy";
 import { getOrCreateFormTemplate } from "../../utils/formTemplates/formTemplates";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   queryReportMetadatasForState: jest.fn(),
@@ -158,10 +159,10 @@ describe("Test createReport API method", () => {
     consoleSpy.warn = jest.spyOn(console, "warn").mockImplementation();
   });
 
-  test("Test unauthorized report creation throws 403 error", async () => {
+  test("Test unauthorized report creation throws 401 error", async () => {
     jest.spyOn(authFunctions, "isAuthorized").mockResolvedValueOnce(false);
     const res = await createReport(wpCreationEvent, null);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Unauthorized);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -169,7 +170,7 @@ describe("Test createReport API method", () => {
     jest.spyOn(authFunctions, "hasPermissions").mockReturnValueOnce(false);
     const res = await createReport(wpCreationEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -181,7 +182,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(badStateEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
   test("Test report creation throws a 400 when given a bad ReportType", async () => {
@@ -192,14 +193,14 @@ describe("Test createReport API method", () => {
     const res = await createReport(badReportEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
-  test("Test report creation throws a 403 when copying a report of the same period", async () => {
+  test("Test report creation throws a 400 when copying a report of the same period", async () => {
     jest.useFakeTimers().setSystemTime(new Date(2021, 11, 1));
     const res = await createReport(wpCopyCreationEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
   test("Test successful run of work plan report creation, not copied", async () => {
@@ -207,9 +208,9 @@ describe("Test createReport API method", () => {
       { reportYear: 2020, reportPeriod: 1, archived: true },
     ]);
     const res = await createReport(wpCreationEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(body.status).toContain("Not started");
     expect(body.fieldDataId).toBeDefined;
     expect(body.formTemplateId).toBeDefined;
@@ -227,7 +228,7 @@ describe("Test createReport API method", () => {
       { reportYear: 2020, reportPeriod: 1, archived: undefined },
     ]);
     const res = await createReport(wpCreationEvent, null);
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
   test("Test successful run of work plan report creation, copied", async () => {
@@ -239,9 +240,9 @@ describe("Test createReport API method", () => {
     );
     jest.useFakeTimers().setSystemTime(new Date(2022, 11, 1));
     const res = await createReport(wpCopyCreationEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(body.status).toContain("Not started");
     expect(body.fieldDataId).toBeDefined;
     expect(body.formTemplateId).toBeDefined;
@@ -256,7 +257,7 @@ describe("Test createReport API method", () => {
     (getEligibleWorkPlan as jest.Mock).mockResolvedValue({});
     const res = await createReport(sarCreationEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
   });
 
   test("Test successful run of sar report creation, not copied", async () => {
@@ -268,9 +269,9 @@ describe("Test createReport API method", () => {
       { reportYear: 2020, reportPeriod: 1, archived: true },
     ]);
     const res = await createReport(sarCreationEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.CREATED);
+    expect(res.statusCode).toBe(StatusCodes.Created);
     expect(body.status).toContain("Not started");
     expect(body.fieldDataId).toBeDefined;
     expect(body.formTemplateId).toBeDefined;
@@ -280,14 +281,14 @@ describe("Test createReport API method", () => {
   test("Test attempted report creation with invalid data fails", async () => {
     const res = await createReport(creationEventWithInvalidData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.INVALID_DATA);
   });
 
   test("Test attempted report creation without field data throws 400 error", async () => {
     const res = await createReport(creationEventWithNoFieldData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.MISSING_DATA);
   });
 
@@ -299,7 +300,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(noKeyEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -311,7 +312,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(noKeyEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -48,7 +48,7 @@ jest.mock("../../utils/formTemplates/formTemplates", () => ({
 
 jest.mock("../../utils/auth/authorization", () => ({
   hasPermissions: jest.fn().mockReturnValue(true),
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   isAuthorizedToFetchState: jest.fn().mockReturnValue(true),
 }));
 
@@ -160,7 +160,7 @@ describe("Test createReport API method", () => {
   });
 
   test("Test unauthorized report creation throws 401 error", async () => {
-    jest.spyOn(authFunctions, "isAuthorized").mockResolvedValueOnce(false);
+    jest.spyOn(authFunctions, "isAuthenticated").mockResolvedValueOnce(false);
     const res = await createReport(wpCreationEvent, null);
     expect(res.statusCode).toBe(StatusCodes.Unauthenticated);
     expect(res.body).toContain(error.UNAUTHORIZED);

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -17,6 +17,7 @@ import {
 // types
 import { APIGatewayProxyEvent } from "../../utils/types";
 import { StatusCodes } from "../../utils/responses/response-lib";
+import { isAuthorizedToFetchState } from "../../utils/auth/authorization";
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
@@ -28,10 +29,8 @@ jest.mock("../../storage/reports", () => ({
 jest.mock("../../utils/auth/authorization", () => ({
   hasPermissions: jest.fn(() => {}),
   isAuthenticated: jest.fn().mockReturnValue(true),
-  isAuthorizedToFetchState: jest.fn(() => {}),
+  isAuthorizedToFetchState: jest.fn().mockReturnValue(true),
 }));
-
-const mockAuthUtil = require("../../utils/auth/authorization");
 
 const testReadEvent: APIGatewayProxyEvent = {
   ...proxyEvent,
@@ -59,8 +58,7 @@ let consoleSpy: {
 
 describe("handlers/reports/fetch", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
-    mockAuthUtil.isAuthorizedToFetchState.mockReturnValueOnce(true);
+    jest.clearAllMocks();
     consoleSpy.debug = jest.spyOn(console, "debug").mockImplementation();
     consoleSpy.warn = jest.spyOn(console, "warn").mockImplementation();
   });
@@ -129,6 +127,26 @@ describe("handlers/reports/fetch", () => {
       expect(body.formTemplate).toStrictEqual(mockReportJson);
     });
 
+    test("Test Successful Report Fetch, creating completionStatus", async () => {
+      const metadataWithNoCompletionStatus = {
+        ...mockDynamoDataWPCompleted,
+        completionStatus: undefined,
+      };
+      (getReportMetadata as jest.Mock).mockResolvedValue(
+        metadataWithNoCompletionStatus
+      );
+      (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
+      (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
+      const res = await fetchReport(testReadEvent, null);
+      expect(res.statusCode).toBe(StatusCodes.Ok);
+      const body = JSON.parse(res.body!);
+      expect(body.completionStatus).toEqual({
+        "/mock/mock-route-1": false,
+        "/mock/mock-route-2": {},
+      });
+      expect(body.isComplete).toEqual(false);
+    });
+
     test("Test reportKeys not provided throws 400 error", async () => {
       const noKeyEvent: APIGatewayProxyEvent = {
         ...testReadEvent,
@@ -149,6 +167,13 @@ describe("handlers/reports/fetch", () => {
       expect(consoleSpy.warn).toHaveBeenCalled();
       expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
+    });
+
+    test("Test unauthorized returns 403", async () => {
+      (isAuthorizedToFetchState as jest.Mock).mockReturnValueOnce(false);
+      const res = await fetchReport(testReadEvent, null);
+      expect(res.statusCode).toBe(StatusCodes.Forbidden);
+      expect(res.body).toContain(error.UNAUTHORIZED);
     });
   });
 
@@ -185,6 +210,13 @@ describe("handlers/reports/fetch", () => {
       expect(consoleSpy.warn).toHaveBeenCalled();
       expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
+    });
+
+    test("Test unauthorized returns 403", async () => {
+      (isAuthorizedToFetchState as jest.Mock).mockReturnValueOnce(false);
+      const res = await fetchReportsByState(testReadEventByState, null);
+      expect(res.statusCode).toBe(StatusCodes.Forbidden);
+      expect(res.body).toContain(error.UNAUTHORIZED);
     });
   });
 });

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -27,7 +27,7 @@ jest.mock("../../storage/reports", () => ({
 
 jest.mock("../../utils/auth/authorization", () => ({
   hasPermissions: jest.fn(() => {}),
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   isAuthorizedToFetchState: jest.fn(() => {}),
 }));
 

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -15,7 +15,8 @@ import {
   queryReportMetadatasForState,
 } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
@@ -69,7 +70,7 @@ describe("handlers/reports/fetch", () => {
       (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
       const res = await fetchReport(testReadEvent, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+      expect(res.statusCode).toBe(StatusCodes.NotFound);
     });
 
     test("Test Report Form not found in S3", async () => {
@@ -78,7 +79,7 @@ describe("handlers/reports/fetch", () => {
       (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
       const res = await fetchReport(testReadEvent, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+      expect(res.statusCode).toBe(StatusCodes.NotFound);
     });
 
     test("Test Field Data not found in S3", async () => {
@@ -87,7 +88,7 @@ describe("handlers/reports/fetch", () => {
       (getReportFieldData as jest.Mock).mockResolvedValue(undefined);
       const res = await fetchReport(testReadEvent, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+      expect(res.statusCode).toBe(StatusCodes.NotFound);
     });
 
     test("Test Successful Report Fetch w/ Incomplete Report", async () => {
@@ -96,8 +97,8 @@ describe("handlers/reports/fetch", () => {
       (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
       const res = await fetchReport(testReadEvent, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-      const body = JSON.parse(res.body);
+      expect(res.statusCode).toBe(StatusCodes.Ok);
+      const body = JSON.parse(res.body!);
       expect(body.lastAlteredBy).toContain("Thelonious States");
       expect(body.submissionName).toContain("testProgram");
       expect(body.completionStatus).toMatchObject(
@@ -116,8 +117,8 @@ describe("handlers/reports/fetch", () => {
       (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
       const res = await fetchReport(testReadEvent, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-      const body = JSON.parse(res.body);
+      expect(res.statusCode).toBe(StatusCodes.Ok);
+      const body = JSON.parse(res.body!);
       expect(body.lastAlteredBy).toContain("Thelonious States");
       expect(body.submissionName).toContain("testProgram");
       expect(body.completionStatus).toMatchObject({
@@ -135,7 +136,7 @@ describe("handlers/reports/fetch", () => {
       };
       const res = await fetchReport(noKeyEvent, null);
       expect(consoleSpy.warn).toHaveBeenCalled();
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
     });
 
@@ -146,7 +147,7 @@ describe("handlers/reports/fetch", () => {
       };
       const res = await fetchReport(noKeyEvent, null);
       expect(consoleSpy.warn).toHaveBeenCalled();
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
     });
   });
@@ -158,8 +159,8 @@ describe("handlers/reports/fetch", () => {
       ]);
       const res = await fetchReportsByState(testReadEventByState, null);
       expect(consoleSpy.debug).toHaveBeenCalled();
-      expect(res.statusCode).toBe(StatusCodes.SUCCESS);
-      const body = JSON.parse(res.body);
+      expect(res.statusCode).toBe(StatusCodes.Ok);
+      const body = JSON.parse(res.body!);
       expect(body[0].lastAlteredBy).toContain("Thelonious States");
       expect(body[0].submissionName).toContain("testProgram");
     });
@@ -171,7 +172,7 @@ describe("handlers/reports/fetch", () => {
       };
       const res = await fetchReportsByState(noKeyEvent, null);
       expect(consoleSpy.warn).toHaveBeenCalled();
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
     });
 
@@ -182,7 +183,7 @@ describe("handlers/reports/fetch", () => {
       };
       const res = await fetchReportsByState(noKeyEvent, null);
       expect(consoleSpy.warn).toHaveBeenCalled();
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(StatusCodes.BadRequest);
       expect(res.body).toContain(error.NO_KEY);
     });
   });

--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -17,7 +17,8 @@ import {
   putReportFieldData,
 } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   getReportMetadata: jest.fn(),
@@ -64,10 +65,10 @@ describe("Test releaseReport method", () => {
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
 
     const res = await releaseReport(releaseEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.locked).toBe(false);
     expect(body.previousRevisions).toEqual([
       mockDynamoDataWPLocked.fieldDataId,
@@ -91,10 +92,10 @@ describe("Test releaseReport method", () => {
     (getReportFormTemplate as jest.Mock).mockResolvedValue(mockReportJson);
 
     const res = await releaseReport(releaseEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.locked).toBe(false);
     expect(body.submissionCount).toBe(1);
     expect(body.previousRevisions.length).toBe(2);
@@ -110,7 +111,7 @@ describe("Test releaseReport method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await releaseReport(releaseEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
@@ -118,7 +119,7 @@ describe("Test releaseReport method", () => {
     mockAuthUtil.hasPermissions.mockReturnValueOnce(false);
     const res = await releaseReport(releaseEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 });

--- a/services/app-api/handlers/reports/release.test.ts
+++ b/services/app-api/handlers/reports/release.test.ts
@@ -29,7 +29,7 @@ jest.mock("../../storage/reports", () => ({
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
 

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -16,9 +16,16 @@ import {
 import {
   ReportMetadataShape,
   ReportStatus,
-  StatusCodes,
   UserRoles,
 } from "../../utils/types";
+import {
+  badRequest,
+  conflict,
+  forbidden,
+  internalServerError,
+  notFound,
+  ok,
+} from "../../utils/responses/response-lib";
 
 /**
  * Locked reports can be released by admins.
@@ -35,47 +42,30 @@ export const releaseReport = handler(async (event) => {
   const { allParamsValid, reportType, state, id } =
     parseSpecificReportParameters(event);
   if (!allParamsValid) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   // Return a 403 status if the user is not an admin.
   if (!hasPermissions(event, [UserRoles.ADMIN, UserRoles.APPROVER])) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
 
   const metadata = await getReportMetadata(reportType, state, id);
   if (!metadata) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
   const isLocked = metadata.locked;
 
   // Report is not locked.
   if (!isLocked) {
-    return {
-      status: StatusCodes.SUCCESS,
-      body: {
-        ...metadata,
-      },
-    };
+    return ok(metadata);
   }
 
   const isArchived = metadata.archived;
 
   if (isArchived) {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.ALREADY_ARCHIVED,
-    };
+    return conflict(error.ALREADY_ARCHIVED);
   }
 
   const newFieldDataId = KSUID.randomSync().string;
@@ -86,18 +76,12 @@ export const releaseReport = handler(async (event) => {
 
   const fieldData = await getReportFieldData(metadata);
   if (!fieldData) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
   const formTemplate = await getReportFormTemplate(metadata);
   if (!formTemplate) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
   const updatedFieldData = {
@@ -120,23 +104,14 @@ export const releaseReport = handler(async (event) => {
   try {
     await putReportMetadata(newReportMetadata);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.DYNAMO_UPDATE_ERROR,
-    };
+    internalServerError(error.DYNAMO_UPDATE_ERROR);
   }
   // Copy the original field data to a new location.
   try {
     await putReportFieldData(newReportMetadata, updatedFieldData);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.S3_OBJECT_CREATION_ERROR,
-    };
+    internalServerError(error.S3_OBJECT_CREATION_ERROR);
   }
 
-  return {
-    status: StatusCodes.SUCCESS,
-    body: newReportMetadata,
-  };
+  return ok(newReportMetadata);
 });

--- a/services/app-api/handlers/reports/release.ts
+++ b/services/app-api/handlers/reports/release.ts
@@ -104,13 +104,13 @@ export const releaseReport = handler(async (event) => {
   try {
     await putReportMetadata(newReportMetadata);
   } catch {
-    internalServerError(error.DYNAMO_UPDATE_ERROR);
+    return internalServerError(error.DYNAMO_UPDATE_ERROR);
   }
   // Copy the original field data to a new location.
   try {
     await putReportFieldData(newReportMetadata, updatedFieldData);
   } catch {
-    internalServerError(error.S3_OBJECT_CREATION_ERROR);
+    return internalServerError(error.S3_OBJECT_CREATION_ERROR);
   }
 
   return ok(newReportMetadata);

--- a/services/app-api/handlers/reports/submit.test.ts
+++ b/services/app-api/handlers/reports/submit.test.ts
@@ -33,7 +33,7 @@ jest.mock("../../storage/reports", () => ({
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
   hasPermissions: jest.fn().mockReturnValue(true),
 }));
 

--- a/services/app-api/handlers/reports/submit.test.ts
+++ b/services/app-api/handlers/reports/submit.test.ts
@@ -19,7 +19,8 @@ import {
   putReportMetadata,
 } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 mockClient(DynamoDBDocumentClient);
 
@@ -65,7 +66,7 @@ describe("Test submitReport API method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await submitReport(testSubmitEvent, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
   });
 
   test("Test Successful Report Submittal", async () => {
@@ -76,10 +77,10 @@ describe("Test submitReport API method", () => {
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
 
     const res = await submitReport(testSubmitEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.lastAlteredBy).toContain("Thelonious States");
     expect(body.submissionName).toContain("testProgram");
     expect(body.isComplete).toStrictEqual(true);
@@ -99,10 +100,10 @@ describe("Test submitReport API method", () => {
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
 
     const res = await submitReport(testSubmitEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(body.lastAlteredBy).toContain("Thelonious States");
     expect(body.submissionName).toContain("testProgram");
     expect(body.isComplete).toStrictEqual(true);
@@ -117,10 +118,10 @@ describe("Test submitReport API method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(mockDynamoData);
 
     const res = await submitReport(testSubmitEvent, null);
-    const body = JSON.parse(res.body);
+    const body = JSON.parse(res.body!);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.Conflict);
     expect(body).toStrictEqual(error.REPORT_INCOMPLETE);
   });
 
@@ -131,7 +132,7 @@ describe("Test submitReport API method", () => {
     };
     const res = await submitReport(noKeyEvent, null);
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -142,7 +143,7 @@ describe("Test submitReport API method", () => {
     };
     const res = await submitReport(noKeyEvent, null);
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/submit.ts
+++ b/services/app-api/handlers/reports/submit.ts
@@ -7,7 +7,7 @@ import { parseSpecificReportParameters } from "../../utils/auth/parameters";
 import { error } from "../../utils/constants/constants";
 import { convertDateUtcToEt } from "../../utils/time/time";
 // types
-import { ReportStatus, StatusCodes, UserRoles } from "../../utils/types";
+import { ReportStatus, UserRoles } from "../../utils/types";
 import {
   getReportFieldData,
   getReportFormTemplate,
@@ -15,125 +15,94 @@ import {
   putReportFieldData,
   putReportMetadata,
 } from "../../storage/reports";
+import {
+  badRequest,
+  conflict,
+  forbidden,
+  internalServerError,
+  notFound,
+  ok,
+} from "../../utils/responses/response-lib";
 
 export const submitReport = handler(async (event, _context) => {
   const { allParamsValid, reportType, state, id } =
     parseSpecificReportParameters(event);
   if (!allParamsValid) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
+  }
+
+  const reportMetadata = await getReportMetadata(reportType, state, id);
+  if (!reportMetadata) {
+    return notFound(error.NOT_IN_DATABASE);
+  }
+
+  const { status, isComplete } = reportMetadata;
+
+  if (status === "Submitted") {
+    return ok(reportMetadata);
+  }
+
+  if (!isComplete) {
+    return conflict(error.REPORT_INCOMPLETE);
+  }
+
+  const jwt = jwtDecode(event.headers["x-api-key"]!) as Record<
+    string,
+    string | bool
+  >;
+
+  const date = Date.now();
+  const fullName = `${jwt.given_name} ${jwt.family_name}`;
+  const submissionCount = reportMetadata.submissionCount
+    ? reportMetadata.submissionCount + 1
+    : 1;
+  const submittedReportMetadata = {
+    ...reportMetadata,
+    submittedBy: fullName,
+    submittedOnDate: date,
+    status: ReportStatus.SUBMITTED,
+    locked: true,
+    submissionCount: submissionCount,
+  };
+
+  try {
+    await putReportMetadata(submittedReportMetadata);
+  } catch {
+    return internalServerError(error.DYNAMO_UPDATE_ERROR);
+  }
+
+  const existingFieldData = await getReportFieldData(reportMetadata);
+  if (!existingFieldData) {
+    return internalServerError(error.NOT_IN_DATABASE);
+  }
+
+  const fieldData = {
+    ...existingFieldData,
+    submitterName: fullName,
+    submitterEmailAddress: jwt.email,
+    reportSubmissionDate: convertDateUtcToEt(date),
+  };
+
+  const formTemplate = await getReportFormTemplate(reportMetadata);
+  if (!formTemplate) {
+    return internalServerError(error.NOT_IN_DATABASE);
   }
 
   try {
-    const reportMetadata = await getReportMetadata(reportType, state, id);
-    if (!reportMetadata) {
-      return {
-        status: StatusCodes.NOT_FOUND,
-        body: error.NOT_IN_DATABASE,
-      };
-    }
-
-    const { status, isComplete } = reportMetadata;
-
-    if (status === "Submitted") {
-      return {
-        status: StatusCodes.SUCCESS,
-        body: {
-          ...reportMetadata,
-        },
-      };
-    }
-
-    if (!isComplete) {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.REPORT_INCOMPLETE,
-      };
-    }
-
-    const jwt = jwtDecode(event.headers["x-api-key"]!) as Record<
-      string,
-      string | bool
-    >;
-
-    const date = Date.now();
-    const fullName = `${jwt.given_name} ${jwt.family_name}`;
-    const submissionCount = reportMetadata.submissionCount
-      ? reportMetadata.submissionCount + 1
-      : 1;
-    const submittedReportMetadata = {
-      ...reportMetadata,
-      submittedBy: fullName,
-      submittedOnDate: date,
-      status: ReportStatus.SUBMITTED,
-      locked: true,
-      submissionCount: submissionCount,
-    };
-
-    try {
-      await putReportMetadata(submittedReportMetadata);
-    } catch {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.DYNAMO_UPDATE_ERROR,
-      };
-    }
-
-    const existingFieldData = await getReportFieldData(reportMetadata);
-    if (!existingFieldData) {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.NOT_IN_DATABASE,
-      };
-    }
-
-    const fieldData = {
-      ...existingFieldData,
-      submitterName: fullName,
-      submitterEmailAddress: jwt.email,
-      reportSubmissionDate: convertDateUtcToEt(date),
-    };
-
-    const formTemplate = await getReportFormTemplate(reportMetadata);
-    if (!formTemplate) {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.NOT_IN_DATABASE,
-      };
-    }
-
-    try {
-      await putReportFieldData(reportMetadata, fieldData);
-    } catch {
-      return {
-        status: StatusCodes.SERVER_ERROR,
-        body: error.S3_OBJECT_UPDATE_ERROR,
-      };
-    }
-
-    return {
-      status: StatusCodes.SUCCESS,
-      body: {
-        ...submittedReportMetadata,
-        fieldData: { ...fieldData },
-        formTemplate: {
-          ...formTemplate,
-        },
-      },
-    };
+    await putReportFieldData(reportMetadata, fieldData);
   } catch {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return internalServerError(error.S3_OBJECT_UPDATE_ERROR);
   }
+
+  return ok({
+    ...submittedReportMetadata,
+    fieldData: { ...fieldData },
+    formTemplate: {
+      ...formTemplate,
+    },
+  });
 });

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -28,7 +28,7 @@ jest.mock("../../storage/reports", () => ({
 }));
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockResolvedValue(true),
+  isAuthenticated: jest.fn().mockResolvedValue(true),
   hasPermissions: jest.fn(() => {}),
 }));
 const mockAuthUtil = require("../../utils/auth/authorization");

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -16,7 +16,8 @@ import {
   putReportMetadata,
 } from "../../storage/reports";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
@@ -113,12 +114,12 @@ describe("Test updateReport API method", () => {
     (getReportFieldData as jest.Mock).mockResolvedValue(mockReportFieldData);
 
     const response = await updateReport(submissionEvent, null);
-    const body = JSON.parse(response.body);
+    const body = JSON.parse(response.body!);
 
     expect(body.status).toContain("submitted");
     expect(body.fieldData["mock-number-field"]).toBe("2");
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(response.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(response.statusCode).toBe(StatusCodes.Ok);
     expect(putReportFieldData).toHaveBeenCalled();
     expect(putReportMetadata).toHaveBeenCalled();
   });
@@ -131,7 +132,7 @@ describe("Test updateReport API method", () => {
     const response = await updateReport(invalidFieldDataSubmissionEvent, null);
 
     expect(consoleSpy.error).toHaveBeenCalled();
-    expect(response.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(response.statusCode).toBe(StatusCodes.InternalServerError);
     expect(response.body).toContain(error.INVALID_DATA);
     expect(putReportFieldData).not.toHaveBeenCalled();
     expect(putReportMetadata).not.toHaveBeenCalled();
@@ -141,7 +142,7 @@ describe("Test updateReport API method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(mockWPReport);
     const res = await updateReport(updateEventWithInvalidData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.MISSING_DATA);
   });
 
@@ -149,7 +150,7 @@ describe("Test updateReport API method", () => {
     (getReportMetadata as jest.Mock).mockResolvedValue(undefined);
     const res = await updateReport(updateEventWithInvalidData, null);
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.statusCode).toBe(StatusCodes.NotFound);
     expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
@@ -162,7 +163,7 @@ describe("Test updateReport API method", () => {
     const res = await updateReport(updateEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    expect(res.statusCode).toBe(StatusCodes.Forbidden);
     expect(res.body).toContain(error.UNAUTHORIZED);
   });
 
@@ -174,7 +175,7 @@ describe("Test updateReport API method", () => {
     const res = await updateReport(noKeyEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 
@@ -186,7 +187,7 @@ describe("Test updateReport API method", () => {
     const res = await updateReport(noKeyEvent, null);
 
     expect(consoleSpy.warn).toHaveBeenCalled();
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_KEY);
   });
 });

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -13,7 +13,7 @@ import {
   isComplete,
 } from "../../utils/validation/completionStatus";
 // types
-import { StatusCodes, UserRoles } from "../../utils/types";
+import { UserRoles } from "../../utils/types";
 import { removeNotApplicablePopsFromInitiatives } from "../../utils/data/data";
 import {
   getReportFieldData,
@@ -22,23 +22,24 @@ import {
   putReportFieldData,
   putReportMetadata,
 } from "../../storage/reports";
+import {
+  badRequest,
+  forbidden,
+  internalServerError,
+  notFound,
+  ok,
+} from "../../utils/responses/response-lib";
 
 export const updateReport = handler(async (event) => {
   const { allParamsValid, reportType, state, id } =
     parseSpecificReportParameters(event);
   if (!allParamsValid) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.NO_KEY,
-    };
+    return badRequest(error.NO_KEY);
   }
 
   // If request body is missing, return a 400 error.
   if (!event?.body) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_DATA,
-    };
+    return badRequest(error.MISSING_DATA);
   }
 
   // Blocklisted keys
@@ -66,55 +67,34 @@ export const updateReport = handler(async (event) => {
           fieldDataBlocklist.includes(_)
         ))
     ) {
-      return {
-        status: StatusCodes.BAD_REQUEST,
-        body: error.INVALID_DATA,
-      };
+      return badRequest(error.INVALID_DATA);
     }
   } catch {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.INVALID_DATA,
-    };
+    return badRequest(error.INVALID_DATA);
   }
 
   // Ensure user has correct permissions to update a report.
   if (!hasPermissions(event, [UserRoles.STATE_USER], state)) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
 
   const currentReport = await getReportMetadata(reportType, state, id);
   if (!currentReport) {
-    return {
-      status: StatusCodes.NOT_FOUND,
-      body: error.NO_MATCHING_RECORD,
-    };
+    return notFound(error.NO_MATCHING_RECORD);
   }
 
   if (currentReport.archived || currentReport.locked) {
-    return {
-      status: StatusCodes.UNAUTHORIZED,
-      body: error.UNAUTHORIZED,
-    };
+    return forbidden(error.UNAUTHORIZED);
   }
 
   const formTemplate = await getReportFormTemplate(currentReport);
   if (!formTemplate) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_DATA,
-    };
+    return badRequest(error.MISSING_DATA);
   }
 
   const existingFieldData = await getReportFieldData(currentReport);
   if (!existingFieldData) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_DATA,
-    };
+    return badRequest(error.MISSING_DATA);
   }
 
   // Parse the passed payload.
@@ -124,18 +104,12 @@ export const updateReport = handler(async (event) => {
     unvalidatedPayload;
 
   if (!unvalidatedFieldData) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_DATA,
-    };
+    return badRequest(error.MISSING_DATA);
   }
 
   // Validation JSON should be there—if it's not, there's an issue.
   if (!formTemplate.validationJson) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.MISSING_FORM_TEMPLATE,
-    };
+    return badRequest(error.MISSING_FORM_TEMPLATE);
   }
 
   // Validate passed field data
@@ -145,10 +119,7 @@ export const updateReport = handler(async (event) => {
   );
 
   if (!validatedFieldData) {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.INVALID_DATA,
-    };
+    return badRequest(error.INVALID_DATA);
   }
 
   // Finalize fieldData to be sent to s3
@@ -161,10 +132,7 @@ export const updateReport = handler(async (event) => {
   try {
     await putReportFieldData(currentReport, cleanedFieldData);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.S3_OBJECT_UPDATE_ERROR,
-    };
+    return internalServerError(error.S3_OBJECT_UPDATE_ERROR);
   }
 
   const completionStatus = await calculateCompletionStatus(
@@ -180,10 +148,7 @@ export const updateReport = handler(async (event) => {
 
   // If metadata fails validation, return 400
   if (!validatedMetadata) {
-    return {
-      status: StatusCodes.BAD_REQUEST,
-      body: error.INVALID_DATA,
-    };
+    return badRequest(error.INVALID_DATA);
   }
 
   // Update record in report metadata table
@@ -197,18 +162,12 @@ export const updateReport = handler(async (event) => {
   try {
     await putReportMetadata(updatedMetadata);
   } catch {
-    return {
-      status: StatusCodes.SERVER_ERROR,
-      body: error.DYNAMO_UPDATE_ERROR,
-    };
+    return internalServerError(error.DYNAMO_UPDATE_ERROR);
   }
 
-  return {
-    status: StatusCodes.SUCCESS,
-    body: {
-      ...updatedMetadata,
-      fieldData,
-      formTemplate,
-    },
-  };
+  return ok({
+    ...updatedMetadata,
+    fieldData,
+    formTemplate,
+  });
 });

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -55,21 +55,18 @@ export const updateReport = handler(async (event) => {
     "reportSubmissionDate",
   ];
 
-  try {
-    const eventBody = JSON.parse(event.body);
-    if (
-      (eventBody.metadata &&
-        Object.keys(eventBody.metadata).some((_) =>
-          metadataBlocklist.includes(_)
-        )) ||
-      (eventBody.fieldData &&
-        Object.keys(eventBody.fieldData).some((_) =>
-          fieldDataBlocklist.includes(_)
-        ))
-    ) {
-      return badRequest(error.INVALID_DATA);
-    }
-  } catch {
+  // This parse is guaranteed to succeed, because handler-lib already did it.
+  const eventBody = JSON.parse(event.body);
+  if (
+    (eventBody.metadata &&
+      Object.keys(eventBody.metadata).some((_) =>
+        metadataBlocklist.includes(_)
+      )) ||
+    (eventBody.fieldData &&
+      Object.keys(eventBody.fieldData).some((_) =>
+        fieldDataBlocklist.includes(_)
+      ))
+  ) {
     return badRequest(error.INVALID_DATA);
   }
 
@@ -89,12 +86,12 @@ export const updateReport = handler(async (event) => {
 
   const formTemplate = await getReportFormTemplate(currentReport);
   if (!formTemplate) {
-    return badRequest(error.MISSING_DATA);
+    return notFound(error.MISSING_DATA);
   }
 
   const existingFieldData = await getReportFieldData(currentReport);
   if (!existingFieldData) {
-    return badRequest(error.MISSING_DATA);
+    return notFound(error.MISSING_DATA);
   }
 
   // Parse the passed payload.
@@ -109,7 +106,7 @@ export const updateReport = handler(async (event) => {
 
   // Validation JSON should be there—if it's not, there's an issue.
   if (!formTemplate.validationJson) {
-    return badRequest(error.MISSING_FORM_TEMPLATE);
+    return internalServerError(error.MISSING_FORM_TEMPLATE);
   }
 
   // Validate passed field data

--- a/services/app-api/handlers/templates/fetch.test.ts
+++ b/services/app-api/handlers/templates/fetch.test.ts
@@ -3,7 +3,8 @@ import { fetchTemplate } from "./fetch";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { error } from "../../utils/constants/constants";
 // types
-import { APIGatewayProxyEvent, StatusCodes } from "../../utils/types";
+import { APIGatewayProxyEvent } from "../../utils/types";
+import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../utils/auth/authorization", () => ({
   isAuthorized: jest.fn().mockReturnValue(true),
@@ -37,7 +38,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(wpEvent, null);
 
     expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.Ok);
     expect(res.body).toContain("s3://fakeurl.bucket.here");
   });
 
@@ -49,7 +50,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(noKeyEvent, null);
 
     expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
     expect(res.body).toContain(error.NO_TEMPLATE_NAME);
   });
 
@@ -61,7 +62,7 @@ describe("Test fetchTemplate API method", () => {
     const res = await fetchTemplate(noKeyEvent, null);
 
     expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
     expect(res.body).toContain(error.INVALID_TEMPLATE_NAME);
   });
 });

--- a/services/app-api/handlers/templates/fetch.test.ts
+++ b/services/app-api/handlers/templates/fetch.test.ts
@@ -7,7 +7,7 @@ import { APIGatewayProxyEvent } from "../../utils/types";
 import { StatusCodes } from "../../utils/responses/response-lib";
 
 jest.mock("../../utils/auth/authorization", () => ({
-  isAuthorized: jest.fn().mockReturnValue(true),
+  isAuthenticated: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock("../../storage/templates", () => ({

--- a/services/app-api/handlers/templates/fetch.test.ts
+++ b/services/app-api/handlers/templates/fetch.test.ts
@@ -49,8 +49,7 @@ describe("Test fetchTemplate API method", () => {
     };
     const res = await fetchTemplate(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.NO_TEMPLATE_NAME);
   });
 
@@ -61,8 +60,7 @@ describe("Test fetchTemplate API method", () => {
     };
     const res = await fetchTemplate(noKeyEvent, null);
 
-    expect(consoleSpy.error).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.InternalServerError);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
     expect(res.body).toContain(error.INVALID_TEMPLATE_NAME);
   });
 });

--- a/services/app-api/handlers/templates/fetch.ts
+++ b/services/app-api/handlers/templates/fetch.ts
@@ -4,7 +4,7 @@ import { error } from "../../utils/constants/constants";
 import { getTemplateDownloadUrl } from "../../storage/templates";
 // types
 import { TemplateKeys } from "../../utils/types";
-import { ok } from "../../utils/responses/response-lib";
+import { badRequest, ok } from "../../utils/responses/response-lib";
 
 /*
  * NOTE: This handler is not concerned with _form_ templates, like wp.json!
@@ -15,13 +15,13 @@ import { ok } from "../../utils/responses/response-lib";
 
 export const fetchTemplate = handler(async (event, _context) => {
   if (!event?.pathParameters?.templateName!) {
-    throw new Error(error.NO_TEMPLATE_NAME);
+    return badRequest(error.NO_TEMPLATE_NAME);
   }
   let key: TemplateKeys | undefined;
   if (event.pathParameters.templateName === "WP") {
     key = TemplateKeys.WP;
   } else {
-    throw new Error(error.INVALID_TEMPLATE_NAME);
+    return badRequest(error.INVALID_TEMPLATE_NAME);
   }
   const url = await getTemplateDownloadUrl(key);
   return ok(url);

--- a/services/app-api/handlers/templates/fetch.ts
+++ b/services/app-api/handlers/templates/fetch.ts
@@ -3,7 +3,8 @@ import handler from "../handler-lib";
 import { error } from "../../utils/constants/constants";
 import { getTemplateDownloadUrl } from "../../storage/templates";
 // types
-import { StatusCodes, TemplateKeys } from "../../utils/types";
+import { TemplateKeys } from "../../utils/types";
+import { ok } from "../../utils/responses/response-lib";
 
 /*
  * NOTE: This handler is not concerned with _form_ templates, like wp.json!
@@ -23,5 +24,5 @@ export const fetchTemplate = handler(async (event, _context) => {
     throw new Error(error.INVALID_TEMPLATE_NAME);
   }
   const url = await getTemplateDownloadUrl(key);
-  return { status: StatusCodes.SUCCESS, body: url };
+  return ok(url);
 });

--- a/services/app-api/storage/dynamodb-lib.ts
+++ b/services/app-api/storage/dynamodb-lib.ts
@@ -35,7 +35,7 @@ export const collectPageItems = async <
 >(
   paginator: Paginator<T>
 ) => {
-  let items: Record<string, any> = [];
+  let items: Record<string, any>[] = [];
   for await (let page of paginator) {
     items = items.concat(page.Items ?? []);
   }

--- a/services/app-api/utils/auth/authorization.test.ts
+++ b/services/app-api/utils/auth/authorization.test.ts
@@ -3,7 +3,7 @@ import { mockClient } from "aws-sdk-client-mock";
 import { proxyEvent } from "../testing/proxyEvent";
 import {
   hasPermissions,
-  isAuthorized,
+  isAuthenticated,
   isAuthorizedToFetchState,
 } from "./authorization";
 import { UserRoles } from "../types";
@@ -46,19 +46,19 @@ describe("Test authorization with api key and environment variables", () => {
   });
   test("is not authorized when no api key is passed", async () => {
     mockVerifier.mockReturnValue(true);
-    const authStatus = await isAuthorized(noApiKeyEvent);
+    const authStatus = await isAuthenticated(noApiKeyEvent);
     expect(authStatus).toBeFalsy();
   });
   test("is not authorized when token is invalid", async () => {
     mockVerifier.mockImplementation(() => {
       throw new Error("could not verify");
     });
-    const authStatus = await isAuthorized(apiKeyEvent);
+    const authStatus = await isAuthenticated(apiKeyEvent);
     expect(authStatus).toBeFalsy();
   });
   test("is authorized when api key is passed and environment variables are set", async () => {
     mockVerifier.mockReturnValue(true);
-    const authStatus = await isAuthorized(apiKeyEvent);
+    const authStatus = await isAuthenticated(apiKeyEvent);
     expect(authStatus).toBeTruthy();
   });
 });
@@ -75,14 +75,16 @@ describe("Test authorization with api key and ssm parameters", () => {
       throw new Error("failed in test");
     });
     ssmClientMock.on(GetParameterCommand).callsFake(mockGetSsmParameter);
-    await expect(isAuthorized(apiKeyEvent)).rejects.toThrow("failed in test");
+    await expect(isAuthenticated(apiKeyEvent)).rejects.toThrow(
+      "failed in test"
+    );
   });
   test("is authorized when api key is passed and ssm parameters exist", async () => {
     const mockGetSsmParameter = jest
       .fn()
       .mockResolvedValue({ Parameter: { Value: "VALUE" } });
     ssmClientMock.on(GetParameterCommand).callsFake(mockGetSsmParameter);
-    const authStatus = await isAuthorized(apiKeyEvent);
+    const authStatus = await isAuthenticated(apiKeyEvent);
     expect(authStatus).toBeTruthy();
   });
 
@@ -92,7 +94,7 @@ describe("Test authorization with api key and ssm parameters", () => {
     const mockGetSsmParameter = jest.fn().mockResolvedValue(mockSsmResponse);
     ssmClientMock.on(GetParameterCommand).callsFake(mockGetSsmParameter);
 
-    await isAuthorized(apiKeyEvent);
+    await isAuthenticated(apiKeyEvent);
     expect(mockGetSsmParameter).toHaveBeenCalled();
   });
 
@@ -101,7 +103,7 @@ describe("Test authorization with api key and ssm parameters", () => {
     delete process.env["COGNITO_USER_POOL_CLIENT_ID"];
     ssmClientMock.on(GetParameterCommand).resolves({});
 
-    await expect(isAuthorized(apiKeyEvent)).rejects.toThrow(Error);
+    await expect(isAuthenticated(apiKeyEvent)).rejects.toThrow(Error);
   });
 });
 

--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -41,7 +41,7 @@ const loadCognitoValues = async () => {
   }
 };
 
-export const isAuthorized = async (event: APIGatewayProxyEvent) => {
+export const isAuthenticated = async (event: APIGatewayProxyEvent) => {
   const cognitoValues = await loadCognitoValues();
 
   // Verifier that expects valid access tokens:
@@ -51,17 +51,17 @@ export const isAuthorized = async (event: APIGatewayProxyEvent) => {
     clientId: cognitoValues.userPoolClientId,
   });
 
-  let isAuthorized;
+  let isAuthenticated;
   if (event?.headers?.["x-api-key"]) {
     try {
-      isAuthorized = await verifier.verify(event.headers["x-api-key"]);
+      isAuthenticated = await verifier.verify(event.headers["x-api-key"]);
     } catch {
-      // verification failed - unauthorized
-      isAuthorized = false;
+      // verification failed - unauthenticated
+      isAuthenticated = false;
     }
   }
 
-  return !!isAuthorized;
+  return !!isAuthenticated;
 };
 
 export const hasPermissions = (

--- a/services/app-api/utils/constants/constants.ts
+++ b/services/app-api/utils/constants/constants.ts
@@ -28,7 +28,7 @@ export const error = {
   ALREADY_ARCHIVED: "Cannot update archived report.",
   ALREADY_LOCKED: "Cannot update locked report.",
   REPORT_INCOMPLETE: "Cannot submit incomplete form.",
-};
+} as const;
 
 export const buckets = {
   FORM_TEMPLATE: "formTemplates",

--- a/services/app-api/utils/responses/response-lib.test.ts
+++ b/services/app-api/utils/responses/response-lib.test.ts
@@ -1,25 +1,39 @@
-import { buildResponse, internalServerError } from "./response-lib";
+import {
+  ok,
+  created,
+  badRequest,
+  unauthorized,
+  forbidden,
+  notFound,
+  conflict,
+  internalServerError,
+} from "./response-lib";
 
-test("Internal Server Error should give a 500 status", () => {
-  const res = internalServerError("internal error");
-  expect(res.body).toBe(JSON.stringify("internal error"));
-  expect(res.statusCode).toBe(500);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
-});
+describe("HTTP Response helper functions", () => {
+  test("Responses should have correct status codes", () => {
+    expect(ok({}).statusCode).toBe(200);
+    expect(created({}).statusCode).toBe(201);
+    expect(badRequest({}).statusCode).toBe(400);
+    expect(unauthorized({}).statusCode).toBe(401);
+    expect(forbidden({}).statusCode).toBe(403);
+    expect(notFound({}).statusCode).toBe(404);
+    expect(conflict({}).statusCode).toBe(409);
+    expect(internalServerError({}).statusCode).toBe(500);
+  });
 
-test("Build Response should create an object with a status code 420 and message", () => {
-  const res = buildResponse(400, "status is 400");
-  expect(res.body).toBe(JSON.stringify("status is 400"));
-  expect(res.statusCode).toBe(400);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
-});
+  test("Responses should exclude a body if not provided", () => {
+    const response = badRequest();
+    expect(response.body).toBeUndefined();
+  });
 
-test("Build Response should create an object with a status code 403 and message", () => {
-  const res = buildResponse(403, "Unauthorized");
-  expect(res.body).toBe(JSON.stringify("Unauthorized"));
-  expect(res.statusCode).toBe(403);
-  expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
-  expect(res.headers["Access-Control-Allow-Credentials"]).toBe(true);
+  test("Responses should include a body if provided", () => {
+    const res = badRequest("try again");
+    expect(res.body).toBe('"try again"');
+  });
+
+  test("Responses should have the correct headers", () => {
+    const response = ok({});
+    expect(response.headers["Access-Control-Allow-Origin"]).toBe("*");
+    expect(response.headers["Access-Control-Allow-Credentials"]).toBe(true);
+  });
 });

--- a/services/app-api/utils/responses/response-lib.test.ts
+++ b/services/app-api/utils/responses/response-lib.test.ts
@@ -2,7 +2,7 @@ import {
   ok,
   created,
   badRequest,
-  unauthorized,
+  unauthenticated,
   forbidden,
   notFound,
   conflict,
@@ -14,7 +14,7 @@ describe("HTTP Response helper functions", () => {
     expect(ok({}).statusCode).toBe(200);
     expect(created({}).statusCode).toBe(201);
     expect(badRequest({}).statusCode).toBe(400);
-    expect(unauthorized({}).statusCode).toBe(401);
+    expect(unauthenticated({}).statusCode).toBe(401);
     expect(forbidden({}).statusCode).toBe(403);
     expect(notFound({}).statusCode).toBe(404);
     expect(conflict({}).statusCode).toBe(409);

--- a/services/app-api/utils/responses/response-lib.ts
+++ b/services/app-api/utils/responses/response-lib.ts
@@ -1,14 +1,64 @@
-export function internalServerError(body: any) {
-  return buildResponse(500, body);
+export class HttpResponse {
+  readonly statusCode: number;
+  readonly body: string | undefined;
+  readonly headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true,
+  };
+  constructor(statusCode: number, body?: Object | undefined) {
+    this.statusCode = statusCode;
+    if (body !== undefined) {
+      this.body = JSON.stringify(body);
+    }
+  }
 }
 
-export function buildResponse(statusCode: number, body: any) {
-  return {
-    statusCode: statusCode,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Credentials": true,
-    },
-    body: JSON.stringify(body),
-  };
-}
+/**
+ * The response for a successful request.
+ * Should include a body for GET, PUT, or POST - which is all our requests.
+ */
+export const ok = (body: Object) => new HttpResponse(200, body);
+
+/**
+ * The response for a successful POST or PUT request,
+ * which resulted in the creation of a new resource.
+ */
+export const created = (body: Object) => new HttpResponse(201, body);
+
+/**
+ * The response for a failed request, due to client-side issues.
+ * Typically indicates a missing parameter or malformed body.
+ */
+export const badRequest = (body?: Object) => new HttpResponse(400, body);
+
+/**
+ * The response for a client without any authorization.
+ * Typically indicates an issue with the request's headers or token.
+ */
+export const unauthorized = (body?: Object) => new HttpResponse(401, body);
+
+/**
+ * The response for a client without sufficient permissions.
+ * This is specific to the requested operation.
+ * For example, a regular user requesting an admin-only endpoint.
+ */
+export const forbidden = (body?: Object) => new HttpResponse(403, body);
+
+/**
+ * The response for a request that assumes the existence of a missing resource.
+ * For example, attempting to submit a report that isn't in the database.
+ */
+export const notFound = (body?: Object) => new HttpResponse(404, body);
+
+/**
+ * The response for a request that assumes the server is in a different state.
+ * For example, attempting to submit a report that's already submitted.
+ */
+export const conflict = (body?: Object) => new HttpResponse(409, body);
+
+/**
+ * The response for a request that errored out on the server side.
+ * Typically indicates there is nothing the client can do to resolve the issue.
+ */
+export const internalServerError = (body?: Object) =>
+  new HttpResponse(500, body);

--- a/services/app-api/utils/responses/response-lib.ts
+++ b/services/app-api/utils/responses/response-lib.ts
@@ -22,9 +22,12 @@ export const badRequest = (body?: Object) =>
 /**
  * The response for a client without any authorization.
  * Typically indicates an issue with the request's headers or token.
+ *
+ * Note: The usual name for HTTP 401 is "Unauthorized", but that's misleading.
+ * Authentication is for identity; authorization is for permissions.
  */
-export const unauthorized = (body?: Object) =>
-  new HttpResponse(StatusCodes.Unauthorized, body);
+export const unauthenticated = (body?: Object) =>
+  new HttpResponse(StatusCodes.Unauthenticated, body);
 
 /**
  * The response for a client without sufficient permissions.
@@ -65,7 +68,7 @@ export enum StatusCodes {
   Ok = 200,
   Created = 201,
   BadRequest = 400,
-  Unauthorized = 401,
+  Unauthenticated = 401,
   Forbidden = 403,
   NotFound = 404,
   Conflict = 409,

--- a/services/app-api/utils/responses/response-lib.ts
+++ b/services/app-api/utils/responses/response-lib.ts
@@ -1,3 +1,81 @@
+/**
+ * The response for a successful request.
+ * Should include a body for GET, PUT, or POST.
+ * Need not include a body for DELETE
+ */
+export const ok = (body?: Object) => new HttpResponse(StatusCodes.Ok, body);
+
+/**
+ * The response for a successful POST or PUT request,
+ * which resulted in the creation of a new resource.
+ */
+export const created = (body: Object) =>
+  new HttpResponse(StatusCodes.Created, body);
+
+/**
+ * The response for a failed request, due to client-side issues.
+ * Typically indicates a missing parameter or malformed body.
+ */
+export const badRequest = (body?: Object) =>
+  new HttpResponse(StatusCodes.BadRequest, body);
+
+/**
+ * The response for a client without any authorization.
+ * Typically indicates an issue with the request's headers or token.
+ */
+export const unauthorized = (body?: Object) =>
+  new HttpResponse(StatusCodes.Unauthorized, body);
+
+/**
+ * The response for a client without sufficient permissions.
+ * This is specific to the requested operation.
+ * For example, a regular user requesting an admin-only endpoint.
+ */
+export const forbidden = (body?: Object) =>
+  new HttpResponse(StatusCodes.Forbidden, body);
+
+/**
+ * The response for a request that assumes the existence of a missing resource.
+ * For example, attempting to submit a report that isn't in the database.
+ */
+export const notFound = (body?: Object) =>
+  new HttpResponse(StatusCodes.NotFound, body);
+
+/**
+ * The response for a request that assumes the server is in a different state.
+ * For example, attempting to submit a report that's already submitted.
+ */
+export const conflict = (body?: Object) =>
+  new HttpResponse(StatusCodes.Conflict, body);
+
+/**
+ * The response for a request that errored out on the server side.
+ * Typically indicates there is nothing the client can do to resolve the issue.
+ */
+export const internalServerError = (body?: Object) =>
+  new HttpResponse(StatusCodes.InternalServerError, body);
+
+/**
+ * Note: Production code shouldn't need to reference this directly.
+ * Use a helper method instead.
+ *
+ * This enum is listed mainly for the purpose of unit testing.
+ */
+export enum StatusCodes {
+  Ok = 200,
+  Created = 201,
+  BadRequest = 400,
+  Unauthorized = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Conflict = 409,
+  InternalServerError = 500,
+}
+
+/**
+ * Note: Production code shouldn't need to reference this directly.
+ * Use a helper method instead.
+ */
 export class HttpResponse {
   readonly statusCode: number;
   readonly body: string | undefined;
@@ -12,53 +90,3 @@ export class HttpResponse {
     }
   }
 }
-
-/**
- * The response for a successful request.
- * Should include a body for GET, PUT, or POST - which is all our requests.
- */
-export const ok = (body: Object) => new HttpResponse(200, body);
-
-/**
- * The response for a successful POST or PUT request,
- * which resulted in the creation of a new resource.
- */
-export const created = (body: Object) => new HttpResponse(201, body);
-
-/**
- * The response for a failed request, due to client-side issues.
- * Typically indicates a missing parameter or malformed body.
- */
-export const badRequest = (body?: Object) => new HttpResponse(400, body);
-
-/**
- * The response for a client without any authorization.
- * Typically indicates an issue with the request's headers or token.
- */
-export const unauthorized = (body?: Object) => new HttpResponse(401, body);
-
-/**
- * The response for a client without sufficient permissions.
- * This is specific to the requested operation.
- * For example, a regular user requesting an admin-only endpoint.
- */
-export const forbidden = (body?: Object) => new HttpResponse(403, body);
-
-/**
- * The response for a request that assumes the existence of a missing resource.
- * For example, attempting to submit a report that isn't in the database.
- */
-export const notFound = (body?: Object) => new HttpResponse(404, body);
-
-/**
- * The response for a request that assumes the server is in a different state.
- * For example, attempting to submit a report that's already submitted.
- */
-export const conflict = (body?: Object) => new HttpResponse(409, body);
-
-/**
- * The response for a request that errored out on the server side.
- * Typically indicates there is nothing the client can do to resolve the issue.
- */
-export const internalServerError = (body?: Object) =>
-  new HttpResponse(500, body);

--- a/services/app-api/utils/types/other.ts
+++ b/services/app-api/utils/types/other.ts
@@ -4,15 +4,6 @@ export interface AnyObject {
   [key: string]: any;
 }
 
-export const enum StatusCodes {
-  SUCCESS = 200,
-  CREATED = 201,
-  BAD_REQUEST = 400,
-  UNAUTHORIZED = 403,
-  NOT_FOUND = 404,
-  SERVER_ERROR = 500,
-}
-
 export interface CompletionData {
   [key: string]: boolean | CompletionData;
 }


### PR DESCRIPTION
### Description
This PR explores an alternative to Garrett's excellent idea in #752 , for streamlining our API handlers.

In short:
```ts
// Rather than constructing a response object on the fly (current state):
if (!allParamsValid) {
  return {
    status: StatusCodes.BadRequest,
    body: error.NO_KEY,
  };
}

// We will construct a response with a named helper:
if (!allParamsValid) {
  return badRequest(error.NO_KEY);
}
```

## How to Review
The best way to review this is probably commit-by-commit:
1. `Create a new type representing lambda results, with helpers`
   * Note the simplification of handler-lib, and the complexification of response-lib.
   * Note the change to `type LambdaFunction`: lambdas are now _required_ to return an `HttpResponse`
2. `Convert lambdas to use the new response helpers`
   * Pick your favorite handler and see how it has changed. My favorite is reports/fetch.ts
   * All the other changes are just that, times twelve. Safe to ignore if you're just trying to get the gist.
   * There were a few places where I changed the behavior slightly, such as banners/create.ts. I am pretty confident that none of these changes are consequential, beyond possibly streamlining a future API debugging session.
3. `Fix unit tests`
   * This commit was pure tedium. Safe to ignore.
4. `Rename Unauthorized -> Unauthenticated`
   * The only interesting changes are in response-lib.
   * This should probably have been in a separate PR, to be honest. I'm sorry, sometimes I can't help myself.
5. `Fix all the tests after that rename, whoops`
   * Ignore this one entirely please
   * Avert your eyes from my shame
6. `The rest of the commits`
   * OK maybe you should have gone file-by-file. Sorry! 😓 

### Related ticket(s)
n/a

---
### How to test
This PR touches almost every file in the API, and most changes have to do with requests that are invalid, for one reason or another. That, together with AWS' request signing, makes it very difficult to test from the UI. But, the expected behavioral changes are also very small - for example, changing a 403 response to a 409, for a situation that we don't expect to ever happen.

For that reason, I would say that the automated e2e tests are sufficient here - coupled, of course, with a thorough reading of the code changes.

### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~