### PR TITLE
Add text translate util

### DIFF
--- a/services/app-api/forms/sar.json
+++ b/services/app-api/forms/sar.json
@@ -182,6 +182,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of people who signed an MFP informed consent form in the reporting period",
+              "subsectionTitle": "Number of people who signed an MFP informed consent form in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -220,6 +221,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions in the reporting period",
+              "subsectionTitle": "Number of MFP transitions in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -283,6 +285,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions from qualified institutions in the reporting period",
+              "subsectionTitle": "Number of MFP transitions from qualified institutions in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -400,6 +403,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP transitions to qualified residences in the reporting period",
+              "subsectionTitle": "Number of MFP transitions to qualified residences in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -499,6 +503,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Total number of active MFP participants in the reporting period",
+              "subsectionTitle": "Total number of active MFP participants in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -537,6 +542,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP participants completing the program in the reporting period",
+              "subsectionTitle": "Number of MFP participants completing the program in the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -575,6 +581,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of people re-enrolled in MFP during the reporting period",
+              "subsectionTitle": "Number of people re-enrolled in MFP during the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",
@@ -613,6 +620,7 @@
             "intro": {
               "section": "Recruitment, Enrollment, and Transitions",
               "subsection": "Number of MFP participants disenrolled from the program during the reporting period",
+              "subsectionTitle": "Number of MFP participants disenrolled from the program during the {{reportingPeriod}}",
               "info": [
                 {
                   "type": "text",

--- a/services/ui-src/src/components/app/AppRoutes.test.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.test.tsx
@@ -7,7 +7,6 @@ import { AppRoutes } from "components";
 import { useStore, UserProvider } from "utils";
 import {
   mockStateUserStore,
-  mockLDFlags,
   mockBannerStore,
   mockReportStore,
 } from "utils/testing/setupJest";
@@ -19,8 +18,6 @@ mockedUseStore.mockReturnValue({
   ...mockBannerStore,
   ...mockReportStore,
 });
-
-mockLDFlags.setDefault({ wpReport: true, sarReport: true });
 
 global.structuredClone = jest.fn((val) => {
   return val ? JSON.parse(JSON.stringify(val)) : val;

--- a/services/ui-src/src/components/export/ExportedReportBanner.tsx
+++ b/services/ui-src/src/components/export/ExportedReportBanner.tsx
@@ -23,6 +23,8 @@ export const ExportedReportBanner = () => {
 
   const verbiage = verbiageMap[reportType];
   const { reportBanner } = verbiage;
+
+  // LaunchDarkly
   const printExperience = useFlags()?.printExperience;
 
   const onClickHandler = () => {

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -58,7 +58,7 @@ export const CreateWorkPlanModal = ({
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
 
-  // temporary flag for testing copyover
+  // LaunchDarkly - temporary flag for testing copyover
   const isCopyOverTest = useFlags()?.isCopyOverTest;
 
   const form: FormJson = !previousReport

--- a/services/ui-src/src/components/pages/Home/HomePage.test.tsx
+++ b/services/ui-src/src/components/pages/Home/HomePage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 // components
 import { HomePage } from "components";
 // utils
-import { mockLDFlags, RouterWrappedComponent } from "utils/testing/setupJest";
+import { RouterWrappedComponent } from "utils/testing/setupJest";
 import { testA11y } from "utils/testing/commonTests";
 
 const homeView = (
@@ -10,8 +10,6 @@ const homeView = (
     <HomePage />
   </RouterWrappedComponent>
 );
-
-mockLDFlags.setDefault({ wpReport: true, sarReport: true });
 
 describe("<HomePage />", () => {
   test("Check that HomePage renders", () => {

--- a/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/AdminReview.test.tsx
@@ -4,7 +4,6 @@ import { ReportContext } from "components";
 // utils
 import {
   mockAdminUserStore,
-  mockLDFlags,
   mockReportMethods,
   mockUseStore,
   RouterWrappedComponent,
@@ -18,8 +17,6 @@ import { ReportStatus } from "types";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-
-mockLDFlags.setDefault({ pdfExport: false });
 
 const ReviewSubmitPage = (verbiage: any) => {
   return (

--- a/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/ReviewSubmitPage.test.tsx
@@ -7,7 +7,6 @@ import { ReportStatus } from "types";
 // utils
 import {
   mockAdminUserStore,
-  mockLDFlags,
   mockReportMethods,
   mockUseStore,
   RouterWrappedComponent,
@@ -20,8 +19,6 @@ import { testA11y } from "utils/testing/commonTests";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-
-mockLDFlags.setDefault({ pdfExport: false });
 
 const WpReviewSubmitPage = (
   <RouterWrappedComponent>

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -17,6 +17,7 @@ export interface ReportPageVerbiage {
   intro: {
     section: string;
     subsection?: string;
+    subsectionTitle?: string;
     hint?: string;
     info?: string | CustomHtmlElement[];
     title?: string;

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -153,16 +153,16 @@ export const displayLongformPeriod = (
   reportYear: number | undefined
 ) => {
   if (period === 1) {
-    return ` January 1 to June 30, ${reportYear} reporting period`;
+    return `January 1 to June 30, ${reportYear} reporting period`;
   } else {
-    return ` July 1 to December 31, ${reportYear} reporting period`;
+    return `July 1 to December 31, ${reportYear} reporting period`;
   }
 };
 
 export const displayLongformPeriodSection9 = (
   reportYear: number | undefined
 ) => {
-  return ` August 1, ${
+  return `August 1, ${
     reportYear ? reportYear - 1 : reportYear
   } to July 31, ${reportYear}`;
 };

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
-import { mockFlags, resetLDMocks } from "jest-launchdarkly-mock";
 // types
 import {
   UserRoles,
@@ -54,13 +53,6 @@ jest.mock("@chakra-ui/transition", () => ({
     <div hidden={!inProp}>{children}</div>
   )),
 }));
-
-/* Mock LaunchDarkly (see https://bit.ly/3QAeS7j) */
-export const mockLDFlags = {
-  setDefault: (baseline: any) => mockFlags(baseline),
-  clear: resetLDMocks,
-  set: mockFlags,
-};
 
 // AUTH
 
@@ -343,12 +335,6 @@ export const RouterWrappedComponent: React.FC = ({ children }) => (
   <Router>{children}</Router>
 );
 
-// LAUNCHDARKLY
-
-export const mockLDClient = {
-  variation: jest.fn(() => true),
-};
-
 // ASSET
 export * from "./mockAsset";
 // BANNER
@@ -357,6 +343,8 @@ export * from "./mockBanner";
 export * from "./mockEntities";
 // FORM
 export * from "./mockForm";
+// LAUNCHDARKLY
+export * from "./mockLaunchDarkly";
 // REPORT
 export * from "./mockReport";
 // ROUTER

--- a/services/ui-src/src/utils/text/translate.test.ts
+++ b/services/ui-src/src/utils/text/translate.test.ts
@@ -1,0 +1,34 @@
+import { translate } from "./translate";
+
+describe("translate()", () => {
+  const stateName = "Puerto Rico";
+  const heading = "MFP Work Plan for";
+  const reportYear = "2024";
+  const reportPeriod = "1";
+
+  test("returns translated text", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { stateName, heading, reportYear, reportPeriod }
+    );
+    expect(result).toBe("Puerto Rico MFP Work Plan for 2024 - Period 1");
+  });
+
+  test("returns empty value for missing key", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { heading, reportYear, reportPeriod }
+    );
+
+    expect(result).toBe(" MFP Work Plan for 2024 - Period 1");
+  });
+
+  test("returns empty value for non-existent key", () => {
+    const result = translate(
+      "{{stateName}} {{heading}} {{reportYear}} - Period {{reportPeriod}}",
+      { stateName, nonExistent: "nonExistent", reportYear, reportPeriod }
+    );
+
+    expect(result).toBe("Puerto Rico  2024 - Period 1");
+  });
+});

--- a/services/ui-src/src/utils/text/translate.ts
+++ b/services/ui-src/src/utils/text/translate.ts
@@ -1,0 +1,14 @@
+export function translate(text: string, keysToReplace: any = {}) {
+  const keys = Object.keys(keysToReplace);
+  let translatedText = text;
+
+  keys.forEach((key) => {
+    const matches = new RegExp(`{{${key}}}`, "gm");
+    translatedText = translatedText.replace(matches, keysToReplace[key]);
+  });
+
+  const unmatched = /{{\w*}}/gm;
+  translatedText = translatedText.replace(unmatched, "");
+
+  return translatedText;
+}

--- a/services/ui-src/src/verbiage/pages/sar/sar-export.ts
+++ b/services/ui-src/src/verbiage/pages/sar/sar-export.ts
@@ -37,6 +37,8 @@ export default {
         "Select the target populations applicable to your state during this reporting period.",
       ],
     },
+    reportTitle:
+      "{{stateName}} Semi-Annual Progress Report (SAR) for {{reportYear}} - Period {{reportPeriod}}",
   },
   generalInformationTable: {
     headings: [

--- a/services/ui-src/src/verbiage/pages/wp/wp-export.ts
+++ b/services/ui-src/src/verbiage/pages/wp/wp-export.ts
@@ -26,6 +26,8 @@ export default {
       subtitle:
         "Enrollees in separate CHIP programs funded under Title XXI should not be reported in the WP. Please check this box if the state is unable to remove information about Separate CHIP enrollees from its reporting on this program.",
     },
+    reportTitle:
+      "{{stateName}} MFP Work Plan for {{reportYear}} - Period {{reportPeriod}}",
   },
   tableHeaders: {
     indicator: "Indicator",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Add a `translate` util that replaces any keys in `{{key}}` format within a string with defined values
- Use the util in `ExportedReportPage` with a LaunchDarkly flag
- Remove old LD flags in tests

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3677

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Create a WP and SAR.
2. Verify the headings are as expected.
3. Unit tests also provide coverage.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
If we like this pattern, there are several other components where  we can use the util.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
