### PR TITLE
Update kafka sync script

### DIFF
--- a/services/database/scripts/fix-reopen-initiative.js
+++ b/services/database/scripts/fix-reopen-initiative.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 /*
  * Local:
- *    DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/fix-closed-initiative.js {{reportId}}
+ *   DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/fix-closed-initiative.js {{reportId}}
  * Branch:
- *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/fix-reopen-initiative.js {{reportId}}
+ *   branchPrefix="YOUR BRANCH NAME" node services/database/scripts/fix-reopen-initiative.js {{reportId}}
  */
 
 const { buildDynamoClient, scan } = require("./utils/dynamodb.js");

--- a/services/database/scripts/sync-kafka-2024.js
+++ b/services/database/scripts/sync-kafka-2024.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 /*
  * Local:
- *    DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/sync-kafka-2024.js
+ *   DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/sync-kafka-2024.js
  * Branch:
- *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/sync-kafka-2024.js
+ *   branchPrefix="YOUR BRANCH NAME" node services/database/scripts/sync-kafka-2024.js
  */
 
 const { buildDynamoClient, scan, update } = require("./utils/dynamodb.js");

--- a/services/database/scripts/sync-kafka-2024.js
+++ b/services/database/scripts/sync-kafka-2024.js
@@ -1,33 +1,23 @@
 /* eslint-disable no-console */
 /*
  * Local:
- *    `DYNAMODB_URL="http://localhost:8000" S3_LOCAL_ENDPOINT="http://localhost:4569" node services/database/scripts/sync-kafka-2024.js`
- *  Branch:
+ *    DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/sync-kafka-2024.js
+ * Branch:
  *    branchPrefix="YOUR BRANCH NAME" node services/database/scripts/sync-kafka-2024.js
- *
- * THE LOCAL OPTION IS NOW MORE COMPLICATED IT YOU NEED TO RUN THIS SCRIPT IN A LOCAL CONTEXT HERE'S A SPOT TO LOOK FOR SUGGESTIONS:
- * https://stackoverflow.com/questions/73294767/how-do-i-execute-a-shell-script-against-my-localstack-docker-container-after-it
  */
 
 const { buildDynamoClient, scan, update } = require("./utils/dynamodb.js");
 const { buildS3Client, list, putObjectTag } = require("./utils/s3.js");
 
 const isLocal = !!process.env.DYNAMODB_URL;
+const branch = isLocal ? "localstack" : process.env.branchPrefix;
 
-const wpTableName = isLocal
-  ? "local-wp-reports"
-  : process.env.branchPrefix + "-wp-reports";
-const sarTableName = isLocal
-  ? "local-sar-reports"
-  : process.env.branchPrefix + "-sar-reports";
+const wpTableName = `${branch}-wp-reports`;
+const sarTableName = `${branch}-sar-reports`;
 const tables = [wpTableName, sarTableName];
 
-const wpBucketName = isLocal
-  ? "local-wp-form"
-  : "database-" + process.env.branchPrefix + "-wp";
-const sarBucketName = isLocal
-  ? "local-sar-form"
-  : "database-" + process.env.branchPrefix + "-sar";
+const wpBucketName = `database-${branch}-wp`;
+const sarBucketName = `database-${branch}-sar`;
 const buckets = [wpBucketName, sarBucketName];
 
 // Maintaining consistency with the `lastAltered` field in the DB


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update the local table and S3 bucket locations in the `sync-kafka-2024.js` script. Update URLs in comment.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Run MFP locally
2. In a different window, run `DYNAMODB_URL="http://localhost:4566" S3_LOCAL_ENDPOINT="http://localhost:4566" node services/database/scripts/sync-kafka-2024.js`
3. There should be no errors

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

Scripts in other repos after CDK migration would need similar updates.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

<!-- --- -->
<!-- ### Pre-merge checklist -->
<!-- Complete the following steps before merging -->

<!-- #### Review -->
<!-- - [ ] Design: This work has been reviewed and approved by design, if necessary -->
<!-- - [ ] Product: This work has been reviewed and approved by product owner, if necessary -->

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_ -->
