### PR TITLE
Make header unsticky at small screen size/high zoom

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -96,6 +96,9 @@ const sx = {
     "@media print": {
       display: "none",
     },
+    ".tablet &, .mobile &": {
+      position: "static",
+    },
   },
   headerBar: {
     minHeight: "4rem",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Make app header position static at high zoom/small screen size

Note: we have already done this same change for the Export view header https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/885

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4447

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://dr8d3x35p1bqo.cloudfront.net/)
- Log in as any user
- Click around few different pages and:
  - Zoom in past 200% and verify the header becomes fixed to the top
  - Shrink screen size to mobile or tablet at normal zoom and verify header becomes fixed to the top

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Sidebar still sticks to its position lower on the page. Do we want to change this? The problem I foresee would be that it could end up behind the header if we make its positioning dynamic (if it's set to the top at tablet and mobile but you are at the top of the page it would be behind or in front of the header)

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment