### PR TITLE
make all textareas expandable

### DIFF
--- a/services/ui-src/src/styles/styles.ts
+++ b/services/ui-src/src/styles/styles.ts
@@ -3,5 +3,10 @@ export const styles = {
     body: {
       color: "palette.base",
     },
+    textarea: {
+      fieldSizing: "content",
+      // need min-height because fieldSizing overrides the rows attribute
+      minHeight: "82px",
+    },
   },
 };


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

This PR adds the ability to auto-expand textareas with their content using just CSS. It is not compatible with all browsers. Because the majority of our users visit the application on Chrome, we are moving forward with this solution as an easy quick win, while continuing to investigate and evaluate the priority of implementing a solution that provides a similar experience on all browsers (which would require the use of JavaScript).

For more information, see https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-4954

---

### How to test

1. Open Chrome or Edge (not Firefox, sorry).
2. Navigate to any report that contains a textarea.
    - For example, `/mcpar/notes`
3. Write some content and ensure that it exceeds 3 lines of text.
4. Verify that the textarea expands gracefully.
5. Save and navigate to another page, then come back. Verify that the textarea remains expanded with the content.
6. Verify that all of the entered content is saved in the fieldData



https://github.com/user-attachments/assets/9518b48e-5d23-4fa8-8302-cdffdd05adc0


### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
- This implementation is in the global styles of the theme CSS, which means it affects all textareas, regardless of context. Design sign-off indicates that this is an acceptable outcome for now, and we can evaluate contextual implementation via classes or variants if it becomes necessary.


---


#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary


---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
