### PR TITLE
Run pull request action on open and ready for review

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   prchecks:
@@ -21,16 +23,13 @@ jobs:
         run: ./scripts/test-unit.sh
   assignAuthor:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
     steps:
       - uses: actions/checkout@v4
       - name: Assign PR to Creator
         run: |
-          if [ "$PR_AUTHOR_TYPE" != "Bot" ]
-            then
-              gh pr edit $PRNUM --add-assignee $PR_AUTHOR
-            fi
+          gh pr edit $PRNUM --add-assignee $PR_AUTHOR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRNUM: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The production release PR created by GitHub action (https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/959) has been hanging on the `prchecks` and `assignAuthor` actions. This is possibly because the release PR is created with `gh pr create --draft` and it's not triggering on `[pull_request]`, which equivalent to just the `opened` trigger.

This PR updates the Pull Request workflow to run on specific `pull_request` triggers, and also moves the conditional for whether to run `assignAuthor` outside of the steps.

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. This PR passes checks
2. After merge to `main`, test merging to `val`, then `production`

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->

<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->

<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_ -->
