### PR TITLE
Update seed banners

### DIFF
--- a/services/app-api/db/helpers.ts
+++ b/services/app-api/db/helpers.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-console */
 export const createdLog = (obj: any, action: string, type: string): void => {
-  const { id, submissionName } = obj;
-  if (id) {
-    console.log(`${action} ${type} created: ${submissionName} (${id})`);
+  const { id, key, submissionName, title } = obj;
+  if (id || key) {
+    console.log(
+      `${action} ${type} created: ${submissionName || title} (${id || key})`
+    );
   } else {
     console.log(`ℹ️ ${obj}`);
     console.log(

--- a/services/app-api/db/seed.ts
+++ b/services/app-api/db/seed.ts
@@ -9,7 +9,6 @@ import {
 } from "./options";
 import { currentYear } from "../../../tests/seeds/helpers";
 import {
-  bannerKey,
   createApprovedWorkPlan,
   createArchivedSemiAnnualReport,
   createArchivedWorkPlan,
@@ -22,8 +21,8 @@ import {
   createSubmittedSemiAnnualReport,
   createSubmittedWorkPlan,
   createWorkPlan,
-  deleteBannerById,
-  getBannerById,
+  deleteBanners,
+  getBanners,
   getSemiAnnualReportById,
   getSemiAnnualReportsByState,
   getWorkPlanById,
@@ -42,7 +41,7 @@ const seed = async (
   const entityChoices: Choice[] = [
     { title: "Work Plan (WP)", value: "WP" },
     { title: "Semi-Annual Report (SAR)", value: "SAR" },
-    { title: "Banner", value: "banner" },
+    { title: "Banners", value: "banners" },
   ];
 
   let reportYear = chosenYear || currentYear;
@@ -108,18 +107,26 @@ const seed = async (
       },
     },
     {
-      type: (prev: string) => (prev === "banner" ? "select" : null),
+      type: (prev: string) => (prev === "banners" ? "select" : null),
       name: "bannerTask",
       message: "Task",
       choices: [
         {
-          title: `Create Banner: ${bannerKey}`,
-          value: "createBanner",
+          title: "Create Active Banner",
+          value: "createBannerActive",
         },
-        { title: `Get Banner: ${bannerKey}`, value: "getBanner" },
         {
-          title: `Delete Banner: ${bannerKey}`,
-          value: "deleteBanner",
+          title: "Create Inactive Banner",
+          value: "createBannerInactive",
+        },
+        {
+          title: "Create Scheduled Banner",
+          value: "createBannerScheduled",
+        },
+        { title: "Get Banners", value: "getBanners" },
+        {
+          title: "Delete Banners",
+          value: "deleteBanners",
         },
         backToMenu,
       ],
@@ -282,17 +289,24 @@ const seed = async (
       case "getSARsByState":
         expandedLog(await getSemiAnnualReportsByState());
         break;
-      case "createBanner": {
-        await createBanner();
-        console.log("Banner created.");
+      case "createBannerActive": {
+        createdLog(await createBanner("active"), "Active", "Banner");
         break;
       }
-      case "getBanner":
-        expandedLog(await getBannerById());
+      case "createBannerInactive": {
+        createdLog(await createBanner("inactive"), "Inactive", "Banner");
         break;
-      case "deleteBanner": {
-        await deleteBannerById();
-        console.log("Banner deleted.");
+      }
+      case "createBannerScheduled": {
+        createdLog(await createBanner("scheduled"), "Scheduled", "Banner");
+        break;
+      }
+      case "getBanners":
+        expandedLog(await getBanners());
+        break;
+      case "deleteBanners": {
+        await deleteBanners();
+        console.log("Banners deleted.");
         break;
       }
       default:

--- a/tests/seeds/fixtures/banner.ts
+++ b/tests/seeds/fixtures/banner.ts
@@ -1,12 +1,36 @@
+import crypto from "crypto";
 import { faker } from "@faker-js/faker";
 import { SeedBannerShape } from "../types";
 
-export const newBanner = (key: string): SeedBannerShape => ({
-  key,
-  createdAt: faker.date.past({ years: 1 }).getTime(),
-  lastAltered: faker.date.past({ years: 1 }).getTime(),
-  title: faker.lorem.sentence(),
+function getTime(count: number = 0) {
+  const today = new Date();
+  const newDate = new Date(today);
+  newDate.setDate(today.getDate() + count);
+  return newDate.getTime();
+}
+
+const activeStart = 0;
+const inactiveStart = -2;
+const scheduledStart = 2;
+
+function getStartDate(status: string) {
+  if (status === "inactive") return getTime(inactiveStart);
+  if (status === "scheduled") return getTime(scheduledStart);
+  return getTime(activeStart);
+}
+
+function getEndDate(status: string) {
+  if (status === "inactive") return getTime(inactiveStart + 1);
+  if (status === "scheduled") return getTime(scheduledStart + 1);
+  return getTime(activeStart + 1);
+}
+
+export const newBanner = (status: string): SeedBannerShape => ({
+  key: crypto.randomUUID(),
+  createdAt: getStartDate(status),
+  lastAltered: getStartDate(status),
+  title: faker.commerce.productName(),
   description: faker.lorem.sentence(),
-  startDate: faker.date.past({ years: 1 }).getTime(),
-  endDate: faker.date.future({ years: 1 }).getTime(),
+  startDate: getStartDate(status),
+  endDate: getEndDate(status),
 });

--- a/tests/seeds/options.ts
+++ b/tests/seeds/options.ts
@@ -318,26 +318,22 @@ export const getSemiAnnualReportsByState = async (): Promise<
 };
 
 // Banner
-export const bannerKey: string = "admin-banner-id";
-
-export const createBanner = async (): Promise<SeedBannerShape> => {
-  const banner = await postApi(
-    `/banners/${bannerKey}`,
-    adminHeaders,
-    newBanner(bannerKey)
-  );
+export const createBanner = async (
+  status: string
+): Promise<SeedBannerShape> => {
+  const banner = await postApi(`/banners`, adminHeaders, newBanner(status));
   return banner;
 };
 
-export const getBannerById = async (): Promise<SeedBannerShape> => {
-  try {
-    const banner = await getApi(`/banners/${bannerKey}`, adminHeaders);
-    return banner;
-  } catch {
-    return {} as SeedBannerShape;
-  }
+export const getBanners = async (): Promise<SeedBannerShape[]> => {
+  const banners = await getApi(`/banners`, adminHeaders);
+  return banners;
 };
 
-export const deleteBannerById = async (): Promise<void> => {
-  await deleteApi(`/banners/${bannerKey}`, adminHeaders);
+export const deleteBanners = async (): Promise<void> => {
+  const banners = await getBanners();
+
+  banners.map(async (banner: SeedBannerShape) => {
+    await deleteApi(`/banners/${banner.key}`, adminHeaders);
+  });
 };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Following https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/897, `yarn db:seed` needs to be updated. The script now can:
- Create active banner
- Create inactive banner
- Create scheduled banner
- Delete all banners

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Start MFP
2. In a separate terminal window, run `yarn db:seed`
3. Verify options under `Banners` work

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
