### PR TITLE
CMDCT-4622 gets cloudfront logging to stop breaking destroys for ephemeral apps

### DIFF
--- a/deployment/stacks/data.ts
+++ b/deployment/stacks/data.ts
@@ -1,5 +1,10 @@
 import { Construct } from "constructs";
-import { aws_dynamodb as dynamodb, aws_s3 as s3, Aws } from "aws-cdk-lib";
+import {
+  aws_dynamodb as dynamodb,
+  aws_s3 as s3,
+  Aws,
+  RemovalPolicy,
+} from "aws-cdk-lib";
 import { DynamoDBTable } from "../constructs/dynamodb-table";
 
 interface CreateDataComponentsProps {
@@ -59,21 +64,25 @@ export function createDataComponents(props: CreateDataComponentsProps) {
   const sarFormBucket = new s3.Bucket(scope, "SarFormBucket", {
     bucketName: `database-${stage}-sar`,
     encryption: s3.BucketEncryption.S3_MANAGED,
-    versioned: true,
     blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     serverAccessLogsBucket: loggingBucket,
     serverAccessLogsPrefix: `AWSLogs/${Aws.ACCOUNT_ID}/s3/`,
+    versioned: true,
     enforceSSL: true,
+    removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+    autoDeleteObjects: isDev,
   });
 
   const wpFormBucket = new s3.Bucket(scope, "WpFormBucket", {
     bucketName: `database-${stage}-wp`,
     encryption: s3.BucketEncryption.S3_MANAGED,
-    versioned: true,
     blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     serverAccessLogsBucket: loggingBucket,
     serverAccessLogsPrefix: `AWSLogs/${Aws.ACCOUNT_ID}/s3/`,
+    versioned: true,
     enforceSSL: true,
+    removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+    autoDeleteObjects: isDev,
   });
 
   return { tables, sarFormBucket, wpFormBucket };

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -142,7 +142,8 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const userPoolDomain = new cognito.UserPoolDomain(scope, "UserPoolDomain", {
     userPool,
     cognitoDomain: {
-      domainPrefix: userPoolDomainPrefix ?? `${stage}-login-user-pool-client`,
+      domainPrefix:
+        userPoolDomainPrefix ?? `${project}-${stage}-login-user-pool-client`,
     },
   });
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -55,26 +55,38 @@ export function createUiComponents(props: CreateUiComponentsProps) {
     serverAccessLogsPrefix: `AWSLogs/${Aws.ACCOUNT_ID}/s3/`,
   });
 
-  const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
-    bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
-    encryption: s3.BucketEncryption.S3_MANAGED,
-    publicReadAccess: false,
-    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-    objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-    removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
-    autoDeleteObjects: isDev,
-    enforceSSL: true,
-    versioned: true,
-  });
+  let loggingConfig:
+    | { enableLogging: boolean; logBucket: s3.Bucket; logFilePrefix: string }
+    | undefined;
+  if (!isDev) {
+    // this bucket is not created for ephemeral environments because the delete of the bucket often fails because it doesn't decouple from the distribution gracefully
+    // should you need to test these parts of the infrastructure out the easiest method is to add your branch's name to the isDev definition in deployment-config.ts
+    const logBucket = new s3.Bucket(scope, "CloudfrontLogBucket", {
+      bucketName: `ui-${stage}-cloudfront-logs-${Aws.ACCOUNT_ID}`,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      enforceSSL: true,
+      versioned: true,
+    });
 
-  logBucket.addToResourcePolicy(
-    new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
-      actions: ["s3:PutObject"],
-      resources: [`${logBucket.bucketArn}/*`],
-    })
-  );
+    logBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
+        actions: ["s3:PutObject"],
+        resources: [`${logBucket.bucketArn}/*`],
+      })
+    );
+
+    loggingConfig = {
+      enableLogging: true,
+      logBucket,
+      logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
+    };
+  }
 
   const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
     scope,
@@ -136,9 +148,7 @@ export function createUiComponents(props: CreateUiComponentsProps) {
         responseHeadersPolicy: securityHeadersPolicy,
       },
       defaultRootObject: "index.html",
-      enableLogging: true,
-      logBucket,
-      logFilePrefix: `AWSLogs/CLOUDFRONT/${stage}/`,
+      ...loggingConfig,
       httpVersion: cloudfront.HttpVersion.HTTP2,
       errorResponses: [
         {


### PR DESCRIPTION
### Description
This change will mean that we no longer have issues destroying branches which destroys the stack.


### Related ticket(s)
CMDCT-4622

---
### How to test
The app still works the same.

### Notes
NA

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
