### PR TITLE
Update MFP CDK NodejsFunction usage to use our Lambda construct like MCR

### DIFF
--- a/deployment/stacks/parent.ts
+++ b/deployment/stacks/parent.ts
@@ -55,8 +55,8 @@ export class ParentStack extends Stack {
 
     const { tables, wpFormBucket, sarFormBucket, abcdFormBucket } =
       createDataComponents({
-        loggingBucket,
         ...commonProps,
+        loggingBucket,
       });
 
     const { apiGatewayRestApiUrl, restApiId } = createApiComponents({
@@ -78,7 +78,7 @@ export class ParentStack extends Stack {
     if (isLocalStack) return;
 
     const { applicationEndpointUrl, distribution, uiBucket } =
-      createUiComponents({ loggingBucket, ...commonProps });
+      createUiComponents({ ...commonProps, loggingBucket });
 
     const { userPoolDomainName, identityPoolId, userPoolId, userPoolClientId } =
       createUiAuthComponents({

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -2,8 +2,6 @@ import { Construct } from "constructs";
 import {
   aws_cognito as cognito,
   aws_iam as iam,
-  aws_lambda as lambda,
-  aws_lambda_nodejs as lambda_nodejs,
   aws_wafv2 as wafv2,
   Aws,
   Duration,
@@ -12,6 +10,7 @@ import {
 } from "aws-cdk-lib";
 import { WafConstruct } from "../constructs/waf";
 import { isLocalStack } from "../local/util";
+import { Lambda } from "../constructs/lambda";
 
 interface CreateUiAuthComponentsProps {
   scope: Construct;
@@ -25,7 +24,6 @@ interface CreateUiAuthComponentsProps {
   bootstrapUsersPassword?: string;
   secureCloudfrontDomainName?: string;
   userPoolDomainPrefix?: string;
-  sesSourceEmailAddress?: string;
 }
 
 export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
@@ -89,10 +87,10 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
       attributeMapping: {
         email:
           "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-        given_name:
-          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
         family_name:
           "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+        given_name:
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
         "custom:cms_roles": "cmsRoles",
         "custom:cms_state": "state",
       },
@@ -112,9 +110,13 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
   const userPoolClient = new cognito.UserPoolClient(scope, "UserPoolClient", {
     userPoolClientName: `${stage}-user-pool-client`,
     userPool,
-    authFlows: { adminUserPassword: true },
+    authFlows: {
+      userPassword: true,
+    },
     oAuth: {
-      flows: { authorizationCodeGrant: true },
+      flows: {
+        authorizationCodeGrant: true,
+      },
       scopes: [
         cognito.OAuthScope.EMAIL,
         cognito.OAuthScope.OPENID,

--- a/deployment/stacks/ui-auth.ts
+++ b/deployment/stacks/ui-auth.ts
@@ -260,7 +260,6 @@ export function createUiAuthComponents(props: CreateUiAuthComponentsProps) {
       { name: `${project}-${stage}-ui-auth` },
       "REGIONAL"
     );
-    // TODO: do we need the size exclusion for this WAF?
 
     new wafv2.CfnWebACLAssociation(scope, "CognitoUserPoolWAFAssociation", {
       resourceArn: userPool.userPoolArn,

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -84,7 +84,7 @@ export function createUiComponents(props: CreateUiComponentsProps) {
 
   const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
     scope,
-    "CloudFormationHeadersPolicy",
+    "CloudFrontHeadersPolicy",
     {
       responseHeadersPolicyName: `Headers-Policy-${stage}`,
       comment: "Add Security Headers",


### PR DESCRIPTION
### Description
Update MFP CDK NodejsFunction usage to use our Lambda construct like MCR
and 
Fix the logical name of the CloudFront response headers
and
fix loggingBucket logic overrides in parent.ts
and 
create consistency in ui-auth.ts between apps

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4984

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Log in to https://d1k6pvysbcmrqg.cloudfront.net/
refresh, log out, and log back in.  Confirm it still works.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [X] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [X] I have updated relevant documentation, if necessary
- [X] I have performed a self-review of my code
- [X] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
