### PR TITLE
CMDCT-5115 moves github actions oidc template into prerequisite stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
       - name: set variable values
         run: ./.github/buildVars.sh set_values
         env:
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Configure AWS credentials for GitHub Actions
@@ -102,7 +102,6 @@ jobs:
           echo "<$APPLICATION_ENDPOINT>" >> $GITHUB_STEP_SUMMARY
     outputs:
       application_endpoint: ${{ steps.endpoint.outputs.application_endpoint }}
-      BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION }}
       BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME: ${{ steps.set_names.outputs.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME }}
 
   # register-runner:
@@ -127,14 +126,14 @@ jobs:
   #       id: set_values
   #       run: ./.github/buildVars.sh set_values
   #       env:
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   #         AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
 
   #     - name: Configure AWS credentials for GitHub Actions
   #       uses: aws-actions/configure-aws-credentials@v4
   #       with:
   #         role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   #     - name: output account id
   #       id: output_account_id
@@ -297,7 +296,7 @@ jobs:
   #       uses: aws-actions/configure-aws-credentials@v4
   #       with:
   #         role-to-assume: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_OIDC_ROLE_TO_ASSUME] || secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
   #     - name: output account id
   #       id: output_account_id
   #       run: |

--- a/deployment/prerequisites.ts
+++ b/deployment/prerequisites.ts
@@ -19,6 +19,7 @@ import { isLocalStack } from "./local/util";
 interface PrerequisiteConfigProps {
   project: string;
   vpcName: string;
+  branchFilter: string;
 }
 
 export class PrerequisiteStack extends Stack {
@@ -29,7 +30,7 @@ export class PrerequisiteStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const { project, vpcName } = props;
+    const { project, vpcName, branchFilter } = props;
 
     if (!isLocalStack) {
       const vpc = ec2.Vpc.fromLookup(this, "Vpc", { vpcName });
@@ -63,6 +64,50 @@ export class PrerequisiteStack extends Stack {
 
     new apigateway.CfnAccount(this, "ApiGatewayRestApiAccount", {
       cloudWatchRoleArn: cloudWatchRole.roleArn,
+    });
+
+    const githubProvider = new iam.CfnOIDCProvider(
+      this,
+      "GitHubIdentityProvider",
+      {
+        url: "https://token.actions.githubusercontent.com",
+        thumbprintList: ["6938fd4d98bab03faadb97b34396831e3780aea1"], // pragma: allowlist secret
+        clientIdList: ["sts.amazonaws.com"],
+      }
+    );
+
+    new iam.CfnRole(this, "GitHubActionsServiceRole", {
+      description: "Service Role for use in GitHub Actions",
+      assumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Sid: "RoleForGitHubActions",
+            Effect: "Allow",
+            Principal: {
+              Federated: githubProvider.attrArn,
+            },
+            Action: ["sts:AssumeRoleWithWebIdentity"],
+            Condition: {
+              StringEquals: {
+                "token.actions.githubusercontent.com:aud": [
+                  "sts.amazonaws.com",
+                ],
+              },
+              StringLike: {
+                "token.actions.githubusercontent.com:sub": [
+                  `repo:Enterprise-CMCS/macpro-mdct-mfp:${branchFilter}`,
+                ],
+              },
+            },
+          },
+        ],
+      },
+      managedPolicyArns: [
+        `arn:aws:iam::${Aws.ACCOUNT_ID}:policy/ADO-Restriction-Policy`,
+        `arn:aws:iam::${Aws.ACCOUNT_ID}:policy/CMSApprovedAWSServices`,
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+      ],
     });
   }
 }


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
Moving github actions oidc role creation into our modern way of handling the need for assets that need to be in AWS account

### Related ticket(s)
CMDCT-5115

---

### How to test
NA - app still deploys is proof enough

### Notes
NA
---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
