### PR TITLE
Use serverless version installed by package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Before starting the project we're going to install some tools. We recommend havi
 
 - Install nvm: `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash`
 - Install specified version of node. We enforce using a specific version of node, specified in the file `.nvmrc`. This version matches the Lambda runtime. We recommend managing node versions using [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): `nvm install`, then `nvm use`
-- Install [Serverless](https://www.serverless.com/framework/docs/providers/aws/guide/installation/): `npm install -g serverless`
 - Install [yarn](https://classic.yarnpkg.com/en/docs/install/): `brew install yarn`
 - Install pre-commit on your machine with either: `pip install pre-commit` or `brew install pre-commit`
 

--- a/run
+++ b/run
@@ -31,12 +31,6 @@ if ! which yarn > /dev/null ; then
 	exit 1
 fi
 
-# check serverless is installed globally.
-if ! which serverless > /dev/null ; then
-	echo "installing serverless globally"
-	yarn global add serverless@4.4.18
-fi
-
 # have to ensure that yarn install is up to date.
 # we use .yarn_install as a marker for the last time `yarn install` was run. Rerun the command when yarn.lock is updated
 if [ "yarn.lock" -nt ".yarn_install" ]; then

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,6 +3,7 @@ import * as dotenv from "dotenv";
 import LabeledProcessRunner from "./runner.js";
 import { ServerlessStageDestroyer } from "@stratiformdigital/serverless-stage-destroyer";
 import { execSync } from "child_process";
+import path from "path";
 
 // load .env
 dotenv.config();
@@ -16,6 +17,12 @@ const deployedServices = [
   "ui-auth",
   "ui-src",
 ];
+
+const serverlessBin = path.join(
+  process.cwd(),
+  "node_modules/.bin",
+  "serverless"
+);
 
 // Function to update .env files using 1Password CLI
 function updateEnvFiles() {
@@ -45,13 +52,13 @@ async function run_db_locally(runner: LabeledProcessRunner) {
   );
   await runner.run_command_and_output(
     "db svls",
-    ["serverless", "dynamodb", "install", "--stage", "local"],
+    [serverlessBin, "dynamodb", "install", "--stage", "local"],
     "services/database"
   );
   runner.run_command_and_output(
     "db",
     [
-      "serverless",
+      serverlessBin,
       "offline",
       "start",
       "--stage",
@@ -73,7 +80,7 @@ async function run_api_locally(runner: LabeledProcessRunner) {
   runner.run_command_and_output(
     "api",
     [
-      "serverless",
+      serverlessBin,
       "offline",
       "start",
       "--stage",
@@ -96,7 +103,7 @@ async function run_s3_locally(runner: LabeledProcessRunner) {
   );
   runner.run_command_and_output(
     "s3",
-    ["serverless", "s3", "start", "--stage", "local"],
+    [serverlessBin, "s3", "start", "--stage", "local"],
     "services/uploads"
   );
 }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Our apps are set up to use a global version of `serverless`. Since there can only be one version of a package installed globally, it's causing apps to fail if they're not on the same version. Particularly with `serverless`, there doesn't seem to be a reason to use a global version when the apps install a version of `serverless` locally. This PR:

- Updates `./run local` to use the local `serverless` binary
- Removes global installation of `serverless`

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run `./run local` or `./run local --update-env` if you haven't updated your `.env` recently
2. App should boot normally

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
