### PR TITLE
Update optional field schemas

### DIFF
--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -1,5 +1,15 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { number, ratio, validInteger } from "./schemas";
+import {
+  dateOptional,
+  emailOptional,
+  number,
+  numberOptional,
+  ratio,
+  textOptional,
+  urlOptional,
+  validInteger,
+  validIntegerOptional,
+} from "./schemas";
 
 describe("utils/schemas", () => {
   const goodNumberTestCases = [
@@ -77,5 +87,14 @@ describe("utils/schemas", () => {
   test("Evaluate Number Schema using ratio scheme", () => {
     testNumberSchema(ratio(), goodRatioTestCases, true);
     testNumberSchema(ratio(), badRatioTestCases, false);
+  });
+
+  test("Verify optional schemas convert empty string to null", () => {
+    testNumberSchema(textOptional(), [""], true);
+    testNumberSchema(numberOptional(), [""], true);
+    testNumberSchema(validIntegerOptional(), [""], true);
+    testNumberSchema(emailOptional(), [""], true);
+    testNumberSchema(urlOptional(), [""], true);
+    testNumberSchema(dateOptional(), [""], true);
   });
 });

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -21,6 +21,7 @@ export const text = () =>
     });
 export const textOptional = () =>
   string()
+    .nullable()
     .transform((curr, orig) => (orig === "" ? null : curr))
     .typeError(error.INVALID_GENERIC);
 
@@ -141,12 +142,16 @@ export const date = () =>
 export const dateOptional = () =>
   string()
     .typeError(error.INVALID_GENERIC)
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr))
     .test({
       message: error.INVALID_DATE,
-      test: (value) => dateFormatRegex.test(value!),
-    })
-    .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr));
+      test: (value) => {
+        if (value) {
+          return dateFormatRegex.test(value!);
+        } else return true;
+      },
+    });
 
 export const endDate = (startDateField: string) =>
   date()

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -9,6 +9,8 @@ import {
 
 // TEXT - Helpers
 const isWhitespaceString = (value?: string) => value?.trim().length === 0;
+const transformEmptyStringToNull = (curr: string, orig: string) =>
+  orig === "" ? null : curr;
 
 // TEXT
 export const text = () =>
@@ -22,7 +24,7 @@ export const text = () =>
 export const textOptional = () =>
   string()
     .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr))
+    .transform(transformEmptyStringToNull)
     .typeError(error.INVALID_GENERIC);
 
 // NUMBER - Helpers
@@ -62,10 +64,7 @@ export const number = () =>
     });
 
 export const numberOptional = () =>
-  numberSchema()
-    .notRequired()
-    .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr));
+  numberSchema().notRequired().nullable().transform(transformEmptyStringToNull);
 
 // Integer or Valid Strings
 export const validIntegerSchema = () =>
@@ -96,7 +95,7 @@ export const validIntegerOptional = () =>
   validIntegerSchema()
     .notRequired()
     .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr));
+    .transform(transformEmptyStringToNull);
 
 // Number - Ratio
 export const ratio = () =>
@@ -116,18 +115,12 @@ export const ratio = () =>
 // EMAIL
 export const email = () => text().email(error.INVALID_EMAIL);
 export const emailOptional = () =>
-  email()
-    .notRequired()
-    .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr));
+  email().notRequired().nullable().transform(transformEmptyStringToNull);
 
 // URL
 export const url = () => text().url(error.INVALID_URL);
 export const urlOptional = () =>
-  url()
-    .notRequired()
-    .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr));
+  url().notRequired().nullable().transform(transformEmptyStringToNull);
 
 // DATE
 export const date = () =>
@@ -143,13 +136,14 @@ export const dateOptional = () =>
   string()
     .typeError(error.INVALID_GENERIC)
     .nullable()
-    .transform((curr, orig) => (orig === "" ? null : curr))
+    .transform(transformEmptyStringToNull)
     .test({
       message: error.INVALID_DATE,
       test: (value) => {
         if (value) {
-          return dateFormatRegex.test(value!);
-        } else return true;
+          return dateFormatRegex.test(value);
+        }
+        return true;
       },
     });
 

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -19,7 +19,10 @@ export const text = () =>
       test: (value) => !isWhitespaceString(value),
       message: error.REQUIRED_GENERIC,
     });
-export const textOptional = () => string().typeError(error.INVALID_GENERIC);
+export const textOptional = () =>
+  string()
+    .transform((curr, orig) => (orig === "" ? null : curr))
+    .typeError(error.INVALID_GENERIC);
 
 // NUMBER - Helpers
 const validNAValues = ["N/A", "Data not available"];
@@ -57,7 +60,11 @@ export const number = () =>
       message: error.REQUIRED_GENERIC,
     });
 
-export const numberOptional = () => numberSchema().notRequired().nullable();
+export const numberOptional = () =>
+  numberSchema()
+    .notRequired()
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr));
 
 // Integer or Valid Strings
 export const validIntegerSchema = () =>
@@ -85,7 +92,10 @@ export const validInteger = () =>
   validIntegerSchema().required(error.REQUIRED_GENERIC);
 
 export const validIntegerOptional = () =>
-  validIntegerSchema().notRequired().nullable();
+  validIntegerSchema()
+    .notRequired()
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr));
 
 // Number - Ratio
 export const ratio = () =>
@@ -104,11 +114,19 @@ export const ratio = () =>
 
 // EMAIL
 export const email = () => text().email(error.INVALID_EMAIL);
-export const emailOptional = () => email().notRequired();
+export const emailOptional = () =>
+  email()
+    .notRequired()
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr));
 
 // URL
 export const url = () => text().url(error.INVALID_URL);
-export const urlOptional = () => url().notRequired();
+export const urlOptional = () =>
+  url()
+    .notRequired()
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr));
 
 // DATE
 export const date = () =>
@@ -126,7 +144,9 @@ export const dateOptional = () =>
     .test({
       message: error.INVALID_DATE,
       test: (value) => dateFormatRegex.test(value!),
-    });
+    })
+    .nullable()
+    .transform((curr, orig) => (orig === "" ? null : curr));
 
 export const endDate = (startDateField: string) =>
   date()


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Update frontend validation schemas for optional fields to:
- accept `null` values
- convert empty strings to `null` values

Fields where no value is entered or a previous value was removed now save as `null` instead of empty string. Is this something we need to communicate to DataConnect?

I did not update the schemas in the backend because they only receive a singular value. They do not have to determine validation to changing values. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4444

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Deployed env](https://d18uja5w5t1kux.cloudfront.net/)

Admin user
- Log in as an admin and navigate to `/admin`
- Enter text in the banner form's Link field and then delete it
  - Verify validation goes away when the field is empty
  - Verify you can still submit the form when link had text entered and then removed

State user
- Run MFP locally
- Run `yarn db:seed` and create an approved WP in Period 2
- Create a SAR and navigate to the HCBS RE&T section
- Enter numbers for some of the fields
  - Verify you can remove the numbers and still save
  - Verify the values are saved as `null` when removed
  - Verify you can enter and then delete text and validation goes away

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary
---