### PR TITLE
Improve error handling in seed script

### DIFF
--- a/services/app-api/db/helpers.ts
+++ b/services/app-api/db/helpers.ts
@@ -14,3 +14,6 @@ export const createdLog = (obj: any, action: string, type: string): void => {
 export const expandedLog = (json: any): void => {
   console.log(JSON.stringify(json, null, 2));
 };
+
+export const generateReportingPeriod = (year: number, period: number) =>
+  `${year} Period ${period}`;

--- a/services/app-api/db/helpers.ts
+++ b/services/app-api/db/helpers.ts
@@ -1,7 +1,14 @@
 /* eslint-disable no-console */
-export const createdLog = (obj: any, type: string): void => {
+export const createdLog = (obj: any, action: string, type: string): void => {
   const { id, submissionName } = obj;
-  console.log(`${type} created: ${submissionName} (${id})`);
+  if (id) {
+    console.log(`${action} ${type} created: ${submissionName} (${id})`);
+  } else {
+    console.log(`ℹ️ ${obj}`);
+    console.log(
+      `⚠️ Could not create ${action.toLowerCase()} ${type} for reporting period.`
+    );
+  }
 };
 
 export const expandedLog = (json: any): void => {

--- a/services/app-api/db/options.ts
+++ b/services/app-api/db/options.ts
@@ -2,8 +2,10 @@ import { Choice } from "prompts";
 import {
   getSemiAnnualReportsByState,
   getWorkPlansByState,
+  state,
 } from "../../../tests/seeds/options";
 import { SeedReportShape } from "../../../tests/seeds/types";
+import { generateReportingPeriod } from "./helpers";
 
 export const workPlanChoices = async (): Promise<Choice[]> => {
   try {
@@ -27,4 +29,55 @@ export const semiAnnualReportChoices = async (): Promise<Choice[]> => {
   } catch {
     process.exit();
   }
+};
+
+export const backToMenu = {
+  title: "Back to Menu",
+  value: "back",
+};
+
+export const generateChoices = (
+  type: string,
+  year: number,
+  period: number
+): Choice[] => {
+  const reportingPeriod = generateReportingPeriod(year, period);
+
+  const choices = [
+    {
+      title: `Create base ${type}: ${reportingPeriod}`,
+      value: `create${type}`,
+    },
+    {
+      title: `Create filled ${type}: ${reportingPeriod}`,
+      value: `createFilled${type}`,
+    },
+    {
+      title: `Create submitted ${type}: ${reportingPeriod}`,
+      value: `createSubmitted${type}`,
+    },
+    {
+      title: `Create locked ${type}: ${reportingPeriod}`,
+      value: `createLocked${type}`,
+    },
+    {
+      title: `Create archived ${type}: ${reportingPeriod}`,
+      value: `createArchived${type}`,
+    },
+    { title: `Get ${type} by id`, value: `get${type}ById` },
+    {
+      title: `Get ${type}s by state: ${state}`,
+      value: `get${type}sByState`,
+    },
+    backToMenu,
+  ];
+
+  if (type === "WP") {
+    choices.splice(3, 0, {
+      title: `Create approved ${type}: ${reportingPeriod}`,
+      value: `createApproved${type}`,
+    });
+  }
+
+  return choices;
 };

--- a/services/app-api/db/seed.ts
+++ b/services/app-api/db/seed.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-console */
-import prompts, { Choice as PromptChoice, PromptObject } from "prompts";
-import { createdLog, expandedLog } from "./helpers";
-import { semiAnnualReportChoices, workPlanChoices } from "./options";
+import prompts, { Choice, PromptObject } from "prompts";
+import { createdLog, expandedLog, generateReportingPeriod } from "./helpers";
+import {
+  backToMenu,
+  generateChoices,
+  semiAnnualReportChoices,
+  workPlanChoices,
+} from "./options";
 import { currentYear } from "../../../tests/seeds/helpers";
 import {
   bannerKey,
@@ -24,7 +29,6 @@ import {
   getWorkPlanById,
   getWorkPlansByState,
   loginSeedUsers,
-  state,
 } from "../../../tests/seeds/options";
 
 const seed = async (
@@ -32,10 +36,10 @@ const seed = async (
   chosenPeriod?: number
 ): Promise<void> => {
   await loginSeedUsers();
-  const wpIds: PromptChoice[] = await workPlanChoices();
-  const sarIds: PromptChoice[] = await semiAnnualReportChoices();
+  const wpIds: Choice[] = await workPlanChoices();
+  const sarIds: Choice[] = await semiAnnualReportChoices();
 
-  const entityChoices: PromptChoice[] = [
+  const entityChoices: Choice[] = [
     { title: "Work Plan (WP)", value: "WP" },
     { title: "Semi-Annual Report (SAR)", value: "SAR" },
     { title: "Banner", value: "banner" },
@@ -43,60 +47,6 @@ const seed = async (
 
   let reportYear = chosenYear || currentYear;
   let reportPeriod = chosenPeriod || 1;
-
-  const backToMenu = {
-    title: "Back to Menu",
-    value: "back",
-  };
-
-  const generateReportingPeriod = (year: number, period: number) =>
-    `${year} Period ${period}`;
-
-  const generateChoices = (
-    type: string,
-    year: number,
-    period: number
-  ): PromptChoice[] => {
-    const reportingPeriod = generateReportingPeriod(year, period);
-
-    const choices = [
-      {
-        title: `Create base ${type}: ${reportingPeriod}`,
-        value: `create${type}`,
-      },
-      {
-        title: `Create filled ${type}: ${reportingPeriod}`,
-        value: `createFilled${type}`,
-      },
-      {
-        title: `Create submitted ${type}: ${reportingPeriod}`,
-        value: `createSubmitted${type}`,
-      },
-      {
-        title: `Create locked ${type}: ${reportingPeriod}`,
-        value: `createLocked${type}`,
-      },
-      {
-        title: `Create archived ${type}: ${reportingPeriod}`,
-        value: `createArchived${type}`,
-      },
-      { title: `Get ${type} by id`, value: `get${type}ById` },
-      {
-        title: `Get ${type}s by state: ${state}`,
-        value: `get${type}sByState`,
-      },
-      backToMenu,
-    ];
-
-    if (type === "WP") {
-      choices.splice(3, 0, {
-        title: `Create approved ${type}: ${reportingPeriod}`,
-        value: `createApproved${type}`,
-      });
-    }
-
-    return choices;
-  };
 
   const questions: PromptObject[] = [
     {
@@ -154,11 +104,7 @@ const seed = async (
       name: "task",
       message: "Task",
       choices: (prev: string) => {
-        return generateChoices(
-          prev,
-          reportYear,
-          reportPeriod
-        ) as PromptChoice[];
+        return generateChoices(prev, reportYear, reportPeriod) as Choice[];
       },
     },
     {
@@ -337,16 +283,16 @@ const seed = async (
         expandedLog(await getSemiAnnualReportsByState());
         break;
       case "createBanner": {
-        const { Item } = await createBanner();
-        console.log(`Banner created: ${Item?.key}`);
+        await createBanner();
+        console.log("Banner created.");
         break;
       }
       case "getBanner":
         expandedLog(await getBannerById());
         break;
       case "deleteBanner": {
-        const { Key } = await deleteBannerById();
-        console.log(`Banner deleted: ${Key?.key}`);
+        await deleteBannerById();
+        console.log("Banner deleted.");
         break;
       }
       default:

--- a/services/app-api/db/seed.ts
+++ b/services/app-api/db/seed.ts
@@ -161,7 +161,7 @@ const seed = async (
           reportPeriod = answerInt;
         }
 
-        if (answerInt > currentYear) {
+        if (answerInt >= currentYear) {
           reportYear = answerInt;
         }
 

--- a/services/app-api/db/seed.ts
+++ b/services/app-api/db/seed.ts
@@ -6,6 +6,7 @@ import { currentYear } from "../../../tests/seeds/helpers";
 import {
   bannerKey,
   createApprovedWorkPlan,
+  createArchivedSemiAnnualReport,
   createArchivedWorkPlan,
   createBanner,
   createFilledSemiAnnualReport,
@@ -26,7 +27,10 @@ import {
   state,
 } from "../../../tests/seeds/options";
 
-const seed = async (): Promise<void> => {
+const seed = async (
+  chosenYear?: number,
+  chosenPeriod?: number
+): Promise<void> => {
   await loginSeedUsers();
   const wpIds: PromptChoice[] = await workPlanChoices();
   const sarIds: PromptChoice[] = await semiAnnualReportChoices();
@@ -37,8 +41,13 @@ const seed = async (): Promise<void> => {
     { title: "Banner", value: "banner" },
   ];
 
-  let reportYear = currentYear;
-  let reportPeriod = 1;
+  let reportYear = chosenYear || currentYear;
+  let reportPeriod = chosenPeriod || 1;
+
+  const backToMenu = {
+    title: "Back to Menu",
+    value: "back",
+  };
 
   const generateReportingPeriod = (year: number, period: number) =>
     `${year} Period ${period}`;
@@ -76,6 +85,7 @@ const seed = async (): Promise<void> => {
         title: `Get ${type}s by state: ${state}`,
         value: `get${type}sByState`,
       },
+      backToMenu,
     ];
 
     if (type === "WP") {
@@ -95,15 +105,37 @@ const seed = async (): Promise<void> => {
       message: "Type",
       choices: [
         {
-          title: `Change Reporting Period: ${generateReportingPeriod(
+          title: `Change Reporting Year: ${reportYear}`,
+          value: "chooseReportingYear",
+        },
+        {
+          title: `Change Reporting Period: ${reportPeriod}`,
+          value: "chooseReportingPeriod",
+        },
+        {
+          title: `Create approved WP and filled SAR: ${generateReportingPeriod(
             reportYear,
             reportPeriod
           )}`,
-          value: "chooseReportingPeriod",
+          value: "createFilledSAR",
         },
-        { title: "Create filled WP and filled SAR", value: "createFilledEach" },
         ...entityChoices,
       ],
+    },
+    {
+      type: (prev: string) =>
+        prev === "chooseReportingYear" ? "select" : null,
+      name: "reportingYear",
+      message: "Reporting Year",
+      choices: () => {
+        return [
+          { title: `${currentYear}`, value: `${currentYear}` },
+          { title: `${currentYear + 1}`, value: `${currentYear + 1}` },
+          { title: `${currentYear + 2}`, value: `${currentYear + 2}` },
+          { title: `${currentYear + 3}`, value: `${currentYear + 3}` },
+          { title: `${currentYear + 4}`, value: `${currentYear + 4}` },
+        ];
+      },
     },
     {
       type: (prev: string) =>
@@ -112,41 +144,8 @@ const seed = async (): Promise<void> => {
       message: "Reporting Period",
       choices: () => {
         return [
-          { title: `${currentYear} Period 1`, value: "period1" },
-          { title: `${currentYear} Period 2`, value: "period2" },
-          { title: `${currentYear + 1} Period 1`, value: "period3" },
-          { title: `${currentYear + 1} Period 2`, value: "period4" },
-        ];
-      },
-    },
-    {
-      type: (prev: string) =>
-        ["period1", "period2", "period3", "period4"].includes(prev)
-          ? "select"
-          : null,
-      name: "type",
-      message: "Type",
-      choices: (prev: string) => {
-        reportYear = currentYear;
-        reportPeriod = 1;
-
-        if (["period2", "period4"].includes(prev)) {
-          reportPeriod = 2;
-        }
-
-        if (["period3", "period4"].includes(prev)) {
-          reportYear = currentYear + 1;
-        }
-
-        return [
-          {
-            title: `Create filled WP and filled SAR: ${generateReportingPeriod(
-              reportYear,
-              reportPeriod
-            )}`,
-            value: "createFilledEach",
-          },
-          ...entityChoices,
+          { title: "1", value: "1" },
+          { title: "2", value: "2" },
         ];
       },
     },
@@ -176,6 +175,7 @@ const seed = async (): Promise<void> => {
           title: `Delete Banner: ${bannerKey}`,
           value: "deleteBanner",
         },
+        backToMenu,
       ],
     },
     {
@@ -193,7 +193,10 @@ const seed = async (): Promise<void> => {
       choices: sarIds,
     },
     {
-      type: "confirm",
+      type: (prev: string) =>
+        Number.isInteger(parseInt(prev, 10)) || prev === "back"
+          ? null
+          : "confirm",
       name: "exit",
       message: "Exit?",
     },
@@ -204,6 +207,21 @@ const seed = async (): Promise<void> => {
     answer: string | boolean
   ): Promise<void> => {
     switch (prompt.name) {
+      case "reportingPeriod":
+      case "reportingYear": {
+        const answerInt = parseInt(answer as string, 10);
+
+        if ([1, 2].includes(answerInt)) {
+          reportPeriod = answerInt;
+        }
+
+        if (answerInt > currentYear) {
+          reportYear = answerInt;
+        }
+
+        seed(reportYear, reportPeriod);
+        break;
+      }
       case "workPlanId":
         expandedLog(await getWorkPlanById(answer as string));
         break;
@@ -212,7 +230,7 @@ const seed = async (): Promise<void> => {
         break;
       case "exit": {
         if (answer === false) {
-          seed();
+          seed(reportYear, reportPeriod);
         }
         break;
       }
@@ -221,53 +239,54 @@ const seed = async (): Promise<void> => {
     }
 
     switch (answer) {
-      case "createFilledEach": {
+      case "back":
+        seed(reportYear, reportPeriod);
+        break;
+      case "createFilledWP": {
         createdLog(
           await createFilledWorkPlan(reportYear, reportPeriod),
-          "Filled WP"
-        );
-        createdLog(
-          await createFilledSemiAnnualReport(reportYear, reportPeriod),
-          "Filled SAR"
+          "Filled",
+          "WP"
         );
         break;
       }
       case "createWP": {
-        createdLog(await createWorkPlan(reportYear, reportPeriod), "Base WP");
-        break;
-      }
-      case "createFilledWP": {
         createdLog(
-          await createFilledWorkPlan(reportYear, reportPeriod),
-          "Filled WP"
+          await createWorkPlan(reportYear, reportPeriod),
+          "Base",
+          "WP"
         );
         break;
       }
       case "createSubmittedWP": {
         createdLog(
           await createSubmittedWorkPlan(reportYear, reportPeriod),
-          "Submitted WP"
+          "Submitted",
+          "WP"
         );
         break;
       }
       case "createApprovedWP": {
         createdLog(
           await createApprovedWorkPlan(reportYear, reportPeriod),
-          "Approved WP"
+          "Approved",
+          "WP"
         );
         break;
       }
       case "createLockedWP": {
         createdLog(
           await createLockedWorkPlan(reportYear, reportPeriod),
-          "Locked WP"
+          "Locked",
+          "WP"
         );
         break;
       }
       case "createArchivedWP": {
         createdLog(
           await createArchivedWorkPlan(reportYear, reportPeriod),
-          "Archived WP"
+          "Archived",
+          "WP"
         );
         break;
       }
@@ -277,28 +296,40 @@ const seed = async (): Promise<void> => {
       case "createSAR": {
         createdLog(
           await createSemiAnnualReport(reportYear, reportPeriod),
-          "Base SAR"
+          "Base",
+          "SAR"
         );
         break;
       }
       case "createFilledSAR": {
         createdLog(
           await createFilledSemiAnnualReport(reportYear, reportPeriod),
-          "Filled SAR"
+          "Filled",
+          "SAR"
         );
         break;
       }
       case "createSubmittedSAR": {
         createdLog(
           await createSubmittedSemiAnnualReport(reportYear, reportPeriod),
-          "Submitted SAR"
+          "Submitted",
+          "SAR"
         );
         break;
       }
       case "createLockedSAR": {
         createdLog(
           await createLockedSemiAnnualReport(reportYear, reportPeriod),
-          "Locked SAR"
+          "Locked",
+          "SAR"
+        );
+        break;
+      }
+      case "createArchivedSAR": {
+        createdLog(
+          await createArchivedSemiAnnualReport(reportYear, reportPeriod),
+          "Archived",
+          "SAR"
         );
         break;
       }

--- a/tests/seeds/fixtures/banner.ts
+++ b/tests/seeds/fixtures/banner.ts
@@ -1,8 +1,10 @@
 import { faker } from "@faker-js/faker";
-import { SeedBannerDataShape } from "../types";
+import { SeedBannerShape } from "../types";
 
-export const newBanner = (key: string): SeedBannerDataShape => ({
+export const newBanner = (key: string): SeedBannerShape => ({
   key,
+  createdAt: faker.date.past({ years: 1 }).getTime(),
+  lastAltered: faker.date.past({ years: 1 }).getTime(),
   title: faker.lorem.sentence(),
   description: faker.lorem.sentence(),
   startDate: faker.date.past({ years: 1 }).getTime(),

--- a/tests/seeds/fixtures/work-plan.ts
+++ b/tests/seeds/fixtures/work-plan.ts
@@ -5,27 +5,22 @@ import {
   ReportStatus,
   ReportType,
 } from "../../../services/app-api/utils/types";
-import {
-  dateFormat,
-  quarterlyKeyValueGenerator,
-  randomReportPeriod,
-  randomReportYear,
-} from "../helpers";
+import { dateFormat, quarterlyKeyValueGenerator } from "../helpers";
 import { SeedFillReportShape, SeedNewReportShape } from "../types";
 
 export const newWorkPlan = (
   stateName: string,
-  reportYear?: number,
-  reportPeriod?: number
+  reportYear: number,
+  reportPeriod: number
 ): SeedNewReportShape => ({
   metadata: {
     isComplete: false,
     lastAlteredBy: faker.person.fullName(),
     locked: false,
     previousRevisions: [],
-    reportPeriod: reportPeriod || randomReportPeriod,
+    reportPeriod: reportPeriod,
     reportType: ReportType.WP,
-    reportYear: reportYear || randomReportYear,
+    reportYear: reportYear,
     status: ReportStatus.NOT_STARTED,
     submissionCount: 0,
     submissionName: "Work Plan",

--- a/tests/seeds/helpers.ts
+++ b/tests/seeds/helpers.ts
@@ -115,8 +115,8 @@ const del = async (
   };
 
   try {
-    const response = await fetch(url, request);
-    return response.json();
+    await fetch(url, request);
+    return {};
   } catch (error) {
     errorResponse(error);
   }

--- a/tests/seeds/helpers.ts
+++ b/tests/seeds/helpers.ts
@@ -201,13 +201,6 @@ export const dateFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(
 
 export const currentYear: number = new Date().getFullYear();
 
-export const randomReportPeriod: number = faker.number.int({ min: 1, max: 2 });
-
-export const randomReportYear: number = faker.number.int({
-  min: currentYear,
-  max: currentYear + 1,
-});
-
 export const quarterlyKeyValueGenerator = (
   year: number,
   period: number,

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -1,3 +1,4 @@
+import { ReportStatus } from "../../services/app-api/utils/types";
 import {
   fillSemiAnnualReport,
   fillWorkPlan,
@@ -28,25 +29,31 @@ export const loginSeedUsers = async (): Promise<void> => {
 
 // Work Plan (WP)
 export const createWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
   const report = await postApi(
     `/reports/WP/${state}`,
     headers,
-    newWorkPlan(stateName, customReportYear, customReportPeriod)
+    newWorkPlan(stateName, year, period)
   );
   return report;
 };
 
 export const createFilledWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id, reportYear, reportPeriod } = await createWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  const { id } = await createWorkPlan(year, period);
+  const report = await updateFillWorkPlan(id);
+  return report;
+};
+
+export const updateFillWorkPlan = async (
+  id: string
+): Promise<SeedReportShape> => {
+  const { reportYear, reportPeriod } = await getWorkPlanById(id);
+
   const report = await putApi(
     `/reports/WP/${state}/${id}`,
     headers,
@@ -56,13 +63,17 @@ export const createFilledWorkPlan = async (
 };
 
 export const createSubmittedWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createFilledWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  const { id } = await createFilledWorkPlan(year, period);
+  const report = await updateSubmitWorkPlan(id);
+  return report;
+};
+
+export const updateSubmitWorkPlan = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await postApi(
     `/reports/submit/WP/${state}/${id}`,
     headers,
@@ -72,13 +83,17 @@ export const createSubmittedWorkPlan = async (
 };
 
 export const createApprovedWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createSubmittedWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  const { id } = await createSubmittedWorkPlan(year, period);
+  const report = await updateApproveWorkPlan(id);
+  return report;
+};
+
+export const updateApproveWorkPlan = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await putApi(
     `/reports/approve/WP/${state}/${id}`,
     adminHeaders,
@@ -88,13 +103,17 @@ export const createApprovedWorkPlan = async (
 };
 
 export const createLockedWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createApprovedWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  const { id } = await createApprovedWorkPlan(year, period);
+  const report = await updateLockWorkPlan(id);
+  return report;
+};
+
+export const updateLockWorkPlan = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await putApi(
     `/reports/release/WP/${state}/${id}`,
     adminHeaders,
@@ -104,19 +123,34 @@ export const createLockedWorkPlan = async (
 };
 
 export const createArchivedWorkPlan = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createApprovedWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  const { id } = await createApprovedWorkPlan(year, period);
+  const report = await updateArchiveWorkPlan(id);
+  return report;
+};
+
+export const updateArchiveWorkPlan = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await putApi(
     `/reports/archive/WP/${state}/${id}`,
     adminHeaders,
     {}
   );
   return report;
+};
+
+export const getWorkPlansByReportingPeriod = async (
+  year: number,
+  period: number
+): Promise<SeedReportShape[]> => {
+  const wps = await getWorkPlansByState();
+  const reports = wps.filter(
+    (w) => w.reportYear === year && w.reportPeriod === period
+  );
+  return reports;
 };
 
 export const getWorkPlanById = async (id: string): Promise<SeedReportShape> => {
@@ -131,13 +165,28 @@ export const getWorkPlansByState = async (): Promise<SeedReportShape[]> => {
 
 // Semi-Annual Report (SAR)
 export const createSemiAnnualReport = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createApprovedWorkPlan(
-    customReportYear,
-    customReportPeriod
-  );
+  let id;
+
+  const newWP = await createApprovedWorkPlan(year, period);
+
+  if (newWP.id) {
+    id = newWP.id;
+  } else {
+    const existingWPs = await getWorkPlansByReportingPeriod(year, period);
+    const approvedWPs = existingWPs.filter(
+      (w) => w.status === ReportStatus.APPROVED
+    );
+
+    if (approvedWPs.length === 0) {
+      return "No approved WP available for this SAR." as unknown as SeedReportShape;
+    }
+
+    id = approvedWPs[0].id;
+  }
+
   const wp = await getWorkPlanById(id);
 
   const report = await postApi(
@@ -150,31 +199,53 @@ export const createSemiAnnualReport = async (
 };
 
 export const createFilledSemiAnnualReport = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const sar = await createSemiAnnualReport(
-    customReportYear,
-    customReportPeriod
-  );
+  const sar = await createSemiAnnualReport(year, period);
 
+  if (sar.id) {
+    const report = await updateFillSemiAnnualReport(sar.id);
+    return report;
+  }
+
+  // Error message
+  return sar;
+};
+
+export const updateFillSemiAnnualReport = async (
+  id: string
+): Promise<SeedReportShape> => {
+  const sar = await getSemiAnnualReportById(id);
   const report = await putApi(
-    `/reports/SAR/${state}/${sar.id}`,
+    `/reports/SAR/${state}/${id}`,
     headers,
     fillSemiAnnualReport(sar)
   );
-
   return report;
 };
 
 export const createSubmittedSemiAnnualReport = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createFilledSemiAnnualReport(
-    customReportYear,
-    customReportPeriod
-  );
+  const sar = (await createFilledSemiAnnualReport(
+    year,
+    period
+  )) as SeedReportShape;
+
+  if (sar.id) {
+    const report = await updateSubmitSemiAnnualReport(sar.id);
+    return report;
+  }
+
+  // Error message
+  return sar;
+};
+
+export const updateSubmitSemiAnnualReport = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await postApi(
     `/reports/submit/SAR/${state}/${id}`,
     headers,
@@ -184,13 +255,26 @@ export const createSubmittedSemiAnnualReport = async (
 };
 
 export const createLockedSemiAnnualReport = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createFilledSemiAnnualReport(
-    customReportYear,
-    customReportPeriod
-  );
+  const sar = (await createFilledSemiAnnualReport(
+    year,
+    period
+  )) as SeedReportShape;
+
+  if (sar.id) {
+    const report = await updateLockSemiAnnualReport(sar.id);
+    return report;
+  }
+
+  // Error message
+  return sar;
+};
+
+export const updateLockSemiAnnualReport = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await putApi(
     `/reports/release/SAR/${state}/${id}`,
     adminHeaders,
@@ -200,13 +284,26 @@ export const createLockedSemiAnnualReport = async (
 };
 
 export const createArchivedSemiAnnualReport = async (
-  customReportYear?: number,
-  customReportPeriod?: number
+  year: number,
+  period: number
 ): Promise<SeedReportShape> => {
-  const { id } = await createFilledSemiAnnualReport(
-    customReportYear,
-    customReportPeriod
-  );
+  const sar = (await createFilledSemiAnnualReport(
+    year,
+    period
+  )) as SeedReportShape;
+
+  if (sar.id) {
+    const report = await updateArchiveSemiAnnualReport(sar.id);
+    return report;
+  }
+
+  // Error message
+  return sar;
+};
+
+export const updateArchiveSemiAnnualReport = async (
+  id: string
+): Promise<SeedReportShape> => {
   const report = await putApi(
     `/reports/archive/SAR/${state}/${id}`,
     adminHeaders,

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -333,8 +333,7 @@ export const getBannerById = async (): Promise<SeedBannerShape> => {
   try {
     const banner = await getApi(`/banners/${bannerKey}`, adminHeaders);
     return banner;
-    // eslint-disable-next-line no-unused-vars
-  } catch (_e) {
+  } catch {
     return {} as SeedBannerShape;
   }
 };

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -333,6 +333,7 @@ export const getBannerById = async (): Promise<SeedBannerShape> => {
   try {
     const banner = await getApi(`/banners/${bannerKey}`, adminHeaders);
     return banner;
+    // eslint-disable-next-line no-unused-vars
   } catch (_e) {
     return {} as SeedBannerShape;
   }

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -330,8 +330,12 @@ export const createBanner = async (): Promise<SeedBannerShape> => {
 };
 
 export const getBannerById = async (): Promise<SeedBannerShape> => {
-  const banner = await getApi(`/banners/${bannerKey}`, headers);
-  return banner;
+  try {
+    const banner = await getApi(`/banners/${bannerKey}`, adminHeaders);
+    return banner;
+  } catch (e) {
+    return {} as SeedBannerShape;
+  }
 };
 
 export const deleteBannerById = async (): Promise<void> => {

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -334,7 +334,6 @@ export const getBannerById = async (): Promise<SeedBannerShape> => {
   return banner;
 };
 
-export const deleteBannerById = async (): Promise<SeedBannerShape> => {
-  const banner = await deleteApi(`/banners/${bannerKey}`, adminHeaders);
-  return banner;
+export const deleteBannerById = async (): Promise<void> => {
+  await deleteApi(`/banners/${bannerKey}`, adminHeaders);
 };

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -333,7 +333,7 @@ export const getBannerById = async (): Promise<SeedBannerShape> => {
   try {
     const banner = await getApi(`/banners/${bannerKey}`, adminHeaders);
     return banner;
-  } catch (e) {
+  } catch (_e) {
     return {} as SeedBannerShape;
   }
 };

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -229,10 +229,7 @@ export const createSubmittedSemiAnnualReport = async (
   year: number,
   period: number
 ): Promise<SeedReportShape> => {
-  const sar = (await createFilledSemiAnnualReport(
-    year,
-    period
-  )) as SeedReportShape;
+  const sar = await createFilledSemiAnnualReport(year, period);
 
   if (sar.id) {
     const report = await updateSubmitSemiAnnualReport(sar.id);
@@ -258,10 +255,7 @@ export const createLockedSemiAnnualReport = async (
   year: number,
   period: number
 ): Promise<SeedReportShape> => {
-  const sar = (await createFilledSemiAnnualReport(
-    year,
-    period
-  )) as SeedReportShape;
+  const sar = await createFilledSemiAnnualReport(year, period);
 
   if (sar.id) {
     const report = await updateLockSemiAnnualReport(sar.id);
@@ -287,10 +281,7 @@ export const createArchivedSemiAnnualReport = async (
   year: number,
   period: number
 ): Promise<SeedReportShape> => {
-  const sar = (await createFilledSemiAnnualReport(
-    year,
-    period
-  )) as SeedReportShape;
+  const sar = await createFilledSemiAnnualReport(year, period);
 
   if (sar.id) {
     const report = await updateArchiveSemiAnnualReport(sar.id);

--- a/tests/seeds/types.ts
+++ b/tests/seeds/types.ts
@@ -38,15 +38,12 @@ export type SeedReportShape = ReportMetadataShape & {
   fieldData: ReportFieldData;
 };
 
-export type SeedBannerDataShape = {
+export type SeedBannerShape = {
   key: string;
+  createdAt: number;
+  lastAltered: number;
   title: string;
   description: string;
   startDate: number;
   endDate: number;
-};
-
-export type SeedBannerShape = {
-  Item?: SeedBannerDataShape;
-  Key?: SeedBannerDataShape;
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The seed script was erroring silently if it couldn't create a WP or SAR and would terminate the script. These updates print errors to console and leaves the script running.

Also:
- Split changing reporting period to separate year and period options
- Remember selected reporting period when script goes back to main menu
- Add "Back to menu" options when in WP and SAR submenus

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Start MFP locally
2. Run `yarn db:seed`
3. Confirm WPs and SARs can be created for reporting period
4. Confirm if WPs and SARs already exist for reporting period, receive an accurate error message

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
