### PR TITLE
added job to report test failure to Slack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,7 +278,7 @@ jobs:
       test-filter: '--grep-invert "@flaky|@probation"'
       timeout-minutes: 60
       artifact-name-prefix: "playwright"
-      continue-on-error: true
+      continue-on-error: false
       upload-to-pages: true
       pages-destination-dir: ""
       aws-role-varname: "BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -186,3 +186,19 @@ jobs:
           echo "url=$URL" >> $GITHUB_OUTPUT
           echo "## 📊 ${{ inputs.artifact-name-prefix }} Test Results" >> $GITHUB_STEP_SUMMARY
           echo "Test results are available at: [$URL]($URL)" >> $GITHUB_STEP_SUMMARY
+
+  notify-slack-on-failure:
+    name: Notify Slack on Test Failure
+    needs: [playwright-tests, upload-reports]
+    if: ${{ always() && needs.playwright-tests.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          MSG_MINIMAL: true
+          SLACK_COLOR: danger
+          SLACK_TITLE: "🚨 E2E Tests Failed on ${{ github.ref_name }} against ${{ inputs.base-url }}"
+          SLACK_MESSAGE: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>${{ needs.upload-reports.outputs.report-url && format(' • <{0}|View Report>', needs.upload-reports.outputs.report-url) || '' }}
+          SLACK_FOOTER: ${{ github.repository }}

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -25,67 +25,9 @@ jobs:
       test-filter: '--grep-invert "@flaky"'
       timeout-minutes: 90
       artifact-name-prefix: 'regression'
-      continue-on-error: true
+      continue-on-error: false
       upload-to-pages: true
       pages-destination-dir: 'regression'
       aws-role-varname: 'AWS_OIDC_ROLE_TO_ASSUME'
       aws-region-varname: 'AWS_DEFAULT_REGION'
     secrets: inherit #pragma: allowlist secret
-
-  notify-results:
-    name: Notify Stakeholders
-    needs: regression-tests
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Determine test status
-        id: test-status
-        run: |
-          if [[ "${{ needs.regression-tests.outputs.test-result }}" == "success" ]]; then
-            echo "status=✅ PASSED" >> $GITHUB_OUTPUT
-            echo "color=good" >> $GITHUB_OUTPUT
-          elif [[ "${{ needs.regression-tests.outputs.test-result }}" == "failure" ]]; then
-            echo "status=❌ FAILED" >> $GITHUB_OUTPUT
-            echo "color=danger" >> $GITHUB_OUTPUT
-          else
-            echo "status=⚠️ CANCELLED/SKIPPED" >> $GITHUB_OUTPUT
-            echo "color=warning" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create summary
-        run: |
-          echo "## 🔄 Regression Test Summary" >> $GITHUB_STEP_SUMMARY
-          echo "**Status:** ${{ steps.test-status.outputs.status }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** https://mfp-val.mdctdemo.com" >> $GITHUB_STEP_SUMMARY
-          echo "**Timestamp:** $(date --utc)" >> $GITHUB_STEP_SUMMARY
-          echo "**Report:** ${{ needs.regression-tests.outputs.report-url }}" >> $GITHUB_STEP_SUMMARY
-
-      # Uncomment and configure this step when Slack integration is ready
-      # - name: Notify Slack
-      #   if: ${{ always() }}
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: custom
-      #     custom_payload: |
-      #       {
-      #         "text": "MFP Regression Tests ${{ steps.test-status.outputs.status }}",
-      #         "attachments": [
-      #           {
-      #             "color": "${{ steps.test-status.outputs.color }}",
-      #             "fields": [
-      #               {
-      #                 "title": "Environment",
-      #                 "value": "https://mfp-val.mdctdemo.com",
-      #                 "short": true
-      #               },
-      #               {
-      #                 "title": "Results",
-      #                 "value": "<${{ needs.regression-tests.outputs.report-url }}|View Report>",
-      #                 "short": true
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Description
* Added a new job in e2e-tests.yml called notify-slack-on-failure that posts a message in the macpro-mdct-ALERTS Slack channel when the tests fail.
* Set continue-on-error to false in regression-test.yml and deploy.yml so that failure would bubble up to the new notify-slack-on-failure job

### Related ticket(s)
CMDCT-4885

---

### How to test
* Modify one of the tests to fail and re-run the workflow, when the tests pass it should post to the macrpo-mdct-ALERTS Slack channel

### Notes

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
