### PR TITLE
Update stack name in PR notification

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -34,7 +34,7 @@ jobs:
         id: getendpoint
         run: |
           set +e
-          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name ui-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
+          application_endpoint_url=$(aws cloudformation describe-stacks --stack-name mfp-${{ env.branch_name }} --output text --query "Stacks[0].Outputs[?OutputKey=='ApplicationEndpointUrl'].OutputValue")
           set -e
           if [[ -z $application_endpoint_url || ! $application_endpoint_url == http* ]]; then
               application_endpoint_url="endpoint not found"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The pr-notification action notifies the `#mdct-integrations-channel` when a PR is opened. The notifications have been listing `Cloudfront URL: endpoint not found` because it can't find the stack name. This PR updates the stack name.

<img width="693" height="316" alt="Screenshot 2025-08-08 at 11 58 11 AM" src="https://github.com/user-attachments/assets/a49c5840-bf0b-438b-82f1-3d06522be952" />

<!-- ### Related ticket(s) -->
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
<!-- CMDCT- -->

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1. Future MFP PRs will have the Cloudfront URL populated

<!-- ### Notes -->
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->

<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->

<!-- --- -->

<!-- If deploying to val or prod, click 'Preview' and select template -->
<!-- _convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_ -->
