### PR TITLE
Fix disabled state for dashboard buttons

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -393,6 +393,7 @@ export const DashboardPage = ({ reportType }: Props) => {
           <Box sx={sx.callToActionContainer}>
             <Button
               type="submit"
+              variant="primary"
               disabled={isAddSubmissionDisabled()}
               onClick={() => openCreateReportModal()}
             >
@@ -406,7 +407,7 @@ export const DashboardPage = ({ reportType }: Props) => {
                 onClick={openResetWorkPlanModal}
                 disabled={isAddSubmissionDisabled()}
                 type="submit"
-                variant="outline"
+                variant="transparent"
               >
                 Reset MFP Work Plan
               </Button>

--- a/services/ui-src/src/styles/components/button.ts
+++ b/services/ui-src/src/styles/components/button.ts
@@ -10,6 +10,7 @@ const baseStyles = {
   "&:disabled, &:disabled:hover": {
     color: "palette.gray",
     backgroundColor: "palette.gray_lighter",
+    opacity: "1",
   },
 };
 
@@ -64,7 +65,7 @@ const transparentVariant = {
     color: "palette.primary",
   },
   "&:disabled, &:disabled:hover": {
-    color: "palette.gray_lighter",
+    color: "palette.gray_light",
     backgroundColor: "transparent",
   },
 };


### PR DESCRIPTION
### Description
This is a hotfix for a bug I noticed: the disabled buttons and links on the work plan dashboard were extremely light and do not meet accessibility contrast standards


### Related ticket(s)

N/A


### How to test
1. Log in as a state user and create a work plan
2. Stay on the dashboard and see the disabled "Continue MFP Work Plan" and "Reset MFP Work Plan" buttons. They should be legible.

**Before**

<img width="1009" alt="Screenshot 2024-09-20 at 9 49 48 AM" src="https://github.com/user-attachments/assets/07ab6e3a-1aee-4203-a0d9-cf5dae81df35">

**After**

<img width="1117" alt="Screenshot 2024-09-20 at 10 12 27 AM" src="https://github.com/user-attachments/assets/567c2da2-c348-452e-aa33-dcc96a1b1e3a">
