### PR TITLE
remove serverless destroy commands

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -61,11 +61,7 @@ jobs:
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
       - name: Destroy
-        # destroy app-api first due to a dependency between it and database
-        run: |
-          ./run destroy --stage $branch_name --verify false --service app-api
-          ./run destroy --stage $branch_name --verify false
-          serverless reconcile
+        run: ./run destroy --stage $branch_name --verify false
 
   # Notify the integrations channel when a destroy action fails
   notify_on_destroy_failure:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
We had some lingering serverless specific commands in our destroy workflow

Now this section of the workflow matches what we see in [HCBS](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/blob/main/.github/workflows/destroy.yml#L64)