### PR TITLE
Spike: Storing auth for playwright tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ services/database/local_buckets
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+playwright/.auth

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,8 +38,14 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: "chromium",
+      name: "setup",
       use: { ...devices["Desktop Chrome"] },
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: "behind-auth",
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
     },
   ],
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
       testMatch: /.*\.setup\.ts/,
     },
     {
-      name: "behind-auth",
+      name: "chromium",
       use: { ...devices["Desktop Chrome"] },
       dependencies: ["setup"],
     },

--- a/tests/e2e/pages/admin.spec.ts
+++ b/tests/e2e/pages/admin.spec.ts
@@ -1,10 +1,8 @@
 import { test } from "../utils/fixtures/base";
-import { e2eA11y } from "../utils";
 
 test("Is accessible on all device types for admin user", async ({
-  page,
   adminHomePage,
 }) => {
-  await adminHomePage.isReady();
-  await e2eA11y(page, "/admin");
+  await adminHomePage.goto("/admin");
+  await adminHomePage.e2eA11y();
 });

--- a/tests/e2e/pages/admin.spec.ts
+++ b/tests/e2e/pages/admin.spec.ts
@@ -1,7 +1,10 @@
-import { test } from "@playwright/test";
-import { e2eA11y, logInAdminUser } from "../utils";
+import { test } from "../utils/fixtures/base";
+import { e2eA11y } from "../utils";
 
-test("Is accessible on all device types for admin user", async ({ page }) => {
-  await logInAdminUser(page);
+test("Is accessible on all device types for admin user", async ({
+  page,
+  adminHomePage,
+}) => {
+  await adminHomePage.isReady();
   await e2eA11y(page, "/admin");
 });

--- a/tests/e2e/pages/home.spec.ts
+++ b/tests/e2e/pages/home.spec.ts
@@ -1,37 +1,52 @@
-import { e2eA11y, logInAdminUser, logInStateUser } from "../utils";
 import { test, expect } from "../utils/fixtures/base";
+import BasePage from "../utils/pageObjects/base.page";
 
-test("Should see the correct home page as a state user", async ({
-  page,
-  stateHomePage,
-}) => {
-  await page.goto("/");
-  await logInStateUser(page);
-  await stateHomePage.isReady();
-  await expect(stateHomePage.wpButton).toBeVisible();
-  await expect(stateHomePage.sarButton).toBeVisible();
+test.describe("state user home page", () => {
+  test("Should see the correct home page as a state user", async ({
+    stateHomePage,
+  }) => {
+    await stateHomePage.goto();
+    await stateHomePage.isReady();
+    await expect(stateHomePage.wpButton).toBeVisible();
+    await expect(stateHomePage.sarButton).toBeVisible();
+  });
+
+  test("Is accessible on all device types for state user", async ({
+    stateHomePage,
+  }) => {
+    await stateHomePage.goto();
+    await stateHomePage.e2eA11y();
+  });
 });
 
-test("Should see the correct home page as an admin user", async ({
-  page,
-  adminHomePage,
-}) => {
-  await page.goto("/");
-  await logInAdminUser(page);
-  await adminHomePage.isReady();
-  await expect(adminHomePage.dropdown).toBeVisible();
+test.describe("admin user home page", () => {
+  test("Should see the correct home page as an admin user", async ({
+    adminHomePage,
+  }) => {
+    await adminHomePage.goto();
+    await adminHomePage.isReady();
+    await expect(adminHomePage.dropdown).toBeVisible();
+  });
+
+  test("Is accessible on all device types for admin user", async ({
+    adminHomePage,
+  }) => {
+    await adminHomePage.goto();
+    await adminHomePage.e2eA11y();
+  });
 });
 
-test("Is accessible on all device types for state user", async ({ page }) => {
-  await logInStateUser(page);
-  await e2eA11y(page, "/");
-});
-
-test("Is accessible on all device types for admin user", async ({ page }) => {
-  await logInAdminUser(page);
-  await e2eA11y(page, "/");
-});
-
-test("Is assessible when not logged in", async ({ page }) => {
-  await e2eA11y(page, "/");
+test.describe("not logged in home page", () => {
+  test("Is assessible when not logged in", async ({ browser }) => {
+    const userContext = await browser.newContext({
+      storageState: {
+        cookies: [],
+        origins: [],
+      },
+    });
+    const homePage = new BasePage(await userContext.newPage());
+    await homePage.goto();
+    await homePage.e2eA11y();
+    await userContext.close();
+  });
 });

--- a/tests/e2e/pages/profile.spec.ts
+++ b/tests/e2e/pages/profile.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "../utils/fixtures/base";
-import { e2eA11y } from "../utils";
 import { BrowserContext, Page } from "@playwright/test";
 import ProfilePage from "../utils/pageObjects/profile.page";
 import BannerEditorPage from "../utils/pageObjects/banner.page";
@@ -25,27 +24,33 @@ test.afterAll(async () => {
   await userContext.close();
 });
 test.describe("Admin profile", () => {
-  test("Admin user can navigate to /admin", async ({ adminHomePage }) => {
-    const profilePage = new ProfilePage(adminPage);
-    const bannerEditorPage = new BannerEditorPage(adminPage);
-    await adminHomePage.goto();
-    await adminHomePage.isReady();
-    await adminHomePage.manageAccount();
-    await profilePage.goto();
-    await expect(profilePage.bannerEditorButton).toBeVisible();
+  test(
+    "Admin user can navigate to /admin",
+    { tag: "@admin" },
+    async ({ adminHomePage }) => {
+      const profilePage = new ProfilePage(adminPage);
+      const bannerEditorPage = new BannerEditorPage(adminPage);
+      await adminHomePage.goto();
+      await adminHomePage.isReady();
+      await adminHomePage.manageAccount();
+      await profilePage.goto();
+      await expect(profilePage.bannerEditorButton).toBeVisible();
 
-    await profilePage.bannerEditorButton.click();
-    await bannerEditorPage.goto();
-    await bannerEditorPage.isReady();
-  });
+      await profilePage.bannerEditorButton.click();
+      await bannerEditorPage.goto();
+      await bannerEditorPage.isReady();
+    }
+  );
 
-  test("Is accessible on all device types for admin user", async ({
-    adminHomePage,
-  }) => {
-    await adminHomePage.goto();
-    await adminHomePage.isReady();
-    await e2eA11y(adminPage, "/profile");
-  });
+  test(
+    "Is accessible on all device types for admin user",
+    { tag: "@admin" },
+    async () => {
+      const profilePage = new ProfilePage(adminPage);
+      await profilePage.goto();
+      await profilePage.e2eA11y();
+    }
+  );
 });
 
 test.describe("State user profile", { tag: "@user" }, () => {
@@ -64,11 +69,9 @@ test.describe("State user profile", { tag: "@user" }, () => {
     await profilePage.isReady();
   });
 
-  test("Is accessible on all device types for state user", async ({
-    stateHomePage,
-  }) => {
-    await stateHomePage.goto();
-    await stateHomePage.isReady();
-    await e2eA11y(userPage, "/profile");
+  test("Is accessible on all device types for state user", async () => {
+    const profilePage = new ProfilePage(userPage);
+    await profilePage.goto();
+    await profilePage.e2eA11y();
   });
 });

--- a/tests/e2e/utils/auth.setup.ts
+++ b/tests/e2e/utils/auth.setup.ts
@@ -29,8 +29,8 @@ setup("authenticate as user", async ({ page }) => {
   const emailInput = page.getByRole("textbox", { name: "email" });
   const passwordInput = page.getByRole("textbox", { name: "password" });
   const loginButton = page.getByRole("button", { name: "Log In with Cognito" });
-  await emailInput.fill(statePassword);
-  await passwordInput.fill(stateUser);
+  await emailInput.fill(stateUser);
+  await passwordInput.fill(statePassword);
   await loginButton.click();
   await page.waitForURL("/");
   await page

--- a/tests/e2e/utils/auth.setup.ts
+++ b/tests/e2e/utils/auth.setup.ts
@@ -1,0 +1,43 @@
+import { test as setup } from "@playwright/test";
+
+import { adminPassword, adminUser, statePassword, stateUser } from "./consts";
+
+const adminFile = "playwright/.auth/admin.json";
+
+setup("authenticate as admin", async ({ page }) => {
+  await page.goto("/");
+  const emailInput = page.getByRole("textbox", { name: "email" });
+  const passwordInput = page.getByRole("textbox", { name: "password" });
+  const loginButton = page.getByRole("button", { name: "Log In with Cognito" });
+  await emailInput.fill(adminUser);
+  await passwordInput.fill(adminPassword);
+  await loginButton.click();
+  await page.waitForURL("/");
+  await page
+    .getByRole("heading", {
+      name: "View State/Territory Reports",
+    })
+    .isVisible();
+  await page.waitForTimeout(1000);
+  await page.context().storageState({ path: adminFile });
+});
+
+const userFile = "playwright/.auth/user.json";
+
+setup("authenticate as user", async ({ page }) => {
+  await page.goto("/");
+  const emailInput = page.getByRole("textbox", { name: "email" });
+  const passwordInput = page.getByRole("textbox", { name: "password" });
+  const loginButton = page.getByRole("button", { name: "Log In with Cognito" });
+  await emailInput.fill(statePassword);
+  await passwordInput.fill(stateUser);
+  await loginButton.click();
+  await page.waitForURL("/");
+  await page
+    .getByRole("heading", {
+      name: "Money Follows the Person (MFP) Portal",
+    })
+    .isVisible();
+  await page.waitForTimeout(1000);
+  await page.context().storageState({ path: userFile });
+});

--- a/tests/e2e/utils/fixtures/base.ts
+++ b/tests/e2e/utils/fixtures/base.ts
@@ -3,14 +3,10 @@ import { test as sarTest } from "./sar.ts";
 import { test as wpTest } from "./wp.ts";
 import StateHomePage from "../pageObjects/stateHome.page";
 import AdminHomePage from "../pageObjects/adminHome.page";
-import ProfilePage from "../pageObjects/profile.page.ts";
-import BannerEditorPage from "../pageObjects/banner.page.ts";
 
 type CustomFixtures = {
   stateHomePage: StateHomePage;
   adminHomePage: AdminHomePage;
-  profilePage: ProfilePage;
-  bannerEditorPage: BannerEditorPage;
 };
 
 export const baseTest = base.extend<CustomFixtures>({
@@ -29,12 +25,6 @@ export const baseTest = base.extend<CustomFixtures>({
     const adminHomePage = new AdminHomePage(await context.newPage());
     await use(adminHomePage);
     await context.close();
-  },
-  profilePage: async ({ page }, use) => {
-    await use(new ProfilePage(page));
-  },
-  bannerEditorPage: async ({ page }, use) => {
-    await use(new BannerEditorPage(page));
   },
 });
 

--- a/tests/e2e/utils/fixtures/base.ts
+++ b/tests/e2e/utils/fixtures/base.ts
@@ -14,11 +14,21 @@ type CustomFixtures = {
 };
 
 export const baseTest = base.extend<CustomFixtures>({
-  stateHomePage: async ({ page }, use) => {
-    await use(new StateHomePage(page));
+  stateHomePage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "playwright/.auth/user.json",
+    });
+    const stateHomePage = new StateHomePage(await context.newPage());
+    await use(stateHomePage);
+    await context.close();
   },
-  adminHomePage: async ({ page }, use) => {
-    await use(new AdminHomePage(page));
+  adminHomePage: async ({ browser }, use) => {
+    const context = await browser.newContext({
+      storageState: "playwright/.auth/admin.json",
+    });
+    const adminHomePage = new AdminHomePage(await context.newPage());
+    await use(adminHomePage);
+    await context.close();
   },
   profilePage: async ({ page }, use) => {
     await use(new ProfilePage(page));

--- a/tests/e2e/utils/pageObjects/base.page.ts
+++ b/tests/e2e/utils/pageObjects/base.page.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
 
 export default class BasePage {
   public path = "/";
@@ -46,5 +47,22 @@ export default class BasePage {
     await this.myAccountButton.click();
     await this.accountMenu.isVisible();
     await this.logoutButton.click();
+  }
+
+  public async e2eA11y() {
+    const breakpoints = {
+      mobile: [560, 800],
+      tablet: [880, 1000],
+      desktop: [1200, 1200],
+    };
+
+    for (const size of Object.values(breakpoints)) {
+      this.page.setViewportSize({ width: size[0], height: size[1] });
+      const results = await new AxeBuilder({ page: this.page })
+        .withTags(["wcag2a", "wcag2aa"])
+        .disableRules(["duplicate-id"])
+        .analyze();
+      expect(results.violations).toEqual([]);
+    }
   }
 }

--- a/tests/e2e/utils/pageObjects/base.page.ts
+++ b/tests/e2e/utils/pageObjects/base.page.ts
@@ -28,8 +28,12 @@ export default class BasePage {
     this.logoutButton = page.getByRole("menuitem", { name: "Log Out" });
   }
 
-  public async goto() {
-    await this.page.goto(this.path);
+  public async goto(url?: string) {
+    if (url) {
+      await this.page.goto(url);
+    } else {
+      await this.page.goto(this.path);
+    }
   }
 
   public async isReady() {

--- a/tests/e2e/utils/pageObjects/wp/wpInitiativeDefine.page.ts
+++ b/tests/e2e/utils/pageObjects/wp/wpInitiativeDefine.page.ts
@@ -8,7 +8,8 @@ export class WPDefineInitiativePage extends BasePage {
   readonly title: Locator;
   readonly backButton: Locator;
   readonly description: Locator;
-  readonly targetPopulations: Locator;
+  readonly olderAdultsCheckbox: Locator;
+  readonly individualsPhysicalCheckbox: Locator;
   readonly startDate: Locator;
   readonly endDate: Locator;
   readonly saveButton: Locator;
@@ -27,7 +28,10 @@ export class WPDefineInitiativePage extends BasePage {
     this.description = page.getByLabel(
       "Describe the initiative, including key activities:"
     );
-    this.targetPopulations = page.getByRole("checkbox");
+    this.olderAdultsCheckbox = page.getByLabel("Older adults");
+    this.individualsPhysicalCheckbox = page.getByLabel(
+      "Individuals with physical"
+    );
     this.startDate = page.getByLabel("Start date");
     this.endDate = page.getByRole("group", {
       name: "Does the initiative have a projected end date?",
@@ -37,8 +41,8 @@ export class WPDefineInitiativePage extends BasePage {
 
   public async fillFields() {
     await this.description.fill("test");
-    await this.page.getByLabel("Older adults").check();
-    await this.page.getByLabel("Individuals with physical").check();
+    await this.olderAdultsCheckbox.check();
+    await this.individualsPhysicalCheckbox.check();
     await this.startDate.fill("01/01/2024");
     await this.endDate.getByLabel("No").click();
   }

--- a/tests/e2e/utils/pageObjects/wp/wpInitiativeOverlay.page.ts
+++ b/tests/e2e/utils/pageObjects/wp/wpInitiativeOverlay.page.ts
@@ -38,18 +38,18 @@ export class WPInitiativeOverlayPage extends BasePage {
     return this.page.getByRole("heading", { name: topic }).isVisible();
   }
 
-  public async completeDefineInitiative() {
+  public async completeDefineInitiative(page: Page) {
     await this.defineInitiative.getByRole("button", { name: "Edit" }).click();
-    const definePage = new WPDefineInitiativePage(this.page);
+    const definePage = new WPDefineInitiativePage(page);
     await definePage.isReady();
     await definePage.fillFields();
     await definePage.saveButton.click();
     await expect(definePage.page.getByRole("alert")).not.toBeVisible();
   }
 
-  public async completeEvaluationPlan() {
+  public async completeEvaluationPlan(page: Page) {
     await this.evaluationPlan.getByRole("button", { name: "Edit" }).click();
-    const evaluationPage = new WPEvaluationPlanPage(this.page);
+    const evaluationPage = new WPEvaluationPlanPage(page);
     await evaluationPage.isReady();
     const noObjectivesText = evaluationPage.page.getByText(
       "Objective total count: 0"
@@ -61,9 +61,9 @@ export class WPInitiativeOverlayPage extends BasePage {
     await evaluationPage.backButton.click();
   }
 
-  public async completeFundingSources() {
+  public async completeFundingSources(page: Page) {
     await this.fundingSources.getByRole("button", { name: "Edit" }).click();
-    const fundingPage = new WPFundingSourcesPage(this.page);
+    const fundingPage = new WPFundingSourcesPage(page);
     await fundingPage.isReady();
     const noFundingSourcesText =
       fundingPage.page.getByText("Funding Sources: 0");

--- a/tests/e2e/wp/create.spec.ts
+++ b/tests/e2e/wp/create.spec.ts
@@ -1,18 +1,60 @@
+import { BrowserContext, Page } from "@playwright/test";
 import { archiveExistingWPs, logInStateUser } from "../utils";
 import { test, expect } from "../utils/fixtures/base";
 import { WPInitiativeOverlayPage } from "../utils/pageObjects/wp/wpInitiativeOverlay.page";
+import StateHomePage from "../utils/pageObjects/stateHome.page";
+import { WPDashboardPage } from "../utils/pageObjects/wp/wpDashboard.page";
+import { WPGeneralInformationPage } from "../utils/pageObjects/wp/wpGeneral.page";
+import { WPTransitionBenchmarkProjectionsPage } from "../utils/pageObjects/wp/wpTransitionBenchmarkProjections.page";
+import { WPTransitionBenchmarkStrategyPage } from "../utils/pageObjects/wp/wpTransitionBenchmarkStrategy.page";
+import { WPInitiativesInstructionsPage } from "../utils/pageObjects/wp/wpInitiativesInstructions.page";
+import { WPInitiativesDashboardPage } from "../utils/pageObjects/wp/wpInitiativesDashboard.page";
+import { WPReviewAndSubmitPage } from "../utils/pageObjects/wp/wpReviewAndSubmit.page";
+
+let userPage: Page;
+let userContext: BrowserContext;
+let homePage: StateHomePage;
+let wpDashboard: WPDashboardPage;
+let wpGeneralInformation: WPGeneralInformationPage;
+let wpTransitionBenchmarkProjections: WPTransitionBenchmarkProjectionsPage;
+let wpTransitionBenchmarkStrategy: WPTransitionBenchmarkStrategyPage;
+let wpInitiativesInstructions: WPInitiativesInstructionsPage;
+let wpInitiativesDashboard: WPInitiativesDashboardPage;
+let wpReviewAndSubmit: WPReviewAndSubmitPage;
+
+test.beforeAll(async ({ browser }) => {
+  userContext = await browser.newContext({
+    storageState: "playwright/.auth/user.json",
+  });
+  userPage = await userContext.newPage();
+
+  homePage = new StateHomePage(userPage);
+  wpDashboard = new WPDashboardPage(userPage);
+  wpGeneralInformation = new WPGeneralInformationPage(userPage);
+  wpTransitionBenchmarkProjections = new WPTransitionBenchmarkProjectionsPage(
+    userPage
+  );
+  wpTransitionBenchmarkStrategy = new WPTransitionBenchmarkStrategyPage(
+    userPage
+  );
+  wpInitiativesInstructions = new WPInitiativesInstructionsPage(userPage);
+  wpInitiativesDashboard = new WPInitiativesDashboardPage(userPage);
+  wpReviewAndSubmit = new WPReviewAndSubmitPage(userPage);
+});
+
+test.afterAll(async () => {
+  await userContext.close();
+});
 
 test.describe("Creating a new Work Plan", () => {
-  test("State user can create a Work Plan", async ({
-    page,
-    stateHomePage,
-    wpDashboard,
-  }) => {
+  test("State user can create a Work Plan", async ({ page }) => {
+    // TODO: migrate these functions to use the save auth model
     await archiveExistingWPs(page);
     await logInStateUser(page);
 
     // View WPs
-    await stateHomePage.wpButton.click();
+    await homePage.goto();
+    await homePage.wpButton.click();
     await wpDashboard.isReady();
 
     // check if work plans exist already or not
@@ -35,7 +77,7 @@ test.describe("Creating a new Work Plan", () => {
       await wpDashboard.copyoverButton.click();
       await expect(wpDashboard.modal).toBeVisible();
       await expect(wpDashboard.modal).toContainText("Continue");
-      await page
+      await wpDashboard.page
         .getByRole("button", { name: "Continue from previous period" })
         .click();
 
@@ -53,19 +95,10 @@ test.describe("Creating a new Work Plan", () => {
     }
   });
 
-  test("State user can fill and submit a Work Plan", async ({
-    page,
-    stateHomePage,
-    wpDashboard,
-    wpGeneralInformation,
-    wpTransitionBenchmarksProjections,
-    wpTransitionBenchmarkStrategy,
-    wpInitiativesInstructions,
-    wpInitiativesDashboard,
-    wpReviewAndSubmit,
-  }) => {
+  test("State user can fill and submit a Work Plan", async ({ page }) => {
     await logInStateUser(page);
-    await stateHomePage.wpButton.click();
+    await homePage.goto();
+    await homePage.wpButton.click();
 
     // Dashboard
     await wpDashboard.isReady();
@@ -81,11 +114,11 @@ test.describe("Creating a new Work Plan", () => {
 
     // Transition Benchmarks
     await wpGeneralInformation.continueButton.click();
-    await wpTransitionBenchmarksProjections.isReady();
-    await wpTransitionBenchmarksProjections.editPopulations();
+    await wpTransitionBenchmarkProjections.isReady();
+    await wpTransitionBenchmarkProjections.editPopulations();
 
     // Transition Benchmark Strategy
-    await wpTransitionBenchmarksProjections.continueButton.click();
+    await wpTransitionBenchmarkProjections.continueButton.click();
     await wpTransitionBenchmarkStrategy.isReady();
     await wpTransitionBenchmarkStrategy.fillTextFields();
 
@@ -115,12 +148,12 @@ test.describe("Creating a new Work Plan", () => {
 
     for (const initiative of initiatives) {
       await initiative.getByRole("button", { name: "edit button" }).click();
-      const overlayPage = new WPInitiativeOverlayPage(page);
+      const overlayPage = new WPInitiativeOverlayPage(userPage);
       await overlayPage.isReady();
 
-      await overlayPage.completeDefineInitiative();
-      await overlayPage.completeEvaluationPlan();
-      await overlayPage.completeFundingSources();
+      await overlayPage.completeDefineInitiative(userPage);
+      await overlayPage.completeEvaluationPlan(userPage);
+      await overlayPage.completeFundingSources(userPage);
       await overlayPage.backButton.click();
     }
 


### PR DESCRIPTION
### Description
Sets up a workflow to store and reuse authentication for specific users (admin, state user) that can be loaded and used in our tests. This means we can avoid running a login flow before each test that involves pages behind auth, and instead navigate directly to certain areas of the app with an already authenticated user.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3990

---
### How to test
1. From the root, run the Playwright tests with `yarn test:e2e` or `yarn test:e2e-ui`
2. Try to run all tests. They should all pass
3. Try to run individual tests. They should pass.
4. Before each/all of the tests, you should see the `utils/auth.setup.ts` file run first, as a dependency to all other tests.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
