### PR TITLE
get correct initiative wp topic text to render

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -4,13 +4,16 @@ import {
   mockReportStore,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
-import { mockSARFullReport, mockWPFullReport } from "utils/testing/mockReport";
+import {
+  mockSARReportWithOverlays,
+  mockWPReportWithOtherTypeOverlays,
+  mockWPReportWithOverlays,
+} from "utils/testing/mockReport";
 import {
   EntityDetailsStepTypes,
   ModalOverlayReportPageVerbiage,
   OverlayModalPageShape,
   OverlayModalTypes,
-  ReportRoute,
   OverlayModalStepTypes,
 } from "types";
 import {
@@ -23,95 +26,6 @@ global.structuredClone = (x: any) => JSON.parse(JSON.stringify(x));
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-
-const mockWPReportWithOverlays = {
-  ...mockWPFullReport,
-  fieldData: {
-    ...mockWPFullReport.fieldData,
-    [OverlayModalTypes.INITIATIVE]: [
-      {
-        ...mockWPFullReport.fieldData.entityType[0],
-        type: OverlayModalTypes.INITIATIVE,
-        id: "mock wip id", // this is both our search filter and our search target in renderFieldRow
-        initiative_wpTopic: [
-          {
-            value: "mock WP topic",
-          },
-        ],
-      },
-    ],
-  },
-  formTemplate: {
-    ...mockWPFullReport.formTemplate,
-    routes: [
-      /*
-       * We need the 3th route to have a child with entityType initiative,
-       * to avoid a null reference in getInitiativeStatus()
-       */
-      ...mockWPFullReport.formTemplate.routes.slice(0, 3),
-      {
-        name: "mock-route-4",
-        path: "/mock/mock-route-4",
-        children: [
-          {
-            entityType: OverlayModalTypes.INITIATIVE,
-          },
-        ],
-      } as ReportRoute,
-      ...mockWPFullReport.formTemplate.routes.slice(3),
-    ],
-  },
-};
-
-const mockSARReportWithOverlays = {
-  ...mockSARFullReport,
-  fieldData: {
-    ...mockSARFullReport.fieldData,
-    [OverlayModalTypes.INITIATIVE]: [
-      {
-        ...mockSARFullReport.fieldData.entityType[0],
-        type: OverlayModalTypes.INITIATIVE,
-        id: "mock wip id", // this is both our search filter and our search target in renderFieldRow
-        initiative_wpTopic: [
-          {
-            value: "mock WP topic",
-          },
-        ],
-        "mock-expenditure-field-1": "5",
-        "mock-expenditure-field-2": "10",
-        "mock-expenditure-field-3": "15",
-        "mock-expenditure-field-4": "20",
-      },
-    ],
-  },
-  formTemplate: {
-    ...mockSARFullReport.formTemplate,
-    routes: [
-      /*
-       * We need the 2th route to have a child with entityType initiative,
-       * to avoid a null reference in getInitiativeStatus()
-       */
-      ...mockSARFullReport.formTemplate.routes.slice(0, 2),
-      {
-        name: "mock-dynamic-route",
-        path: "/mock/mock-dynamic-route",
-        initiatives: [
-          {
-            initiatiaveId: "mock-init-id",
-            name: "mock init name",
-            entitySteps: [
-              {
-                // TODO what here?
-                foo: "bar",
-              },
-            ],
-          },
-        ],
-      } as ReportRoute,
-      ...mockSARFullReport.formTemplate.routes.slice(2),
-    ],
-  },
-};
 
 const wpMockProps = {
   section: {
@@ -417,6 +331,15 @@ describe("<ExportedModalOverlayReportSection />", () => {
     expect(
       screen.getAllByTestId("exportedOverlayModalPage")[0]
     ).toBeInTheDocument();
+  });
+
+  test("should render correct initiative topic", () => {
+    mockedUseStore.mockReturnValue({
+      ...mockReportStore,
+      report: mockWPReportWithOtherTypeOverlays,
+    });
+    render(testComponent(wpMockProps));
+    expect(screen.getByText("Unique initiative type")).toBeInTheDocument();
   });
 
   test("should render for SAR", () => {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -164,7 +164,8 @@ export function renderModalOverlayTableBody(
                   {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
                 </Heading>
                 <Text sx={sx.headingSubtitle}>
-                  {entity.initiative_wpTopic[0].value}
+                  {entity.initiative_wp_otherTopic ??
+                    entity.initiative_wpTopic[0].value}
                 </Text>
               </Box>
             </Flex>

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -1,4 +1,4 @@
-import { ReportStatus } from "types";
+import { OverlayModalTypes, ReportRoute, ReportStatus } from "types";
 import { genericErrorContent } from "verbiage/errors";
 import {
   mockStandardReportPageJson,
@@ -479,4 +479,114 @@ export const mockDashboardReportContext = {
 export const mockReportContextNoReports = {
   ...mockWpReportContext,
   reportsByState: undefined,
+};
+
+export const mockWPReportWithOverlays = {
+  ...mockWPFullReport,
+  fieldData: {
+    ...mockWPFullReport.fieldData,
+    [OverlayModalTypes.INITIATIVE]: [
+      {
+        ...mockWPFullReport.fieldData.entityType[0],
+        type: OverlayModalTypes.INITIATIVE,
+        id: "mock wip id", // this is both our search filter and our search target in renderFieldRow
+        initiative_wpTopic: [
+          {
+            value: "mock WP topic",
+          },
+        ],
+      },
+    ],
+  },
+  formTemplate: {
+    ...mockWPFullReport.formTemplate,
+    routes: [
+      /*
+       * We need the 3th route to have a child with entityType initiative,
+       * to avoid a null reference in getInitiativeStatus()
+       */
+      ...mockWPFullReport.formTemplate.routes.slice(0, 3),
+      {
+        name: "mock-route-4",
+        path: "/mock/mock-route-4",
+        children: [
+          {
+            entityType: OverlayModalTypes.INITIATIVE,
+          },
+        ],
+      } as ReportRoute,
+      ...mockWPFullReport.formTemplate.routes.slice(3),
+    ],
+  },
+};
+
+export const mockWPReportWithOtherTypeOverlays = {
+  ...mockWPFullReport,
+  fieldData: {
+    ...mockWPFullReport.fieldData,
+    [OverlayModalTypes.INITIATIVE]: [
+      {
+        ...mockWPFullReport.fieldData.entityType[0],
+        type: OverlayModalTypes.INITIATIVE,
+        id: "mock wip id",
+        initiative_wpTopic: [
+          {
+            key: "other-type-key",
+            value: "Other, specify",
+          },
+        ],
+        initiative_wp_otherTopic: "Unique initiative type",
+      },
+    ],
+  },
+};
+
+export const mockSARReportWithOverlays = {
+  ...mockSARFullReport,
+  fieldData: {
+    ...mockSARFullReport.fieldData,
+    [OverlayModalTypes.INITIATIVE]: [
+      {
+        ...mockSARFullReport.fieldData.entityType[0],
+        type: OverlayModalTypes.INITIATIVE,
+        id: "mock wip id", // this is both our search filter and our search target in renderFieldRow
+        initiative_wpTopic: [
+          {
+            value: "mock WP topic",
+          },
+        ],
+        "mock-expenditure-field-1": "5",
+        "mock-expenditure-field-2": "10",
+        "mock-expenditure-field-3": "15",
+        "mock-expenditure-field-4": "20",
+      },
+    ],
+  },
+  formTemplate: {
+    ...mockSARFullReport.formTemplate,
+    routes: [
+      /*
+       * We need the 2th route to have a child with entityType initiative,
+       * to avoid a null reference in getInitiativeStatus()
+       */
+      ...mockSARFullReport.formTemplate.routes.slice(0, 2),
+      {
+        name: "mock-dynamic-route",
+        path: "/mock/mock-dynamic-route",
+        initiatives: [
+          {
+            initiatiaveId: "mock-init-id",
+            name: "mock init name",
+            entitySteps: [
+              {
+                // TODO what here?
+                foo: "bar",
+              },
+            ],
+          },
+        ],
+      } as ReportRoute,
+      ...mockSARFullReport.formTemplate.routes.slice(2),
+    ],
+  },
 };


### PR DESCRIPTION
### Description
There is a bug when adding an initiative in the workplan with the topic `Other, specify`. The text that renders is `Other, specify` instead of the text the user added in the textfield. This PR fixes that bug.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4025

---
### How to test
Create a workplan, add an initiative, select `Other, specify`, add a description, see that the added text appears beneath the Initiative name.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
