### PR TITLE
Skip completion status checks for closed initiative

### DIFF
--- a/services/app-api/utils/validation/completionStatus.test.ts
+++ b/services/app-api/utils/validation/completionStatus.test.ts
@@ -839,8 +839,6 @@ describe("Completion Status Tests", () => {
           {
             ...route,
             entitySteps: [
-              { stepType: "overlayModal" },
-              { stepType: "closeOutInformation" },
               {
                 stepType: "other",
                 objectiveCards,

--- a/services/app-api/utils/validation/completionStatus.test.ts
+++ b/services/app-api/utils/validation/completionStatus.test.ts
@@ -756,4 +756,231 @@ describe("Completion Status Tests", () => {
       "/wp/transition-benchmarks": false,
     });
   });
+
+  describe("completion status for initiatives", () => {
+    const completedInitiatives = (val: number | string) => [
+      {
+        id: "mockInitiative1",
+        other: [
+          {
+            id: "mockInitiative1_other",
+            mockFieldId1: val,
+          },
+        ],
+      },
+      {
+        id: "mockInitiative2",
+        other: [
+          {
+            id: "mockInitiative2_other",
+            mockFieldId2: val,
+          },
+        ],
+      },
+    ];
+
+    const objectiveCards = [
+      {
+        modalForm: {
+          fields: [
+            {
+              id: "mockFieldId1",
+              validation: "number",
+            },
+          ],
+          objectiveId: "mockInitiative1_other",
+        },
+      },
+      {
+        modalForm: {
+          fields: [
+            {
+              id: "mockFieldId2",
+              validation: "number",
+            },
+          ],
+          objectiveId: "mockInitiative2_other",
+        },
+      },
+    ];
+
+    const route = {
+      entitySteps: [],
+      entityType: "initiative",
+      modalForm: { fields: [] },
+      name: "Mock Initiatives",
+      pageType: "modalOverlay",
+      path: "/mock-initiatives",
+    };
+
+    const validationJson = {
+      mockFieldId1: "number",
+      mockFieldId2: "number",
+    };
+
+    test("no initiatives return false status", async () => {
+      const testData = {};
+      const formTemplate = {
+        routes: [{ ...route }],
+      };
+      const result = await calculateCompletionStatus(testData, formTemplate);
+
+      expect(result).toStrictEqual({
+        "/mock-initiatives": false,
+      });
+    });
+
+    test("completed initiatives return true status", async () => {
+      const testData = {
+        initiative: [...completedInitiatives(1)],
+      };
+      const formTemplate = {
+        routes: [
+          {
+            ...route,
+            entitySteps: [
+              { stepType: "overlayModal" },
+              { stepType: "closeOutInformation" },
+              {
+                stepType: "other",
+                objectiveCards,
+              },
+            ],
+          },
+        ],
+        validationJson,
+      };
+      const result = await calculateCompletionStatus(testData, formTemplate);
+
+      expect(result).toStrictEqual({
+        "/mock-initiatives": true,
+      });
+    });
+
+    test("incomplete initiatives return false status", async () => {
+      const testData = {
+        initiative: [...completedInitiatives("")],
+      };
+      const formTemplate = {
+        routes: [
+          {
+            ...route,
+            entitySteps: [
+              { stepType: "overlayModal" },
+              { stepType: "closeOutInformation" },
+              {
+                stepType: "other",
+                objectiveCards,
+              },
+            ],
+          },
+        ],
+        validationJson,
+      };
+      const result = await calculateCompletionStatus(testData, formTemplate);
+
+      expect(result).toStrictEqual({
+        "/mock-initiatives": false,
+      });
+    });
+
+    test("completed and closed initiatives return true status", async () => {
+      const testData = {
+        initiative: [
+          ...completedInitiatives(1),
+          {
+            id: "mockInitiativeClosed",
+            isInitiativeClosed: true,
+            other: [
+              {
+                id: "mockInitiativeClosed_other",
+                mockFieldIdClosed: "",
+              },
+            ],
+          },
+        ],
+      };
+      const formTemplate = {
+        routes: [
+          {
+            ...route,
+            entitySteps: [
+              {
+                stepType: "other",
+                objectiveCards: [
+                  ...objectiveCards,
+                  {
+                    modalForm: {
+                      fields: [
+                        {
+                          id: "mockFieldIdClosed",
+                          validation: "number",
+                        },
+                      ],
+                      objectiveId: "mockInitiativeClosed_other",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        validationJson: {
+          ...validationJson,
+          mockFieldIdClosed: "number",
+        },
+      };
+      const result = await calculateCompletionStatus(testData, formTemplate);
+
+      expect(result).toStrictEqual({
+        "/mock-initiatives": true,
+      });
+    });
+
+    test("SAR uses initiativeId", async () => {
+      const testData = {
+        initiative: [...completedInitiatives(1)],
+      };
+      const formTemplate = {
+        type: "SAR",
+        routes: [
+          {
+            ...route,
+            entitySteps: [
+              {
+                stepType: "other",
+                form: {
+                  fields: [
+                    {
+                      id: "mockFieldId1",
+                      validation: "number",
+                    },
+                  ],
+                  initiativeId: "mockInitiative1_other",
+                },
+              },
+              {
+                stepType: "other",
+                modalForm: {
+                  fields: [
+                    {
+                      id: "mockFieldId2",
+                      validation: "number",
+                    },
+                  ],
+                  initiativeId: "mockInitiative2_other",
+                },
+              },
+            ],
+          },
+        ],
+        validationJson,
+      };
+      const result = await calculateCompletionStatus(testData, formTemplate);
+
+      expect(result).toStrictEqual({
+        "/mock-initiatives": true,
+      });
+    });
+  });
 });

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -203,9 +203,11 @@ export const calculateCompletionStatus = async (
               for (const card of stepForm.objectiveCards) {
                 if (card?.modalForm) {
                   const nestedFormTemplate = card.modalForm;
+
                   if (nestedFormTemplate?.objectiveId !== stepFields?.id) {
                     continue;
                   }
+
                   const isEntityComplete = await calculateFormCompletion(
                     nestedFormTemplate,
                     stepFields

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -174,34 +174,35 @@ export const calculateCompletionStatus = async (
     stepFormTemplates: any[],
     entityType: string
   ) => {
-    if (!fieldData[entityType] || fieldData[entityType].length <= 0)
-      return false;
+    const entityData = fieldData[entityType];
+    if (!entityData || entityData.length === 0) return false;
 
-    var areAllFormsComplete = true;
-    for (let i = 0; i < stepFormTemplates.length; i++) {
-      let stepForm = stepFormTemplates[i];
-      for (var entityFields of fieldData[entityType]) {
+    let areAllFormsComplete = true;
+    for (const stepForm of stepFormTemplates) {
+      for (const entityFields of entityData) {
+        // if initiative is closed, skip checking other values
+        if (entityFields?.isInitiativeClosed) continue;
+
+        const stepData = entityFields[stepForm.stepType];
+
         //modal overlay pages should have an array of key stepType in fieldData, automatic false if it doesn't exist or array is empty
         if (
           stepForm.pageType === "overlayModal" &&
-          (!entityFields[stepForm.stepType] ||
-            entityFields[stepForm.stepType].length <= 0)
+          (!stepData || stepData.length === 0)
         ) {
           areAllFormsComplete &&= false;
         } else if (stepForm.stepType === "closeOutInformation") {
-          //skip over closeOut at the moment until we can make WP copies
+          // TODO: skip over closeOut at the moment until we can make WP copies
         } else {
-          //detemine which fieldData to match to the stepForm
-          const entityFieldsList = entityFields[stepForm.stepType]
-            ? entityFields[stepForm.stepType]
-            : [entityFields];
+          //determine which fieldData to match to the stepForm
+          const entityFieldsList = stepData ?? [entityFields];
+
           //loop through all children that belong to that entity and validate the values
-          for (var stepFields of entityFieldsList) {
+          for (const stepFields of entityFieldsList) {
             if (stepForm?.objectiveCards) {
-              for (let card of stepForm.objectiveCards) {
+              for (const card of stepForm.objectiveCards) {
                 if (card?.modalForm) {
                   const nestedFormTemplate = card.modalForm;
-
                   if (nestedFormTemplate?.objectiveId !== stepFields?.id) {
                     continue;
                   }
@@ -213,9 +214,7 @@ export const calculateCompletionStatus = async (
                 }
               }
             } else {
-              const nestedFormTemplate = stepForm.form
-                ? stepForm.form
-                : stepForm.modalForm;
+              const nestedFormTemplate = stepForm.form ?? stepForm.modalForm;
 
               //WP uses modaloverlay so it doesn't have an initiativeId, only SAR does
               if (

--- a/services/app-api/utils/validation/completionStatus.ts
+++ b/services/app-api/utils/validation/completionStatus.ts
@@ -207,7 +207,6 @@ export const calculateCompletionStatus = async (
                   if (nestedFormTemplate?.objectiveId !== stepFields?.id) {
                     continue;
                   }
-
                   const isEntityComplete = await calculateFormCompletion(
                     nestedFormTemplate,
                     stepFields


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
If a user copies a work plan and closes out an initiative without filling out required info, the user can't submit the work plan, but they can't go back and fill in the missing info either. This PR changes the `completionStatus` check to skip checking the required info for a closed initiative.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MFP locally
2. Create a work plan, submit and approve it
3. Copy the work plan by selecting "Continue MFP Work Plan for next Period"
4. Close out an initiative without filling in missing info
5. Create another initiative for the one you're closing out
6. Fill in missing info for the other copied-over initiatives
7. Form should be submittable

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
PR https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/917 fixes `yarn db:seed` which will make testing this PR easier.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
