### PR TITLE
Update SASS & Vite-TSConfig-Paths

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -36,7 +36,7 @@
     "react-icons": "^4.12.0",
     "react-router-dom": "6.26.2",
     "react-uuid": "^1.0.3",
-    "sass": "^1.79.5",
+    "sass": "^1.80.7",
     "vite": "^5.4.7",
     "vite-tsconfig-paths": "^4.3.2",
     "yup": "^0.32.11",

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -38,7 +38,7 @@
     "react-uuid": "^1.0.3",
     "sass": "^1.80.7",
     "vite": "^5.4.7",
-    "vite-tsconfig-paths": "^4.3.2",
+    "vite-tsconfig-paths": "^5.1.2",
     "yup": "^0.32.11",
     "zustand": "^4.5.2"
   },

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -1,6 +1,6 @@
 // necessary to render the UsaBanner correctly
 $image-path: "~@cmsgov/design-system/dist/images";
-@import "@cmsgov/design-system/dist/css/index";
+@use "@cmsgov/design-system/dist/css/index";
 
 @mixin tabbed-focus {
   box-shadow: 0 0 0 3px #fff,

--- a/services/ui-src/vite.config.mts
+++ b/services/ui-src/vite.config.mts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import viteTsconfigPaths from "vite-tsconfig-paths";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   base: "/",
-  plugins: [react(), viteTsconfigPaths()],
+  plugins: [react(), tsconfigPaths()],
   server: {
     open: true,
     port: 3000,

--- a/services/ui-src/vite.config.ts
+++ b/services/ui-src/vite.config.ts
@@ -15,4 +15,11 @@ export default defineConfig({
   build: {
     outDir: "./build",
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler", // or "modern"
+      },
+    },
+  },
 });

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -3609,9 +3609,6 @@
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-3.1.5.tgz#ca7a86a3c6b20fabe59667143f58d9e198616d14"
   integrity sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==
-  dependencies:
-    "@smithy/types" "^3.5.0"
-    tslib "^2.6.2"
 
 "@smithy/config-resolver@^3.0.5", "@smithy/config-resolver@^3.0.9":
   version "3.0.9"
@@ -6300,10 +6297,10 @@ immer@9.0.6:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
   integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
-immutable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
-  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+immutable@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.0.2.tgz#bb8a987349a73efbe6b3b292a9cbaf1b530d296b"
+  integrity sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -8511,13 +8508,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass@^1.79.5:
-  version "1.80.6"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.80.6.tgz#5d0aa55763984effe41e40019c9571ab73e6851f"
-  integrity sha512-ccZgdHNiBF1NHBsWvacvT5rju3y1d/Eu+8Ex6c21nHp2lZGLBEtuwc415QfiI1PJa1TpCo3iXwwSRjRpn2Ckjg==
+sass@^1.80.7:
+  version "1.80.7"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.80.7.tgz#7569334c39220f8ca62fcea38dce60f809ba345c"
+  integrity sha512-MVWvN0u5meytrSjsU7AWsbhoXi1sc58zADXFllfZzbsBT1GHjjar6JwBINYPRrkx/zqnQ6uqbQuHgE95O+C+eQ==
   dependencies:
     chokidar "^4.0.0"
-    immutable "^4.0.0"
+    immutable "^5.0.2"
     source-map-js ">=0.6.2 <2.0.0"
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -9288,10 +9288,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vite-tsconfig-paths@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz#321f02e4b736a90ff62f9086467faf4e2da857a9"
-  integrity sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==
+vite-tsconfig-paths@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.2.tgz#975810f12cdaebcda196ce3c2cb4ba19df277bb1"
+  integrity sha512-gEIbKfJzSEv0yR3XS2QEocKetONoWkbROj6hGx0FHM18qKUojhvcokQsxQx5nMkelZq2n37zbSGCJn+FSODSjA==
   dependencies:
     debug "^4.1.1"
     globrex "^0.1.2"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Properly fixes #139816 

Updates SASS to 1.80.6 and migrates changes
Updates vite-tsconfig-paths from 4.3.2 -> 5.1.2 and migrates changes

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Run the app and take a peek! Icons should show properly, data should save and load, etc.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

