### PR TITLE
Remove isCopyOverTest feature flag

### DIFF
--- a/logs/launchdarkly-flags.log
+++ b/logs/launchdarkly-flags.log
@@ -2,7 +2,6 @@
 
 # LaunchDarkly flags in components
 ./services/ui-src/src/components/export/ExportedReportBanner.tsx:28:useFlags()?.printExperience;
-./services/ui-src/src/components/modals/CreateWorkPlanModal.tsx:62:useFlags()?.isCopyOverTest;
 ./services/ui-src/src/components/pages/Export/ExportedReportPage.tsx:162:useFlags()?.translateReport;
 ./services/ui-src/src/components/pages/Export/ExportedReportPage.tsx:89:useFlags()?.translateReport;
 

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -192,13 +192,6 @@ describe("Test createReport API method", () => {
     expect(res.statusCode).toBe(StatusCodes.BadRequest);
   });
 
-  test("Test report creation throws a 400 when copying a report of the same period", async () => {
-    jest.useFakeTimers().setSystemTime(new Date(2021, 11, 1));
-    const res = await createReport(wpCopyCreationEvent, null);
-    expect(consoleSpy.debug).toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BadRequest);
-  });
-
   test("Test successful run of work plan report creation, not copied", async () => {
     (queryReportMetadatasForState as jest.Mock).mockResolvedValue([
       { reportYear: 2020, reportPeriod: 1, archived: true },

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -9,11 +9,7 @@ import {
 } from "../../utils/validation/validation";
 import { metadataValidationSchema } from "../../utils/validation/schemas";
 import { error, reportNames } from "../../utils/constants/constants";
-import {
-  calculateDueDate,
-  calculatePeriod,
-  calculateCurrentYear,
-} from "../../utils/time/time";
+import { calculateDueDate } from "../../utils/time/time";
 import {
   createReportName,
   getEligibleWorkPlan,
@@ -165,16 +161,6 @@ export const createReport = handler(
     };
 
     if (isCopyOver) {
-      const reportPeriod = calculatePeriod(Date.now(), workPlanMetadata);
-      const isCurrentPeriod =
-        calculateCurrentYear() === unvalidatedMetadata.copyReport.reportYear &&
-        reportPeriod === unvalidatedMetadata.copyReport.reportPeriod;
-
-      // do not allow user to create a copy if it's the same period
-      if (isCurrentPeriod) {
-        return badRequest(error.UNABLE_TO_COPY);
-      }
-
       newFieldData = await copyFieldDataFromSource(
         state,
         unvalidatedMetadata.copyReport?.fieldDataId,

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -98,9 +98,7 @@ export const createReport = handler(
 
     const currentDate = Date.now();
 
-    const overrideCopyOver =
-      unvalidatedMetadata?.copyReport &&
-      unvalidatedMetadata?.copyReport?.isCopyOverTest;
+    const isCopyOver = unvalidatedMetadata?.copyReport;
 
     /**
      * If the report is a WP, determine reportYear from the unvalidated metadata. Otherwise, a SAR will use the workplan metadata.
@@ -108,8 +106,8 @@ export const createReport = handler(
     let reportData =
       reportType === ReportType.WP ? unvalidatedMetadata : workPlanMetadata;
 
-    const reportYear = getReportYear(reportData, overrideCopyOver);
-    const reportPeriod = getReportPeriod(reportData, overrideCopyOver);
+    const reportYear = getReportYear(reportData, isCopyOver);
+    const reportPeriod = getReportPeriod(reportData, isCopyOver);
 
     // Begin Section - Getting/Creating newest Form Template based on reportType
     let formTemplate, formTemplateVersion;
@@ -166,14 +164,14 @@ export const createReport = handler(
       generalInformation_resubmissionInformation: "N/A",
     };
 
-    if (unvalidatedMetadata.copyReport) {
+    if (isCopyOver) {
       const reportPeriod = calculatePeriod(Date.now(), workPlanMetadata);
       const isCurrentPeriod =
         calculateCurrentYear() === unvalidatedMetadata.copyReport.reportYear &&
         reportPeriod === unvalidatedMetadata.copyReport.reportPeriod;
 
       //do not allow user to create a copy if it's the same period
-      if (isCurrentPeriod && !overrideCopyOver) {
+      if (isCurrentPeriod && !isCopyOver) {
         return badRequest(error.UNABLE_TO_COPY);
       }
 
@@ -254,7 +252,7 @@ export const createReport = handler(
       ),
       reportYear,
       reportPeriod,
-      isCopied: overrideCopyOver ? true : false,
+      isCopied: isCopyOver ? true : false,
       dueDate: calculateDueDate(reportYear, reportPeriod, reportType),
       associatedWorkPlan: workPlanMetadata?.id,
     };

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -170,8 +170,8 @@ export const createReport = handler(
         calculateCurrentYear() === unvalidatedMetadata.copyReport.reportYear &&
         reportPeriod === unvalidatedMetadata.copyReport.reportPeriod;
 
-      //do not allow user to create a copy if it's the same period
-      if (isCurrentPeriod && !isCopyOver) {
+      // do not allow user to create a copy if it's the same period
+      if (isCurrentPeriod) {
         return badRequest(error.UNABLE_TO_COPY);
       }
 

--- a/services/app-api/utils/other/other.test.ts
+++ b/services/app-api/utils/other/other.test.ts
@@ -55,7 +55,7 @@ describe("API utility functions", () => {
     it("should return the report year for a copied work plan", () => {
       const reportData = {
         ...mockUnvalidatedMetadata,
-        copyReport: { reportYear: 2020, reportPeriod: 1, isCopyOverTest: true },
+        copyReport: { reportYear: 2020, reportPeriod: 1 },
       };
 
       const response = getReportYear(reportData, true);
@@ -66,7 +66,7 @@ describe("API utility functions", () => {
     it("should return the report year for a copied work plan with reportPeriod 2", () => {
       const reportData = {
         ...mockWPData,
-        copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
+        copyReport: { reportPeriod: 2, reportYear: 2020 },
       };
 
       const response = getReportYear(reportData, true);
@@ -110,7 +110,7 @@ describe("API utility functions", () => {
     it("should return the report period for a copied work plan", () => {
       const reportData = {
         ...mockWPData,
-        copyReport: { isCopyOverTest: true, reportPeriod: 1, reportYear: 2020 },
+        copyReport: { reportPeriod: 1, reportYear: 2020 },
       };
       const response = getReportPeriod(reportData, true);
 
@@ -120,7 +120,7 @@ describe("API utility functions", () => {
     it("should return the report period for a copied work plan with reportPeriod 2", () => {
       const reportData = {
         ...mockWPData,
-        copyReport: { isCopyOverTest: true, reportPeriod: 2, reportYear: 2020 },
+        copyReport: { reportPeriod: 2, reportYear: 2020 },
       };
       const responsePeriod = getReportPeriod(reportData, true);
 

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -16,7 +16,6 @@ import {
 } from "types";
 import { useStore } from "utils";
 import { States, DEFAULT_TARGET_POPULATIONS } from "../../constants";
-import { useFlags } from "launchdarkly-react-client-sdk";
 
 const reportType = ReportType.WP;
 
@@ -57,9 +56,6 @@ export const CreateWorkPlanModal = ({
   const [formYearValue, setFormYearValue] = useState<number>();
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
-
-  // LaunchDarkly - temporary flag for testing copyover
-  const isCopyOverTest = useFlags()?.isCopyOverTest;
 
   const form: FormJson = !previousReport
     ? newWPFormJson
@@ -138,11 +134,7 @@ export const CreateWorkPlanModal = ({
         reportPeriod: formattedReportPeriod,
       };
     } else {
-      previousReport.isCopyOverTest = isCopyOverTest;
-      wpPayload.metadata = {
-        ...wpPayload.metadata,
-        copyReport: previousReport,
-      };
+      wpPayload.metadata.copyReport = previousReport;
     }
 
     return wpPayload;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Remove WP copy feature flag from code
- Remove condition preventing users from copying a report when they are still in the same period as the previous report

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4473

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Easiest when running locally
- Run MFP
- use `yarn db:seed` to create an approved WP
- Click the button to continue MFP WP on the WP dashboard
- Verify it creates a copied WP

[Deployed env](https://d3249eji7hebn0.cloudfront.net/)
- log in as `stateuser@test.com`
- Go to the Work Plan dashboard and click the Continue button
- Verify it creates a report for the next period
- As a courtesy to other reviewers, log in as `adminuser@test.com` and archive the new report (under Puerto Rico for `stateuser@test.com`)


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
Need someone with launchdarkly access to remove flag once this is in prod

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---