### PR TITLE
Add aria-label to dashboard table buttons

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -259,8 +259,8 @@ describe("<DashboardPage />", () => {
     });
 
     test("Can still view all WPs", async () => {
-      const viewButtons = screen.getAllByRole("button", { name: "View" });
-      viewButtons.forEach((button) => expect(button).not.toBeDisabled());
+      const enterReportButtons = screen.getAllByTestId("enter-report");
+      enterReportButtons.forEach((button) => expect(button).not.toBeDisabled());
     });
 
     testA11y(wpDashboardViewWithReports, () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -76,15 +76,13 @@ export const DashboardTable = ({
         )}
         {/* Action Buttons */}
         <Td sx={sxOverride.editReportButtonCell}>
-          <Button variant="outline" onClick={() => enterSelectedReport(report)}>
-            {entering && reportId == report.id ? (
-              <Spinner size="md" />
-            ) : isStateLevelUser && !report?.locked ? (
-              "Edit"
-            ) : (
-              "View"
-            )}
-          </Button>
+          <ActionButton
+            report={report}
+            reportId={reportId}
+            isStateLevelUser={isStateLevelUser}
+            entering={entering}
+            enterSelectedReport={enterSelectedReport}
+          />
         </Td>
         {isAdmin && (
           <>
@@ -137,8 +135,8 @@ interface DashboardTableProps {
   openCreateReportModal: Function;
   enterSelectedReport: Function;
   archive: Function;
+  entering: boolean;
   archiving?: boolean;
-  entering?: boolean;
   isAdmin: boolean;
   isStateLevelUser: boolean;
   releaseReport?: Function | undefined;
@@ -193,7 +191,10 @@ const EditReportButton = ({
   return (
     <Td sx={sxOverride.editReport}>
       <button onClick={() => openCreateReportModal(report)}>
-        <Image src={editIcon} alt="Edit Report" />
+        <Image
+          src={editIcon}
+          alt={`Edit ${report.reportYear} Period ${report.reportPeriod} report submission set-up information`}
+        />
       </button>
     </Td>
   );
@@ -203,6 +204,35 @@ interface EditReportProps {
   report: ReportMetadataShape;
   openCreateReportModal: Function;
   sxOverride: AnyObject;
+}
+
+export const ActionButton = ({
+  report,
+  reportId,
+  isStateLevelUser,
+  entering,
+  enterSelectedReport,
+}: ActionButtonProps) => {
+  const editOrView = isStateLevelUser && !report?.locked ? "Edit" : "View";
+
+  return (
+    <Button
+      variant="outline"
+      aria-label={`${editOrView} ${report.reportYear} Period ${report.reportPeriod} report submission set-up information`}
+      onClick={() => enterSelectedReport(report)}
+      data-testid="enter-report"
+    >
+      {entering && reportId == report.id ? <Spinner size="md" /> : editOrView}
+    </Button>
+  );
+};
+
+export interface ActionButtonProps {
+  report: ReportMetadataShape;
+  reportId: string | undefined;
+  isStateLevelUser: boolean;
+  entering: boolean;
+  enterSelectedReport: Function;
 }
 
 const DateFields = ({ report, reportType, isAdmin }: DateFieldProps) => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add labels for dashboard actions that give more details to assistive tech.

Copied from https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12188

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4463
CMDCT-4465

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Run the application locally
- Run `yarn db:seed` to create an approved WP and SAR
- Navigate to /wp and /sar and check the accessible names of the buttons inside of the dashboard table to ensure that they are:
  - unique
  - better describe what the button does

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
