### PR TITLE
Cmdct 3993 - add padding between text and edit button in entity row

### DIFF
--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -263,6 +263,7 @@ const sx = {
     },
   },
   actionContainer: {
+    // paddingLeft: "1.5rem",
     alignItems: "center",
     display: "flex",
   },

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -266,6 +266,9 @@ const sx = {
     paddingLeft: "1.5rem",
     alignItems: "center",
     display: "flex",
+    ".mobile &": {
+      paddingLeft: 0,
+    },
   },
   editNameButton: {
     fontWeight: "normal",

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -263,7 +263,7 @@ const sx = {
     },
   },
   actionContainer: {
-    // paddingLeft: "1.5rem",
+    paddingLeft: "1.5rem",
     alignItems: "center",
     display: "flex",
   },


### PR DESCRIPTION
### Description

There wasn't any padding between the text and edit button, which was visible when the title went long
![Screenshot 2024-09-19 at 3 02 58 PM](https://github.com/user-attachments/assets/51c1adf1-0f44-45c5-840f-730a5b46184b)

change:
This change is viewable in all Entity Rows

![Screenshot 2024-09-19 at 3 02 35 PM](https://github.com/user-attachments/assets/455a9570-5f82-440e-83ee-34ae127999dc)




### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3993

---
### How to test
Create a WP, see table in the WP has padding. Create SAR, see that initiatives table has correct padding.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
