### PR TITLE
Fix padding in list

### DIFF
--- a/services/app-api/forms/wp.json
+++ b/services/app-api/forms/wp.json
@@ -562,7 +562,7 @@
                       "content": "Initiative close-out information, to be completed as appropriate during MFP Work Plan revisions",
                       "props": {
                         "style": {
-                          "paddingTop": ".5rem"
+                          "padding": ".5rem"
                         }
                       }
                     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
All the other items in this list have `padding` and this one had `paddingTop`. Now they are consistent.

Is this work making an ETL to fix existing reports?

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3982

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d1avl5sgzabx32.cloudfront.net/
- Log in as `stateuser@test.com`
- Enter the existing work plan
- Go to the State or Territory-Specific Initiatives Instructions page
- Note the roman numeral list under "For each initiative, recipients will be asked to provide:"
- Note all items are aligned the same
- Compare to any WP in [MFP dev](https://mdctmfpdev.cms.gov/)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
---