### PR TITLE
Fix Regression Workflow

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -50,11 +50,13 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: process.env.CI ? "" : "cd ../ && ./run local",
-    url: process.env.BASE_URL || "http://localhost:3000",
-    timeout: 240 * 1000,
-    reuseExistingServer: !!process.env.CI,
-    stdout: "pipe",
-  },
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: "cd ../ && ./run local",
+        url: process.env.BASE_URL || "http://localhost:3000",
+        timeout: 240 * 1000,
+        reuseExistingServer: false,
+        stdout: "pipe",
+      },
 });


### PR DESCRIPTION
### Description
* The regression workflow we run on a schedule was not executing the tests due to an empty string which was caused by our Playwright config.
* This change only runs the webserver step if we're running the tests locally, avoiding an empty string being sent to the downstream workflow.

### Related ticket(s)
No related ticket as the work seemed small enough.

---

### How to test
* Run the regression workflow and the deploy workflow.
* Tests should pass in deploy
* Tests should run in regression workflow, though likely some will fail since it runs unstable tests not run in deploy

### Notes
* Updated the playwright.config.ts

---

### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist
#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [val release](?expand=1&template=val-deployment.md)_ | _[production release](?expand=1&template=production-deployment.md)_
