### PR TITLE
Bump tar-fs from 2.1.2 to 2.1.3 in /services/ui-src in the npm_and_yarn group across 1 directory

### DIFF
--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -9330,9 +9330,9 @@ tabbable@^6.2.0:
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 tar-fs@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
-  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
+  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"


### PR DESCRIPTION
Renamed branch: https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/950

Bumps the npm_and_yarn group with 1 update in the /services/ui-src directory: [tar-fs](https://github.com/mafintosh/tar-fs).

Updates `tar-fs` from 2.1.2 to 2.1.3
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/mafintosh/tar-fs/commits">compare view</a></li>
</ul>
</details>