### PR TITLE
a11y: allow leave form button to be keyboard accessible

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -71,7 +71,6 @@ export const Header = () => {
                   to={report?.formTemplate.basePath || "/"}
                   sx={sx.leaveFormLink}
                   variant="outlineButton"
-                  tabIndex={-1}
                 >
                   {!isMobile ? (
                     <>Leave form</>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Remove tabindex such that "Leave form" link is accessible with keyboard

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4439

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Deployed env](https://d3cnu2h6tr215l.cloudfront.net/)
- Create and open any report
- Tab through the page and verify you can access the "Leave form" button
- Verify you can activate the button by hitting the return key
- Verify it returns you to the dashboard

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment