### PR TITLE
Fix how tableBody is returned

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -52,6 +52,9 @@ describe("<DashboardTable />", () => {
     const stateBody = {
       headRow: ["row1", "Due date", "Target populations"],
     };
+    const noHeadRow = {
+      caption: "Test",
+    };
 
     test("should remove Due date and Target populations rows for admin", () => {
       expect(tableBody(all, true)).toEqual(adminBody);
@@ -59,6 +62,10 @@ describe("<DashboardTable />", () => {
 
     test("should remove # row for non-admin", () => {
       expect(tableBody(all, false)).toEqual(stateBody);
+    });
+
+    test("should return original body if no headRow key", () => {
+      expect(tableBody(noHeadRow, false)).toEqual(noHeadRow);
     });
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -1,5 +1,5 @@
 import { ReportType } from "types";
-import { getStatus } from "./DashboardTable";
+import { getStatus, tableBody } from "./DashboardTable";
 
 describe("<DashboardTable />", () => {
   describe("getStatus()", () => {
@@ -39,6 +39,26 @@ describe("<DashboardTable />", () => {
       expect(getStatus(ReportType.SAR, "Not started", false, 1)).toBe(
         "Not started"
       );
+    });
+  });
+
+  describe("tableBody()", () => {
+    const all = {
+      headRow: ["row1", "Due date", "Target populations", "#"],
+    };
+    const adminBody = {
+      headRow: ["row1", "#"],
+    };
+    const stateBody = {
+      headRow: ["row1", "Due date", "Target populations"],
+    };
+
+    test("should remove Due date and Target populations rows for admin", () => {
+      expect(tableBody(all, true)).toEqual(adminBody);
+    });
+
+    test("should remove # row for non-admin", () => {
+      expect(tableBody(all, false)).toEqual(stateBody);
     });
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -167,7 +167,7 @@ export const getStatus = (
   return status;
 };
 
-const tableBody = (body: TableContentShape, isAdmin: boolean) => {
+export const tableBody = (body: TableContentShape, isAdmin: boolean) => {
   const tableContent = { ...body };
 
   if (!tableContent.headRow) {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -166,17 +166,23 @@ export const getStatus = (
   }
   return status;
 };
+
 const tableBody = (body: TableContentShape, isAdmin: boolean) => {
-  var tableContent = body;
-  if (!isAdmin) {
-    tableContent.headRow = tableContent.headRow!.filter((e) => e !== "#");
-    return tableContent;
-  } else {
-    tableContent.headRow = tableContent.headRow!.filter(
-      (e) => e !== "Due date" && e !== "Target populations"
-    );
+  const tableContent = { ...body };
+
+  if (!tableContent.headRow) {
+    return body;
   }
-  return body;
+
+  if (isAdmin) {
+    tableContent.headRow = tableContent.headRow.filter(
+      (e) => !["Due date", "Target populations"].includes(e)
+    );
+  } else {
+    tableContent.headRow = tableContent.headRow.filter((e) => e !== "#");
+  }
+
+  return tableContent;
 };
 
 const EditReportButton = ({


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
While testing https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/861, I came across a bug with how we filter out table headers, leaving out `Due date` if switching between admin and state users.

Steps to reproduce:
1. Run mfp on the `main` branch
2. Create a submitted or approved work plan with `yarn db:seed`
3. Log in as state user and view dashboard
4. See table headers are `Submission name`, `Due date`, `Last edited`, `Edited by`, and `Status`
5. Log out and log in as admin user
6. View work plans for Puerto Rico
7.  See table headers are `Submission name`, `Last edited`, `Edited by`,`Status`, and `#`
8. Log out and log in as state user
9. See table headers are `Submission name`, `Last edited`, `Edited by`, and `Status`

<img width="1011" alt="Screenshot 2025-01-29 at 10 04 47 AM" src="https://github.com/user-attachments/assets/b8ab3fbc-187e-474e-95f8-dd84e5e1ecbb" />

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run mfp locally
2. Create a submitted or approved work plan with `yarn db:seed`
3. Log in as state user and view dashboard
4. Verify table headers are `Submission name`, `Due date`, `Last edited`, `Edited by`, and `Status`
5. Log out and log in as admin user
6. View work plans for Puerto Rico
7.  Verify table headers are `Submission name`, `Last edited`, `Edited by`,`Status`, and `#`
8. Log out and log in as state user
9. Verify table headers are `Submission name`, `Due date`, `Last edited`, `Edited by`, and `Status`
10. Unit tests pass

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

This is probably only an issue for testers who switch between user roles, but nevertheless is confusing to encounter. Reloading the page also fixes the issue. Switching between users without reloading causes the bug.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
