### PR TITLE
Generate a .env.seed with API_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build_dev
 tsconfig.tsbuildinfo
 services/uploads/local_buckets
 /.env
+/.env.seed
 tests_output
 *.log
 !launchdarkly-flags.log

--- a/src/run.ts
+++ b/src/run.ts
@@ -12,6 +12,7 @@ import {
 } from "@aws-sdk/client-cloudformation";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 import { writeLocalUiEnvFile } from "./write-ui-env-file.js";
+import { writeSeedEnvFile } from "./write-seed-env-file.js";
 
 // load .env
 dotenv.config();
@@ -88,6 +89,7 @@ async function run_fe_locally(runner: LabeledProcessRunner) {
     "ApiUrl"
   );
   await writeLocalUiEnvFile(apiUrl!);
+  await writeSeedEnvFile(apiUrl!);
   runner.run_command_and_output("ui", ["npm", "start"], "services/ui-src");
 }
 

--- a/src/write-seed-env-file.ts
+++ b/src/write-seed-env-file.ts
@@ -1,0 +1,18 @@
+import path, { dirname } from "path";
+import { promises as fs } from "fs";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const outputPath = path.join(__dirname, "../../");
+const configFilePath = path.resolve(outputPath, ".env.seed");
+
+export async function writeSeedEnvFile(apiUrl: string) {
+  await fs.rm(configFilePath, { force: true });
+
+  const envConfigContent = [`API_URL=${apiUrl.replace("https", "http")}`].join(
+    "\n"
+  );
+
+  await fs.writeFile(configFilePath, envConfigContent);
+}

--- a/tests/seeds/helpers.ts
+++ b/tests/seeds/helpers.ts
@@ -10,6 +10,7 @@ import { ReportFieldData } from "../../services/app-api/utils/types";
 import { AwsHeaders } from "./types";
 
 dotenv.config({ path: "../../.env" });
+dotenv.config({ path: "../../.env.seed" });
 
 const apiUrl: string | undefined = process.env.API_URL;
 const clientId: string | undefined = process.env.COGNITO_USER_POOL_CLIENT_ID;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
With the CDK conversion, `API_URL` is now dynamically generated, so the key was removed from `.env`. The `yarn db:seed` script was using that key, so we need a another way to pass that value to the script. This PR creates a `.env.seed` file when you run MFP locally.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MFP locally
2. Open another terminal window and run `yarn db:seed`
3. All seed commands should work

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
