### PR TITLE
moved playwright test logic into shared workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,108 +272,18 @@ jobs:
       # - e2e-test
       # - a11y-tests
     if: ${{ always() && !cancelled() && needs.deploy.result == 'success' && github.ref_name != 'production' && !startsWith(github.ref_name, 'skipci') && !startsWith(github.ref_name, 'code-json-') }}
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-      - name: yarn install
-        run: yarn install
-      - name: yarn install tests
-        run: yarn install
-        working-directory: tests
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(yarn list @playwright/test --depth=0 --json | jq -r '.data.trees[].name' | sed 's/@playwright\/test@//')" >> $GITHUB_OUTPUT
-        working-directory: tests
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: yarn playwright install --with-deps
-        working-directory: tests
-      - name: Run Playwright tests
-        run: yarn playwright test --grep-invert "@flaky|@probation"
-        working-directory: tests
-        continue-on-error: true
-        env:
-          BASE_URL: ${{ needs.deploy.outputs.application_endpoint }}
-          CYPRESS_STATE_USER_EMAIL: ${{ secrets.CYPRESS_STATE_USER_EMAIL }}
-          CYPRESS_STATE_USER_PASSWORD: ${{ secrets.CYPRESS_STATE_USER_PASSWORD }}
-          CYPRESS_ADMIN_USER_EMAIL: ${{ secrets.CYPRESS_ADMIN_USER_EMAIL }}
-          CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
-          SEED_ADMIN_USER_EMAIL: ${{ secrets.SEED_ADMIN_USER_EMAIL }}
-          SEED_ADMIN_USER_PASSWORD: ${{ secrets.SEED_ADMIN_USER_PASSWORD }}
-          SEED_STATE_USER_EMAIL: ${{ secrets.SEED_STATE_USER_EMAIL }}
-          SEED_STATE_USER_PASSWORD: ${{ secrets.SEED_STATE_USER_PASSWORD }}
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-html-report # upload artifact as this name
-          path: tests/playwright-report # path on runner
-          retention-days: 30
-
-  upload-reports:
-    name: Upload Reports
-    needs:
-      - test
-    if: ${{ always() && github.ref_name != 'production' && !startsWith(github.ref_name, 'skipci') && !startsWith(github.ref_name, 'code-json-') }}
-    runs-on: ubuntu-latest
-    outputs:
-      timestamp: ${{ steps.timestampid.outputs.timestamp }}
-    steps:
-      # create a unique folder name to put playwright reports in
-      - name: Set a Timestamp
-        id: timestampid
-        run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-      - name: Install dependencies
-        run: yarn install
-      # downloads artifact created from the test job
-      - name: Download reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: playwright-html-report # download from previous job
-          path: downloaded-html-report # save as this when downloaded
-      - name: Push files to github pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./downloaded-html-report # publish downloaded dir to github pages
-          destination_dir: ${{ steps.timestampid.outputs.timestamp }}
-      # need to extract just org name for reassembling the github pages URL
-      - name: Extract Organization Name
-        id: extract-org
-        run: |
-          echo "ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)" >> $GITHUB_ENV
-          echo "org name: ${ORG_NAME}"
-      # need to extract just the repo name for reassembling the github pages URL
-      - name: Extract Repository Name
-        id: extract-repo
-        run: |
-          echo "REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)" >> $GITHUB_ENV
-          echo "repo name: ${REPO_NAME}"
-      # assembles org name, repo name, and unique timestamp to link to github pages url that was published
-      - name: Write URL in Summary
-        run: |
-          echo "## Playwright Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "https://${ORG_NAME}.github.io/${REPO_NAME}/${{ steps.timestampid.outputs.timestamp }}/" >> $GITHUB_STEP_SUMMARY
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      base-url: ${{ needs.deploy.outputs.application_endpoint }}
+      test-filter: '--grep-invert "@flaky|@probation"'
+      timeout-minutes: 60
+      artifact-name-prefix: 'playwright'
+      continue-on-error: true
+      upload-to-pages: true
+      pages-destination-dir: ''
+      aws-role-varname: 'BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME'
+      aws-region-varname: 'BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION'
+    secrets: inherit #pragma: allowlist secret
 
   # cleanup:
   #   name: Delist GHA Runner CIDR Blocks

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,188 @@
+name: E2E Tests
+
+on:
+  workflow_call:
+    inputs:
+      base-url:
+        description: 'Base URL for testing'
+        required: true
+        type: string
+      test-filter:
+        description: 'Test filter pattern (e.g., --grep-invert "@flaky|@probation")'
+        required: false
+        type: string
+        default: '--grep-invert "@flaky|@probation"'
+      timeout-minutes:
+        description: 'Timeout for the test job in minutes'
+        required: false
+        type: number
+        default: 60
+      artifact-name-prefix:
+        description: 'Prefix for artifact names'
+        required: false
+        type: string
+        default: 'playwright'
+      continue-on-error:
+        description: 'Whether to continue on test failure'
+        required: false
+        type: boolean
+        default: true
+      upload-to-pages:
+        description: 'Whether to upload results to GitHub Pages'
+        required: false
+        type: boolean
+        default: false
+      pages-destination-dir:
+        description: 'Directory path for GitHub Pages upload'
+        required: false
+        type: string
+        default: ''
+      aws-role-varname:
+        description: 'Environment variable name for AWS role (for branch-specific roles)'
+        required: false
+        type: string
+        default: ''
+      aws-region-varname:
+        description: 'Environment variable name for AWS region (for branch-specific regions)'
+        required: false
+        type: string
+        default: ''
+
+    outputs:
+      test-result:
+        description: 'Result of the test execution'
+        value: ${{ jobs.playwright-tests.result }}
+      report-url:
+        description: 'URL to the test report (if uploaded to pages)'
+        value: ${{ jobs.upload-reports.outputs.report-url }}
+
+permissions:
+  id-token: write
+  contents: write
+  actions: read
+  pages: write
+
+jobs:
+  playwright-tests:
+    name: Playwright Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws-role-varname && secrets[inputs.aws-role-varname] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: ${{ inputs.aws-region-varname && secrets[inputs.aws-region-varname] || secrets.AWS_DEFAULT_REGION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install root dependencies
+        run: yarn install
+
+      - name: Install test dependencies
+        run: yarn install
+        working-directory: tests
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(yarn list @playwright/test --depth=0 --json | jq -r '.data.trees[].name' | sed 's/@playwright\/test@//')" >> $GITHUB_OUTPUT
+        working-directory: tests
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: yarn playwright install --with-deps
+        working-directory: tests
+
+      - name: Run Playwright tests
+        run: yarn playwright test ${{ inputs.test-filter }}
+        working-directory: tests
+        continue-on-error: ${{ inputs.continue-on-error }}
+        env:
+          BASE_URL: ${{ inputs.base-url }}
+          CYPRESS_STATE_USER_EMAIL: ${{ secrets.CYPRESS_STATE_USER_EMAIL }}
+          CYPRESS_STATE_USER_PASSWORD: ${{ secrets.CYPRESS_STATE_USER_PASSWORD }}
+          CYPRESS_ADMIN_USER_EMAIL: ${{ secrets.CYPRESS_ADMIN_USER_EMAIL }}
+          CYPRESS_ADMIN_USER_PASSWORD: ${{ secrets.CYPRESS_ADMIN_USER_PASSWORD }}
+          SEED_ADMIN_USER_EMAIL: ${{ secrets.SEED_ADMIN_USER_EMAIL }}
+          SEED_ADMIN_USER_PASSWORD: ${{ secrets.SEED_ADMIN_USER_PASSWORD }}
+          SEED_STATE_USER_EMAIL: ${{ secrets.SEED_STATE_USER_EMAIL }}
+          SEED_STATE_USER_PASSWORD: ${{ secrets.SEED_STATE_USER_PASSWORD }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ inputs.artifact-name-prefix }}-html-report-${{ github.run_number }}
+          path: tests/playwright-report
+          retention-days: 30
+
+  upload-reports:
+    name: Upload Reports to GitHub Pages
+    needs: playwright-tests
+    if: ${{ always() && inputs.upload-to-pages }}
+    runs-on: ubuntu-latest
+    outputs:
+      report-url: ${{ steps.report-url.outputs.url }}
+      timestamp: ${{ steps.timestampid.outputs.timestamp }}
+    steps:
+      - name: Set timestamp
+        id: timestampid
+        run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Download test reports
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name-prefix }}-html-report-${{ github.run_number }}
+          path: downloaded-html-report
+
+      - name: Determine destination directory
+        id: destination
+        run: |
+          if [[ -n "${{ inputs.pages-destination-dir }}" ]]; then
+            echo "dest_dir=${{ inputs.pages-destination-dir }}/${{ steps.timestampid.outputs.timestamp }}" >> $GITHUB_OUTPUT
+          else
+            echo "dest_dir=${{ steps.timestampid.outputs.timestamp }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push files to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./downloaded-html-report
+          destination_dir: ${{ steps.destination.outputs.dest_dir }}
+
+      - name: Generate report URL
+        id: report-url
+        run: |
+          ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+          REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
+          URL="https://${ORG_NAME}.github.io/${REPO_NAME}/${{ steps.destination.outputs.dest_dir }}/"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "## 📊 ${{ inputs.artifact-name-prefix }} Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "Test results are available at: [$URL]($URL)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -1,0 +1,91 @@
+name: Regression Tests
+
+on:
+  schedule:
+    # Every Monday at 7 AM UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: regression-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+  pages: write
+
+jobs:
+  regression-tests:
+    name: Playwright Regression Tests
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      base-url: 'https://mfp-val.mdctdemo.com'
+      test-filter: '--grep-invert "@flaky"'
+      timeout-minutes: 90
+      artifact-name-prefix: 'regression'
+      continue-on-error: true
+      upload-to-pages: true
+      pages-destination-dir: 'regression'
+      aws-role-varname: 'AWS_OIDC_ROLE_TO_ASSUME'
+      aws-region-varname: 'AWS_DEFAULT_REGION'
+    secrets: inherit #pragma: allowlist secret
+
+  notify-results:
+    name: Notify Stakeholders
+    needs: regression-tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine test status
+        id: test-status
+        run: |
+          if [[ "${{ needs.regression-tests.outputs.test-result }}" == "success" ]]; then
+            echo "status=✅ PASSED" >> $GITHUB_OUTPUT
+            echo "color=good" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.regression-tests.outputs.test-result }}" == "failure" ]]; then
+            echo "status=❌ FAILED" >> $GITHUB_OUTPUT
+            echo "color=danger" >> $GITHUB_OUTPUT
+          else
+            echo "status=⚠️ CANCELLED/SKIPPED" >> $GITHUB_OUTPUT
+            echo "color=warning" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create summary
+        run: |
+          echo "## 🔄 Regression Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ${{ steps.test-status.outputs.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** https://mfp-val.mdctdemo.com" >> $GITHUB_STEP_SUMMARY
+          echo "**Timestamp:** $(date --utc)" >> $GITHUB_STEP_SUMMARY
+          echo "**Report:** ${{ needs.regression-tests.outputs.report-url }}" >> $GITHUB_STEP_SUMMARY
+
+      # Uncomment and configure this step when Slack integration is ready
+      # - name: Notify Slack
+      #   if: ${{ always() }}
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: custom
+      #     custom_payload: |
+      #       {
+      #         "text": "MFP Regression Tests ${{ steps.test-status.outputs.status }}",
+      #         "attachments": [
+      #           {
+      #             "color": "${{ steps.test-status.outputs.color }}",
+      #             "fields": [
+      #               {
+      #                 "title": "Environment",
+      #                 "value": "https://mfp-val.mdctdemo.com",
+      #                 "short": true
+      #               },
+      #               {
+      #                 "title": "Results",
+      #                 "value": "<${{ needs.regression-tests.outputs.report-url }}|View Report>",
+      #                 "short": true
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Description
- Extracted Playwright test configuration from the deploy workflow and moved it into a shareable workflow called e2e-test.yml
- Created a new workflow called regression-test.yml that runs the e2e-test.yml workflow on a cron that runs every Monday at 7am UTC.

### Related ticket(s)
CMDCT-4873

---

### How to test
* Run the workflow manually in Github actions
* Wait until Monday 7am UTC
* In both instances, the workflow should run without issues

### Notes

---

### Pre-review checklist
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
