### PR TITLE
CMDCT-5033: Add background color on hover to outline buttons

### DIFF
--- a/services/ui-src/src/styles/components/button.ts
+++ b/services/ui-src/src/styles/components/button.ts
@@ -37,7 +37,7 @@ const outlineVariant = {
   color: "palette.primary",
   textDecoration: "none",
   "&:hover": {
-    backgroundColor: "transparent",
+    backgroundColor: "palette.gray_lightest",
     color: "palette.primary_darker",
   },
   "&:visited, &:visited:hover": {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Add background color to outline buttons on hover

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5033

---

### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed env](https://d3qkfj45pmpheg.cloudfront.net/)
- Find any outline button style and hover over it
- Verify gray background appears on hover

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary

---