### PR TITLE
pin gitleaks version to prevent config errors

### DIFF
--- a/.github/workflows/scan_secrets.yaml
+++ b/.github/workflows/scan_secrets.yaml
@@ -6,6 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run gitleaks docker
-        uses: docker://zricethezav/gitleaks
+        uses: docker://zricethezav/gitleaks:v8.24.3
         with:
           args: detect --source /github/workspace/ --no-git --verbose


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The latest version of gitleaks is failing in our checks. There was a [change to the allowlist](https://github.com/gitleaks/gitleaks/pull/1777) settings that is causing ours to fail. 

In the future we can look into this more, or perhaps move back to latest when it's fixed. For now lets make sure these pass and not get used to ignoring them.

Docs:
[gitleaks changelog](https://github.com/gitleaks/gitleaks/releases)
[DockerHub gitleaks tag list](https://hub.docker.com/r/zricethezav/gitleaks/tags)


---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Verify gitleaks [passed](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/14756637587/job/41426476569) with the locked version `v8.24.3`
- Verify gitleaks [failed](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/actions/runs/14734940791/job/41358712033) with implicit latest on main