### PR TITLE
add yarn to pre-commit tsc command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,16 +63,16 @@ repos:
         pass_filenames: false
       - id: typescript-check
         name: typescript-check
-        entry: tsc --noEmit
+        entry: yarn tsc --noEmit
         language: system
         pass_filenames: false
       - id: typescript-check-api
         name: typescript-check-api
-        entry: bash -c "cd services/app-api && tsc --noEmit"
+        entry: bash -c "cd services/app-api && yarn tsc --noEmit"
         language: system
         pass_filenames: false
       - id: typescript-check-ui
         name: typescript-check-ui
-        entry: bash -c "cd services/ui-src && tsc --noEmit"
+        entry: bash -c "cd services/ui-src && yarn tsc --noEmit"
         language: system
         pass_filenames: false


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
I had trouble running `tsc` on my local. If you add yarn it should use the project installed tsc and not be machine-dependent.

### How to test
- Pull down this branch
- Make any file change
- Run `git commit -am "test"`
- Verify the commit hooks all run 
- Don't push :) 


Bonus: see if yours works on main
- Run `which tsc` to see if you have tsc installed
- If not, make a branch off main and do the same steps locally and see if the pre-commit hook throws an error

