### PR TITLE
fix hover color change

### DIFF
--- a/services/ui-src/src/styles/components/link.ts
+++ b/services/ui-src/src/styles/components/link.ts
@@ -33,6 +33,7 @@ const unstyledVariant = {
   textDecoration: "none",
   ":focus, :focus-visible, :hover, :visited, :visited:hover": {
     textDecoration: "none",
+    color: "palette.base",
   },
 };
 


### PR DESCRIPTION
### Description

In Firefox, the sidebar nav items were graying out for a second on hover. This fix removes the gray (on hover should not result in text style change).

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3992

---
### How to test
See video in card 
See expected behavior in Firefox -- when you enter into a program, the nav bar items should not have any text style change on hover. 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
