### PR TITLE
Migrate profile tests to Playwright

### DIFF
--- a/tests/e2e/pages/profile.spec.ts
+++ b/tests/e2e/pages/profile.spec.ts
@@ -1,12 +1,53 @@
-import { test } from "@playwright/test";
+import { expect, test } from "../utils/fixtures/base";
 import { e2eA11y, logInAdminUser, logInStateUser } from "../utils";
 
-test("Is accessible on all device types for state user", async ({ page }) => {
+test("Admin user can navigate to /admin", async ({
+  page,
+  adminHomePage,
+  profilePage,
+  bannerEditorPage,
+}) => {
+  await logInAdminUser(page);
+  await adminHomePage.isReady();
+  await adminHomePage.manageAccount();
+  await profilePage.isReady();
+  await expect(profilePage.bannerEditorButton).toBeVisible();
+
+  await profilePage.bannerEditorButton.click();
+  await bannerEditorPage.isReady();
+});
+
+test("State user cannot navigate to /admin", async ({
+  page,
+  stateHomePage,
+  profilePage,
+  bannerEditorPage,
+}) => {
   await logInStateUser(page);
+  await stateHomePage.isReady();
+  await stateHomePage.manageAccount();
+  await profilePage.isReady();
+  await expect(profilePage.bannerEditorButton).not.toBeVisible();
+  await bannerEditorPage.goto();
+
+  // Expect a redirect to the profile page
+  await profilePage.isReady();
+});
+
+test("Is accessible on all device types for state user", async ({
+  page,
+  stateHomePage,
+}) => {
+  await logInStateUser(page);
+  await stateHomePage.isReady();
   await e2eA11y(page, "/profile");
 });
 
-test("Is accessible on all device types for admin user", async ({ page }) => {
+test("Is accessible on all device types for admin user", async ({
+  page,
+  adminHomePage,
+}) => {
   await logInAdminUser(page);
+  await adminHomePage.isReady();
   await e2eA11y(page, "/profile");
 });

--- a/tests/e2e/utils/fixtures/base.ts
+++ b/tests/e2e/utils/fixtures/base.ts
@@ -3,10 +3,14 @@ import { test as sarTest } from "./sar.ts";
 import { test as wpTest } from "./wp.ts";
 import StateHomePage from "../pageObjects/stateHome.page";
 import AdminHomePage from "../pageObjects/adminHome.page";
+import ProfilePage from "../pageObjects/profile.page.ts";
+import BannerEditorPage from "../pageObjects/banner.page.ts";
 
 type CustomFixtures = {
   stateHomePage: StateHomePage;
   adminHomePage: AdminHomePage;
+  profilePage: ProfilePage;
+  bannerEditorPage: BannerEditorPage;
 };
 
 export const baseTest = base.extend<CustomFixtures>({
@@ -15,6 +19,12 @@ export const baseTest = base.extend<CustomFixtures>({
   },
   adminHomePage: async ({ page }, use) => {
     await use(new AdminHomePage(page));
+  },
+  profilePage: async ({ page }, use) => {
+    await use(new ProfilePage(page));
+  },
+  bannerEditorPage: async ({ page }, use) => {
+    await use(new BannerEditorPage(page));
   },
 });
 

--- a/tests/e2e/utils/pageObjects/banner.page.ts
+++ b/tests/e2e/utils/pageObjects/banner.page.ts
@@ -1,0 +1,17 @@
+import { Locator, Page } from "@playwright/test";
+import BasePage from "./base.page";
+
+export default class BannerEditorPage extends BasePage {
+  public path = "/admin";
+
+  readonly page: Page;
+  readonly title: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.page = page;
+    this.title = page.getByRole("heading", {
+      name: "Banner Admin",
+    });
+  }
+}

--- a/tests/e2e/utils/pageObjects/base.page.ts
+++ b/tests/e2e/utils/pageObjects/base.page.ts
@@ -7,6 +7,10 @@ export default class BasePage {
   readonly title: Locator;
   readonly continueButton: Locator;
   readonly previousButton: Locator;
+  readonly myAccountButton: Locator;
+  readonly accountMenu: Locator;
+  readonly manageAccountButton: Locator;
+  readonly logoutButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -15,6 +19,12 @@ export default class BasePage {
     });
     this.continueButton = page.getByRole("button", { name: "Continue" });
     this.previousButton = page.getByRole("button", { name: "Previous" });
+    this.myAccountButton = page.getByRole("button", { name: "my account" });
+    this.accountMenu = page.getByRole("menu");
+    this.manageAccountButton = page.getByRole("menuitem", {
+      name: "Manage Account",
+    });
+    this.logoutButton = page.getByRole("menuitem", { name: "Log Out" });
   }
 
   public async goto() {
@@ -24,5 +34,17 @@ export default class BasePage {
   public async isReady() {
     await this.title.isVisible();
     return expect(this.page).toHaveURL(this.path);
+  }
+
+  public async manageAccount() {
+    await this.myAccountButton.click();
+    await this.accountMenu.isVisible();
+    await this.manageAccountButton.click();
+  }
+
+  public async logOut() {
+    await this.myAccountButton.click();
+    await this.accountMenu.isVisible();
+    await this.logoutButton.click();
   }
 }

--- a/tests/e2e/utils/pageObjects/profile.page.ts
+++ b/tests/e2e/utils/pageObjects/profile.page.ts
@@ -1,0 +1,21 @@
+import { Locator, Page } from "@playwright/test";
+import BasePage from "./base.page";
+
+export default class ProfilePage extends BasePage {
+  public path = "/profile";
+
+  readonly page: Page;
+  readonly title: Locator;
+  readonly bannerEditorButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.page = page;
+    this.title = page.getByRole("heading", {
+      name: "My Account",
+    });
+    this.bannerEditorButton = page.getByRole("button", {
+      name: "Banner Editor",
+    });
+  }
+}


### PR DESCRIPTION
### Description
Moves some itty bitty profile tests to Playwright


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3861

---
### How to test
- From the root, run `yarn test:e2e` or `yarn test:e2e-ui` and run the profile test. 
- There should be 4 tests now instead of 2, and they should all pass
