### PR TITLE
Update drawer information organization for accessibility

### DIFF
--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -35,12 +35,6 @@ export const Drawer = ({
       <DrawerOverlay />
       <DrawerContent sx={sx.drawerContent} className={mqClasses}>
         <DrawerHeader sx={sx.drawerHeader}>
-          <Text sx={sx.drawerHeaderText}>{verbiage.drawerTitle}</Text>
-          {verbiage.drawerInfo && (
-            <Box sx={sx.infoTextBox}>
-              {parseCustomHtml(verbiage.drawerInfo)}
-            </Box>
-          )}
           <Button
             sx={sx.drawerCloseButton}
             leftIcon={<CloseIcon />}
@@ -50,7 +44,15 @@ export const Drawer = ({
             Close
           </Button>
         </DrawerHeader>
-        <DrawerBody sx={sx.drawerBody}>{children}</DrawerBody>
+        <DrawerBody sx={sx.drawerBody}>
+          <Text sx={sx.drawerHeaderText}>{verbiage.drawerTitle}</Text>
+          {verbiage.drawerInfo && (
+            <Box sx={sx.infoTextBox}>
+              {parseCustomHtml(verbiage.drawerInfo)}
+            </Box>
+          )}
+          {children}
+        </DrawerBody>
       </DrawerContent>
     </ChakraDrawer>
   );


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Move drawer header content to the drawer body definition.

Why? The drawer header (managed by chakra) sticks to the top of the drawer. When zoomed in, or on small screens, the header can take up the entire page and not let users view the rest of the drawer body (see for yourself in dev or val). By moving this content to the body, users can scroll past it and get to the form fields. The close button remains in the header so its usable at all times, at the cost of occasionally overlapping with text in the rest of the drawer.

Drawbacks:
- Can no longer view header content from anywhere in the drawer (if it's a long form)
- Close button can overlap text when scrolling

This change addresses an accessibility concern and the drawbacks noted are considered acceptable. Without this change, the drawer is unusable when zoomed in.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4637

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[deployed url](https://d2pqwcuw3dbhea.cloudfront.net/)
- Log in as a state user
- Create or enter a WP
- Go to Transition Benchmarks
- Open any drawer
- Zoom in on page
- At some point you’ll get a scrollbar for the whole drawer except the close button at the top
- Select "Yes" and enter numbers for a drawer
- Verify when you scroll the header scrolls out of view but "close" stays in view
- Verify you can still interact with the drawer in every way you could before

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
