### PR TITLE
bugfix: display WP topic on the export page

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -6,7 +6,6 @@ import {
 } from "utils/testing/setupJest";
 import {
   mockSARReportWithOverlays,
-  mockWPReportWithOtherTypeOverlays,
   mockWPReportWithOverlays,
 } from "utils/testing/mockReport";
 import {
@@ -336,9 +335,10 @@ describe("<ExportedModalOverlayReportSection />", () => {
   test("should render correct initiative topic", () => {
     mockedUseStore.mockReturnValue({
       ...mockReportStore,
-      report: mockWPReportWithOtherTypeOverlays,
+      report: mockWPReportWithOverlays,
     });
     render(testComponent(wpMockProps));
+    expect(screen.getByText("mock WP topic")).toBeInTheDocument();
     expect(screen.getByText("Unique initiative type")).toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -164,8 +164,9 @@ export function renderModalOverlayTableBody(
                   {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
                 </Heading>
                 <Text sx={sx.headingSubtitle}>
-                  {entity.initiative_wp_otherTopic ??
-                    entity.initiative_wpTopic[0].value}
+                  {entity.initiative_wp_otherTopic
+                    ? entity.initiative_wp_otherTopic
+                    : entity.initiative_wpTopic[0].value}
                 </Text>
               </Box>
             </Flex>

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -164,9 +164,8 @@ export function renderModalOverlayTableBody(
                   {`${idx + 1}. ${entity.initiative_name}` ?? "Not entered"}
                 </Heading>
                 <Text sx={sx.headingSubtitle}>
-                  {entity.initiative_wp_otherTopic
-                    ? entity.initiative_wp_otherTopic
-                    : entity.initiative_wpTopic[0].value}
+                  {entity.initiative_wp_otherTopic ||
+                    entity.initiative_wpTopic[0].value}
                 </Text>
               </Box>
             </Flex>

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -496,6 +496,18 @@ export const mockWPReportWithOverlays = {
           },
         ],
       },
+      {
+        ...mockWPFullReport.fieldData.entityType[0],
+        type: OverlayModalTypes.INITIATIVE,
+        id: "mock wip id",
+        initiative_wpTopic: [
+          {
+            key: "other-type-key",
+            value: "Other, specify",
+          },
+        ],
+        initiative_wp_otherTopic: "Unique initiative type",
+      },
     ],
   },
   formTemplate: {
@@ -516,27 +528,6 @@ export const mockWPReportWithOverlays = {
         ],
       } as ReportRoute,
       ...mockWPFullReport.formTemplate.routes.slice(3),
-    ],
-  },
-};
-
-export const mockWPReportWithOtherTypeOverlays = {
-  ...mockWPFullReport,
-  fieldData: {
-    ...mockWPFullReport.fieldData,
-    [OverlayModalTypes.INITIATIVE]: [
-      {
-        ...mockWPFullReport.fieldData.entityType[0],
-        type: OverlayModalTypes.INITIATIVE,
-        id: "mock wip id",
-        initiative_wpTopic: [
-          {
-            key: "other-type-key",
-            value: "Other, specify",
-          },
-        ],
-        initiative_wp_otherTopic: "Unique initiative type",
-      },
     ],
   },
 };


### PR DESCRIPTION
### Description
Fixes a bug where an initiative's work plan topic is not displayed on the export page.

---
### Recreating the bug
To recreate the original bug, you'll have to somehow get your report into a state where your initiative object in the fieldData includes `"initiative_wp_otherTopic": "",`. It is important to include the key and the empty string value. That's how we see that the ["fix" implemented here](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/789/files#diff-9eb44d4565acab11cf8719a06fa704a52ebafaf509478a1319abef892cc14e9fR167-R168) inadvertently introduced the bug we're seeing in prod.

### How to test the fix
1. Create a work plan and enter at least 2 initiatives on the State or Territory-Specific Initiatives page.
    - Create one initiative with an MFP work plan topic from the provided radio list
    - Create one initiative with an MFP work plan topic that is "Other, specify" and enter whatever in the text field.
2. Go to the export page.
3. The work plan topics for both of the initiatives should be displayed under the initiative name.

<img width="676" alt="Screenshot 2024-12-20 at 7 46 39 AM" src="https://github.com/user-attachments/assets/2aaa4099-2c9c-4f72-80d5-93dad2020c26" />


<img width="653" alt="Screenshot 2024-12-20 at 7 46 31 AM" src="https://github.com/user-attachments/assets/2166f6b4-173c-4cdb-b921-682a5348ba37" />

<img width="816" alt="Screenshot 2024-12-20 at 7 50 16 AM" src="https://github.com/user-attachments/assets/0321f528-7f0a-4ef2-a8d3-1b2cd57b3912" />


<img width="805" alt="Screenshot 2024-12-20 at 7 50 00 AM" src="https://github.com/user-attachments/assets/06c1911d-3ebe-4090-91cf-94988d204102" />
