### PR TITLE
WP Initiative close-out section

### DIFF
--- a/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
+++ b/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
@@ -410,7 +410,7 @@ export const initiativesRoute: WPStateOrTerritorySpecificInitiativesV2Route = {
       // Close-out
       {
         forCopyoverOnly: true,
-        id: "defineInitiative_projectedEndDate_value",
+        id: "defineInitiative_endDate",
         type: ReportFormFieldType.DATE,
         validation: ValidationType.TEXT_OPTIONAL,
         props: {
@@ -419,6 +419,8 @@ export const initiativesRoute: WPStateOrTerritorySpecificInitiativesV2Route = {
           label: "Projected end date",
           styleAsOptional: true,
           styleTitleAsOptional: true,
+          subtitle:
+            "Complete for initiatives that end during the upcoming semi-annual reporting period.",
           title: "Close-out {{initiativeName}}",
         },
       },
@@ -634,6 +636,20 @@ export const initiativesRoute: WPStateOrTerritorySpecificInitiativesV2Route = {
 
     // Overlay
     backButtonText: "Return to all initiatives",
+    errorMessage: {
+      description: [
+        {
+          type: "p",
+          content:
+            "This initiative will be closed out and will no longer be editable. You will be able to continue to view this response. If you are not ready to close out an initiative, remove the data in this section.",
+        },
+        {
+          type: "p",
+          content: "This action cannot be undone.",
+        },
+      ],
+      title: "Warning",
+    },
 
     // Table
     editEntityButtonText: "Edit name/topic",

--- a/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
+++ b/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
@@ -410,9 +410,9 @@ export const initiativesRoute: WPStateOrTerritorySpecificInitiativesV2Route = {
       // Close-out
       {
         forCopyoverOnly: true,
-        id: "defineInitiative_endDate",
+        id: "closeOutInformation_projectedEndDate",
         type: ReportFormFieldType.DATE,
-        validation: ValidationType.TEXT_OPTIONAL,
+        validation: ValidationType.DATE_OPTIONAL,
         props: {
           disabled: true,
           hint: "Auto-populates from “I. Define initiative”.",

--- a/services/app-api/utils/data/data.ts
+++ b/services/app-api/utils/data/data.ts
@@ -46,13 +46,14 @@ export const removeNotApplicablePopsFromInitiatives = (
    * to the MFP demonstration, we need to look through the initiatives
    * and remove it from the data
    */
-  for (let initiative of initiatives) {
-    initiative.defineInitiative_targetPopulations =
-      initiative.defineInitiative_targetPopulations?.filter(
-        (initiativePopulation: AnyObject) =>
-          !notApplicablePopulationNames.includes(initiativePopulation.value) ||
-          DEFAULT_TARGET_POPULATION_NAMES.includes(initiativePopulation.value)
-      );
+  for (const initiative of initiatives) {
+    initiative.defineInitiative_targetPopulations = (
+      initiative.defineInitiative_targetPopulations || []
+    ).filter(
+      (initiativePopulation: AnyObject) =>
+        !notApplicablePopulationNames.includes(initiativePopulation.value) ||
+        DEFAULT_TARGET_POPULATION_NAMES.includes(initiativePopulation.value)
+    );
   }
 
   // Now set and return the cleaned up data!

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -12,6 +12,7 @@ import {
   FormTemplateVersion,
   OverlayModalPageShape,
   PageTypes,
+  ReportFormFieldType,
   ReportJson,
   ReportJsonFile,
   ReportRoute,
@@ -262,8 +263,11 @@ export function isFieldElement(
    * This function is duplicated in ui-src/src/types/formFields.ts
    * If you change it here, change it there!
    */
-  const formLayoutElementTypes = ["sectionHeader", "sectionContent"];
-  return !formLayoutElementTypes.includes(field.type);
+  const formLayoutElementTypes = [
+    ReportFormFieldType.SECTION_HEADER,
+    ReportFormFieldType.SECTION_CONTENT,
+  ];
+  return !formLayoutElementTypes.includes(field.type as ReportFormFieldType);
 }
 
 export function isLayoutElement(

--- a/services/app-api/utils/other/copy.test.ts
+++ b/services/app-api/utils/other/copy.test.ts
@@ -6,7 +6,15 @@ import {
   FormField,
   PageTypes,
   ReportType,
+  ValidationType,
 } from "../types";
+import * as LD from "@launchdarkly/node-server-sdk";
+
+jest.mock("@launchdarkly/node-server-sdk", () => ({
+  init: jest.fn(),
+}));
+const waitForInitialization = jest.fn().mockResolvedValue(undefined);
+const variation = jest.fn().mockResolvedValue(true);
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
@@ -15,6 +23,12 @@ jest.mock("../../storage/reports", () => ({
 describe("Field data copy", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.launchDarklyServer = "mock-sdk-key";
+
+    (LD.init as jest.Mock).mockReturnValue({
+      variation,
+      waitForInitialization,
+    });
   });
 
   test("Should copy validated fields", async () => {
@@ -29,7 +43,7 @@ describe("Field data copy", () => {
             fields: [
               {
                 id: "mockFieldId",
-                validation: "number",
+                validation: ValidationType.NUMBER,
               },
             ],
           },
@@ -49,6 +63,7 @@ describe("Field data copy", () => {
     });
   });
 
+  // TODO: Investigate this comment
   test("Should overwrite populated fields, apparently", async () => {
     (getReportFieldData as jest.Mock).mockResolvedValueOnce({
       mockFieldId: "42",
@@ -63,7 +78,7 @@ describe("Field data copy", () => {
             fields: [
               {
                 id: "mockFieldId",
-                validation: "number",
+                validation: ValidationType.NUMBER,
               },
             ],
           },
@@ -130,6 +145,17 @@ describe("Field data copy", () => {
       mockEntityType: [
         {
           mockFieldId: "42",
+          defineInitiative_mockId: "mock",
+          evaluationPlan: [
+            {
+              id: "mockEvaluationPlan",
+            },
+          ],
+          fundingSources: [
+            {
+              id: "mockFundingSource",
+            },
+          ],
         },
       ],
     });
@@ -143,7 +169,15 @@ describe("Field data copy", () => {
             fields: [
               {
                 id: "mockFieldId",
-                validation: "number",
+                validation: ValidationType.NUMBER,
+              },
+              {
+                id: "defineInitiative_mockId",
+                validation: ValidationType.TEXT,
+              },
+              {
+                id: "evaluationPlan",
+                validation: ValidationType.NUMBER,
               },
             ],
           },
@@ -176,7 +210,6 @@ describe("Field data copy", () => {
           value: "mock value",
           id: "mock id",
           type: "mock type",
-          isOtherEntity: "mock is other",
           isRequired: "mock is required",
           isInitiativeClosed: false,
         },
@@ -212,7 +245,6 @@ describe("Field data copy", () => {
           value: "mock value",
           id: "mock id",
           type: "mock type",
-          isOtherEntity: "mock is other",
           isRequired: "mock is required",
           isInitiativeClosed: false,
           isCopied: true,
@@ -240,7 +272,7 @@ describe("Field data copy", () => {
             fields: [
               {
                 id: "mockFieldId",
-                validation: "number",
+                validation: ValidationType.NUMBER,
               },
             ],
           },
@@ -255,6 +287,7 @@ describe("Field data copy", () => {
       fieldData
     );
 
+    // TODO: Investigate this comment
     // I think this is a bug actually. Probably it should not copy this entity.
     expect(copiedData).toEqual({ mockEntityType: [] });
   });
@@ -315,7 +348,7 @@ describe("Field data copy", () => {
             fields: [
               {
                 id: "mockFieldId",
-                validation: "number",
+                validation: ValidationType.NUMBER,
               },
             ],
           },

--- a/services/app-api/utils/other/copy.test.ts
+++ b/services/app-api/utils/other/copy.test.ts
@@ -14,11 +14,17 @@ jest.mock("@launchdarkly/node-server-sdk", () => ({
   init: jest.fn(),
 }));
 const waitForInitialization = jest.fn().mockResolvedValue(undefined);
-const variation = jest.fn().mockResolvedValue(true);
+const variation = jest.fn().mockResolvedValue(false);
 
 jest.mock("../../storage/reports", () => ({
   getReportFieldData: jest.fn(),
 }));
+
+const consoleSpy: {
+  log: jest.SpyInstance<void>;
+} = {
+  log: jest.spyOn(console, "log").mockImplementation(),
+};
 
 describe("Field data copy", () => {
   beforeEach(() => {
@@ -538,5 +544,140 @@ describe("Field data copy", () => {
         await runFinancialCopyCase(sourceFieldData, expected, [fieldId]);
       }
     );
+  });
+
+  describe("Copy initiative", () => {
+    const formTemplate = {
+      type: ReportType.WP,
+      routes: [
+        {
+          pageType: PageTypes.MODAL_DRAWER,
+          entityType: "mockEntityType",
+          drawerForm: {
+            fields: [
+              {
+                id: "mockFieldId",
+                validation: ValidationType.NUMBER,
+              },
+            ],
+          },
+        },
+      ],
+    } as ReportJson;
+
+    const mockInitiative = {
+      mockEntityType: [
+        {
+          mockSteps: [
+            {
+              mockFieldId: "mockStepId",
+              initiative_name: "Mock initiative name",
+              initiative_wpTopic: [
+                {
+                  key: "mockId",
+                  value: "Mock topic",
+                },
+              ],
+              defineInitiative_mock: "Mock description",
+            },
+          ],
+          evaluationPlan: [
+            {
+              id: "mockEvaluationPlanId",
+              value: "Mock value",
+            },
+          ],
+          fundingSources: [
+            {
+              id: "mockFundingSourceId",
+              value: "Mock value",
+            },
+          ],
+        },
+      ],
+    };
+
+    test("copy entire initiative with flag off", async () => {
+      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiative);
+      const copiedData = await copyFieldDataFromSource(
+        "CO",
+        "mock-source-id",
+        formTemplate,
+        {}
+      );
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(copiedData).toEqual({
+        mockEntityType: [
+          {
+            mockSteps: [
+              {
+                mockFieldId: "mockStepId",
+                initiative_name: "Mock initiative name",
+                initiative_wpTopic: [
+                  {
+                    key: "mockId",
+                    value: "Mock topic",
+                    isCopied: true,
+                  },
+                ],
+                defineInitiative_mock: "Mock description",
+                isCopied: true,
+              },
+            ],
+            evaluationPlan: [
+              {
+                id: "mockEvaluationPlanId",
+                value: "Mock value",
+                isCopied: true,
+              },
+            ],
+            fundingSources: [
+              {
+                id: "mockFundingSourceId",
+                value: "Mock value",
+                isCopied: true,
+              },
+            ],
+            isCopied: true,
+          },
+        ],
+      });
+    });
+
+    test("copy only initiative name and topic with flag on", async () => {
+      (LD.init as jest.Mock).mockReturnValue({
+        variation: jest.fn().mockResolvedValue(true),
+        waitForInitialization,
+      });
+      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiative);
+      const copiedData = await copyFieldDataFromSource(
+        "CO",
+        "mock-source-id",
+        formTemplate,
+        {}
+      );
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(copiedData).toEqual({
+        mockEntityType: [
+          {
+            mockSteps: [
+              {
+                mockFieldId: "mockStepId",
+                initiative_name: "Mock initiative name",
+                initiative_wpTopic: [
+                  {
+                    key: "mockId",
+                    value: "Mock topic",
+                    isCopied: true,
+                  },
+                ],
+                isCopied: true,
+              },
+            ],
+            isCopied: true,
+          },
+        ],
+      });
+    });
   });
 });

--- a/services/app-api/utils/other/copy.test.ts
+++ b/services/app-api/utils/other/copy.test.ts
@@ -566,78 +566,8 @@ describe("Field data copy", () => {
       ],
     } as ReportJson;
 
-    const mockInitiativeV1 = {
-      initiative: [
-        {
-          id: "mockInitiativeId",
-          initiative_name: "Mock Initiative",
-          initiative_wp_otherTopic: "",
-          initiative_wpTopic: [
-            {
-              key: "initiative_wpTopic-mockTopicId",
-              value: "Mock topic",
-            },
-          ],
-          type: EntityType.INITIATIVE,
-          defineInitiative_mockField: "Mock description",
-          evaluationPlan: [
-            {
-              id: "mockEvaluationPlanId",
-            },
-          ],
-          fundingSources: [
-            {
-              id: "mockFundingSourceId",
-            },
-          ],
-        },
-      ],
-    };
-
-    const mockInitiativeV2 = {
-      initiative: [
-        {
-          id: "mockInitiativeId",
-          initiative_name: "Mock Initiative",
-          initiative_wp_otherTopic: "",
-          initiative_wpTopic: [
-            {
-              key: "initiative_wpTopic-mockTopicId",
-              value: "Mock topic",
-            },
-          ],
-          type: EntityType.INITIATIVE,
-          defineInitiative_mockField: "Mock description",
-          defineInitiative_mockTable_mocks: [
-            {
-              id: "mockId",
-              mockField: "Mock value",
-              mockChoice: [
-                {
-                  key: "mockChoice-mockChoiceId",
-                  value: "Mock choice",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
-    test("copy entire initiative v1 with flag off", async () => {
-      (LD.init as jest.Mock).mockReturnValue({
-        variation,
-        waitForInitialization,
-      });
-      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV1);
-      const copiedData = await copyFieldDataFromSource(
-        "CO",
-        "mock-source-id",
-        formTemplate,
-        {}
-      );
-      expect(consoleSpy.log).toHaveBeenCalled();
-      expect(copiedData).toEqual({
+    describe("initiativeV1", () => {
+      const mockInitiativeV1 = {
         initiative: [
           {
             id: "mockInitiativeId",
@@ -647,7 +577,6 @@ describe("Field data copy", () => {
               {
                 key: "initiative_wpTopic-mockTopicId",
                 value: "Mock topic",
-                isCopied: true,
               },
             ],
             type: EntityType.INITIATIVE,
@@ -655,35 +584,103 @@ describe("Field data copy", () => {
             evaluationPlan: [
               {
                 id: "mockEvaluationPlanId",
-                isCopied: true,
               },
             ],
             fundingSources: [
               {
                 id: "mockFundingSourceId",
-                isCopied: true,
               },
             ],
-            isCopied: true,
           },
         ],
+      };
+
+      test("copy entire initiative v1 with flag off", async () => {
+        (LD.init as jest.Mock).mockReturnValue({
+          variation,
+          waitForInitialization,
+        });
+        (getReportFieldData as jest.Mock).mockResolvedValueOnce(
+          mockInitiativeV1
+        );
+        const copiedData = await copyFieldDataFromSource(
+          "CO",
+          "mock-source-id",
+          formTemplate,
+          {}
+        );
+        expect(consoleSpy.log).toHaveBeenCalled();
+        expect(copiedData).toEqual({
+          initiative: [
+            {
+              id: "mockInitiativeId",
+              initiative_name: "Mock Initiative",
+              initiative_wp_otherTopic: "",
+              initiative_wpTopic: [
+                {
+                  key: "initiative_wpTopic-mockTopicId",
+                  value: "Mock topic",
+                  isCopied: true,
+                },
+              ],
+              type: EntityType.INITIATIVE,
+              defineInitiative_mockField: "Mock description",
+              evaluationPlan: [
+                {
+                  id: "mockEvaluationPlanId",
+                  isCopied: true,
+                },
+              ],
+              fundingSources: [
+                {
+                  id: "mockFundingSourceId",
+                  isCopied: true,
+                },
+              ],
+              isCopied: true,
+            },
+          ],
+        });
+      });
+
+      test("copy only initiative v1 name and topic with flag on", async () => {
+        (LD.init as jest.Mock).mockReturnValue({
+          variation: jest.fn().mockResolvedValue(true),
+          waitForInitialization,
+        });
+        (getReportFieldData as jest.Mock).mockResolvedValueOnce(
+          mockInitiativeV1
+        );
+        const copiedData = await copyFieldDataFromSource(
+          "CO",
+          "mock-source-id",
+          formTemplate,
+          {}
+        );
+        expect(consoleSpy.log).toHaveBeenCalled();
+        expect(copiedData).toEqual({
+          initiative: [
+            {
+              id: "mockInitiativeId",
+              initiative_name: "Mock Initiative",
+              initiative_wp_otherTopic: "",
+              initiative_wpTopic: [
+                {
+                  key: "initiative_wpTopic-mockTopicId",
+                  value: "Mock topic",
+                  isCopied: true,
+                },
+              ],
+              type: EntityType.INITIATIVE,
+              isCopied: true,
+            },
+          ],
+        });
       });
     });
 
-    test("copy only initiative v1 name and topic with flag on", async () => {
-      (LD.init as jest.Mock).mockReturnValue({
-        variation: jest.fn().mockResolvedValue(true),
-        waitForInitialization,
-      });
-      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV1);
-      const copiedData = await copyFieldDataFromSource(
-        "CO",
-        "mock-source-id",
-        formTemplate,
-        {}
-      );
-      expect(consoleSpy.log).toHaveBeenCalled();
-      expect(copiedData).toEqual({
+    describe("initiativeV2", () => {
+      const mockInitiativeV2 = {
         initiative: [
           {
             id: "mockInitiativeId",
@@ -693,30 +690,27 @@ describe("Field data copy", () => {
               {
                 key: "initiative_wpTopic-mockTopicId",
                 value: "Mock topic",
-                isCopied: true,
               },
             ],
             type: EntityType.INITIATIVE,
-            isCopied: true,
+            defineInitiative_mockField: "Mock description",
+            defineInitiative_mockTable_mocks: [
+              {
+                id: "mockId",
+                mockField: "Mock value",
+                mockChoice: [
+                  {
+                    key: "mockChoice-mockChoiceId",
+                    value: "Mock choice",
+                  },
+                ],
+              },
+            ],
           },
         ],
-      });
-    });
+      };
 
-    test("copy entire initiative v2 with flag off", async () => {
-      (LD.init as jest.Mock).mockReturnValue({
-        variation,
-        waitForInitialization,
-      });
-      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV2);
-      const copiedData = await copyFieldDataFromSource(
-        "CO",
-        "mock-source-id",
-        formTemplate,
-        {}
-      );
-      expect(consoleSpy.log).toHaveBeenCalled();
-      expect(copiedData).toEqual({
+      const expectedResult = {
         initiative: [
           {
             id: "mockInitiativeId",
@@ -748,6 +742,42 @@ describe("Field data copy", () => {
             isCopied: true,
           },
         ],
+      };
+
+      test("copy entire initiative v2 with flag on", async () => {
+        (LD.init as jest.Mock).mockReturnValue({
+          variation: jest.fn().mockResolvedValue(true),
+          waitForInitialization,
+        });
+        (getReportFieldData as jest.Mock).mockResolvedValueOnce(
+          mockInitiativeV2
+        );
+        const copiedData = await copyFieldDataFromSource(
+          "CO",
+          "mock-source-id",
+          formTemplate,
+          {}
+        );
+        expect(consoleSpy.log).toHaveBeenCalled();
+        expect(copiedData).toEqual(expectedResult);
+      });
+
+      test("copy entire initiative v2 with flag off", async () => {
+        (LD.init as jest.Mock).mockReturnValue({
+          variation,
+          waitForInitialization,
+        });
+        (getReportFieldData as jest.Mock).mockResolvedValueOnce(
+          mockInitiativeV2
+        );
+        const copiedData = await copyFieldDataFromSource(
+          "CO",
+          "mock-source-id",
+          formTemplate,
+          {}
+        );
+        expect(consoleSpy.log).toHaveBeenCalled();
+        expect(copiedData).toEqual(expectedResult);
       });
     });
   });

--- a/services/app-api/utils/other/copy.test.ts
+++ b/services/app-api/utils/other/copy.test.ts
@@ -7,6 +7,7 @@ import {
   PageTypes,
   ReportType,
   ValidationType,
+  EntityType,
 } from "../types";
 import * as LD from "@launchdarkly/node-server-sdk";
 
@@ -552,12 +553,12 @@ describe("Field data copy", () => {
       routes: [
         {
           pageType: PageTypes.MODAL_DRAWER,
-          entityType: "mockEntityType",
+          entityType: EntityType.INITIATIVE,
           drawerForm: {
             fields: [
               {
-                id: "mockFieldId",
-                validation: ValidationType.NUMBER,
+                id: "defineInitiative_mockField",
+                validation: ValidationType.TEXT,
               },
             ],
           },
@@ -565,40 +566,70 @@ describe("Field data copy", () => {
       ],
     } as ReportJson;
 
-    const mockInitiative = {
-      mockEntityType: [
+    const mockInitiativeV1 = {
+      initiative: [
         {
-          mockSteps: [
+          id: "mockInitiativeId",
+          initiative_name: "Mock Initiative",
+          initiative_wp_otherTopic: "",
+          initiative_wpTopic: [
             {
-              mockFieldId: "mockStepId",
-              initiative_name: "Mock initiative name",
-              initiative_wpTopic: [
-                {
-                  key: "mockId",
-                  value: "Mock topic",
-                },
-              ],
-              defineInitiative_mock: "Mock description",
+              key: "initiative_wpTopic-mockTopicId",
+              value: "Mock topic",
             },
           ],
+          type: EntityType.INITIATIVE,
+          defineInitiative_mockField: "Mock description",
           evaluationPlan: [
             {
               id: "mockEvaluationPlanId",
-              value: "Mock value",
             },
           ],
           fundingSources: [
             {
               id: "mockFundingSourceId",
-              value: "Mock value",
             },
           ],
         },
       ],
     };
 
-    test("copy entire initiative with flag off", async () => {
-      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiative);
+    const mockInitiativeV2 = {
+      initiative: [
+        {
+          id: "mockInitiativeId",
+          initiative_name: "Mock Initiative",
+          initiative_wp_otherTopic: "",
+          initiative_wpTopic: [
+            {
+              key: "initiative_wpTopic-mockTopicId",
+              value: "Mock topic",
+            },
+          ],
+          type: EntityType.INITIATIVE,
+          defineInitiative_mockField: "Mock description",
+          defineInitiative_mockTable_mocks: [
+            {
+              id: "mockId",
+              mockField: "Mock value",
+              mockChoice: [
+                {
+                  key: "mockChoice-mockChoiceId",
+                  value: "Mock choice",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    test("copy entire initiative v1 with flag off", async () => {
+      (LD.init as jest.Mock).mockReturnValue({
+        variation,
+        waitForInitialization,
+      });
+      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV1);
       const copiedData = await copyFieldDataFromSource(
         "CO",
         "mock-source-id",
@@ -607,34 +638,29 @@ describe("Field data copy", () => {
       );
       expect(consoleSpy.log).toHaveBeenCalled();
       expect(copiedData).toEqual({
-        mockEntityType: [
+        initiative: [
           {
-            mockSteps: [
+            id: "mockInitiativeId",
+            initiative_name: "Mock Initiative",
+            initiative_wp_otherTopic: "",
+            initiative_wpTopic: [
               {
-                mockFieldId: "mockStepId",
-                initiative_name: "Mock initiative name",
-                initiative_wpTopic: [
-                  {
-                    key: "mockId",
-                    value: "Mock topic",
-                    isCopied: true,
-                  },
-                ],
-                defineInitiative_mock: "Mock description",
+                key: "initiative_wpTopic-mockTopicId",
+                value: "Mock topic",
                 isCopied: true,
               },
             ],
+            type: EntityType.INITIATIVE,
+            defineInitiative_mockField: "Mock description",
             evaluationPlan: [
               {
                 id: "mockEvaluationPlanId",
-                value: "Mock value",
                 isCopied: true,
               },
             ],
             fundingSources: [
               {
                 id: "mockFundingSourceId",
-                value: "Mock value",
                 isCopied: true,
               },
             ],
@@ -644,12 +670,12 @@ describe("Field data copy", () => {
       });
     });
 
-    test("copy only initiative name and topic with flag on", async () => {
+    test("copy only initiative v1 name and topic with flag on", async () => {
       (LD.init as jest.Mock).mockReturnValue({
         variation: jest.fn().mockResolvedValue(true),
         waitForInitialization,
       });
-      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiative);
+      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV1);
       const copiedData = await copyFieldDataFromSource(
         "CO",
         "mock-source-id",
@@ -658,16 +684,61 @@ describe("Field data copy", () => {
       );
       expect(consoleSpy.log).toHaveBeenCalled();
       expect(copiedData).toEqual({
-        mockEntityType: [
+        initiative: [
           {
-            mockSteps: [
+            id: "mockInitiativeId",
+            initiative_name: "Mock Initiative",
+            initiative_wp_otherTopic: "",
+            initiative_wpTopic: [
               {
-                mockFieldId: "mockStepId",
-                initiative_name: "Mock initiative name",
-                initiative_wpTopic: [
+                key: "initiative_wpTopic-mockTopicId",
+                value: "Mock topic",
+                isCopied: true,
+              },
+            ],
+            type: EntityType.INITIATIVE,
+            isCopied: true,
+          },
+        ],
+      });
+    });
+
+    test("copy entire initiative v2 with flag off", async () => {
+      (LD.init as jest.Mock).mockReturnValue({
+        variation,
+        waitForInitialization,
+      });
+      (getReportFieldData as jest.Mock).mockResolvedValueOnce(mockInitiativeV2);
+      const copiedData = await copyFieldDataFromSource(
+        "CO",
+        "mock-source-id",
+        formTemplate,
+        {}
+      );
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(copiedData).toEqual({
+        initiative: [
+          {
+            id: "mockInitiativeId",
+            initiative_name: "Mock Initiative",
+            initiative_wp_otherTopic: "",
+            initiative_wpTopic: [
+              {
+                key: "initiative_wpTopic-mockTopicId",
+                value: "Mock topic",
+                isCopied: true,
+              },
+            ],
+            type: EntityType.INITIATIVE,
+            defineInitiative_mockField: "Mock description",
+            defineInitiative_mockTable_mocks: [
+              {
+                id: "mockId",
+                mockField: "Mock value",
+                mockChoice: [
                   {
-                    key: "mockId",
-                    value: "Mock topic",
+                    key: "mockChoice-mockChoiceId",
+                    value: "Mock choice",
                     isCopied: true,
                   },
                 ],

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -1,4 +1,5 @@
 import { getReportFieldData } from "../../storage/reports";
+import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
 import { getPossibleFieldsFromFormTemplate } from "../formTemplates/formTemplates";
 import { ReportFieldData, ReportJson, ReportType, State } from "../types";
 
@@ -15,7 +16,6 @@ import { ReportFieldData, ReportJson, ReportType, State } from "../types";
 const additionalFields = [
   "id",
   "type",
-  "isOtherEntity",
   "isRequired",
   "isCopied",
   "isInitiativeClosed",
@@ -71,59 +71,95 @@ const isExcludedFinancialReportNormalizedField = (
   );
 };
 
-const shouldExcludeCopiedField = (
+const isExcludedInitiativeField = async (fieldKey: string) => {
+  const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
+  if (!wpSarRelease2025) return false;
+
+  return (
+    fieldKey.startsWith("defineInitiative") ||
+    ["evaluationPlan", "fundingSources"].includes(fieldKey)
+  );
+};
+
+const shouldExcludeCopiedField = async (
   reportType: ReportType | undefined,
   fieldKey: string,
   entityType?: string
 ) => {
-  if (reportType !== ReportType.FINANCIAL_REPORT) return false;
-  const normalizedFieldName = getFieldKeySuffix(fieldKey);
-  const entityExcludedFields = entityType
-    ? (financialReportEntityExcludedNormalizedFieldNames[entityType] ?? [])
-    : [];
+  switch (reportType) {
+    case ReportType.WP:
+      return await isExcludedInitiativeField(fieldKey);
+    case ReportType.FINANCIAL_REPORT: {
+      const normalizedFieldName = getFieldKeySuffix(fieldKey);
+      const entityExcludedFields = entityType
+        ? (financialReportEntityExcludedNormalizedFieldNames[entityType] ?? [])
+        : [];
 
-  return (
-    financialReportExcludedFieldIds.includes(fieldKey) ||
-    isFinancialReportCommentField(fieldKey) ||
-    isExcludedFinancialReportNormalizedField(
-      normalizedFieldName,
-      entityExcludedFields
-    )
-  );
+      return (
+        financialReportExcludedFieldIds.includes(fieldKey) ||
+        isFinancialReportCommentField(fieldKey) ||
+        isExcludedFinancialReportNormalizedField(
+          normalizedFieldName,
+          entityExcludedFields
+        )
+      );
+    }
+    default:
+      return false;
+  }
 };
 
-const shouldExcludeCopiedEntityField = (
+const shouldExcludeCopiedEntityField = async (
   reportType: ReportType | undefined,
   fieldKey: string
 ) => {
-  if (reportType !== ReportType.FINANCIAL_REPORT) return true;
-
-  const normalizedFieldName = getFieldKeySuffix(fieldKey);
-  return !financialReportEntityIncludedNormalizedFieldNames.includes(
-    normalizedFieldName
-  );
+  switch (reportType) {
+    case ReportType.WP:
+      return await isExcludedInitiativeField(fieldKey);
+    case ReportType.FINANCIAL_REPORT: {
+      const normalizedFieldName = getFieldKeySuffix(fieldKey);
+      return !financialReportEntityIncludedNormalizedFieldNames.includes(
+        normalizedFieldName
+      );
+    }
+    default:
+      return true;
+  }
 };
 
-function pruneEntityData(
+const isNameField = (entityKey: string) => entityKey.includes("name");
+const isChoiceField = (entityKey: string) =>
+  ["key", "value"].includes(entityKey);
+
+async function pruneEntityData(
   sourceFieldData: ReportFieldData,
   key: string,
   entityData: ReportFieldData[],
   possibleFields: string[],
   reportType?: ReportType
 ) {
-  //adding fields to be copied over from entries
+  // adding fields to be copied over from entries
   const concatEntityFields = [...possibleFields, ...additionalFields];
-  entityData.forEach((entity, index) => {
+
+  for (const [index, entity] of entityData.entries()) {
     // Delete any key existing in the source data not valid in our template, or any entity key that's not a name.
     if (!concatEntityFields.includes(key)) {
       delete sourceFieldData[key];
-      return;
+      continue;
     }
 
-    Object.keys(entity).forEach((entityKey) => {
-      //check to see if the object is an array, this is for capturing substeps in the initiatives
-      if (Array.isArray(entity[entityKey])) {
-        pruneEntityData(
+    for (const entityKey of Object.keys(entity)) {
+      /**
+       * Check to see if the object is an array,
+       * this is for capturing entitySteps in initiatives v1
+       *
+       * In initiatives v2, only name and topic are copied
+       */
+      if (
+        Array.isArray(entity[entityKey]) &&
+        !(await isExcludedInitiativeField(entityKey))
+      ) {
+        await pruneEntityData(
           sourceFieldData,
           key,
           entity[entityKey] as ReportFieldData[],
@@ -131,27 +167,27 @@ function pruneEntityData(
           reportType
         );
       } else if (
-        shouldExcludeCopiedField(reportType, entityKey, key) ||
-        (shouldExcludeCopiedEntityField(reportType, entityKey) &&
-          !entityKey.includes("name") &&
-          !concatEntityFields.includes(entityKey) &&
-          !["key", "value"].includes(entityKey))
+        (await shouldExcludeCopiedField(reportType, entityKey, key)) ||
+        ((await shouldExcludeCopiedEntityField(reportType, entityKey)) &&
+          !isNameField(entityKey) &&
+          !isChoiceField(entityKey) &&
+          !concatEntityFields.includes(entityKey))
       ) {
         delete entityData[index][entityKey];
       }
-    });
+    }
 
     if (Object.keys(entity).length === 0) {
       delete entityData[index];
     } else {
-      entityData[index]["isCopied"] = true;
+      entityData[index].isCopied = true;
     }
-  });
+  }
 
-  //filter out any closeout data
+  // filter out any closeout data
   if (Array.isArray(sourceFieldData[key])) {
     const filteredData = (sourceFieldData[key] as ReportFieldData[]).filter(
-      (field) => !field["isInitiativeClosed"]
+      (field) => !field.isInitiativeClosed
     );
     sourceFieldData[key] = filteredData;
   }
@@ -175,15 +211,16 @@ export async function copyFieldDataFromSource(
 
   if (sourceFieldData) {
     const possibleFields = getPossibleFieldsFromFormTemplate(formTemplate);
-    Object.keys(sourceFieldData).forEach((key: string) => {
-      if (shouldExcludeCopiedField(formTemplate.type, key)) {
+
+    for (const key of Object.keys(sourceFieldData)) {
+      if (await shouldExcludeCopiedField(formTemplate.type, key)) {
         delete sourceFieldData[key];
-        return;
+        continue;
       }
 
       // Only iterate through entities, not choice lists
       if (Array.isArray(sourceFieldData[key])) {
-        pruneEntityData(
+        await pruneEntityData(
           sourceFieldData,
           key,
           sourceFieldData[key] as ReportFieldData[],
@@ -193,7 +230,7 @@ export async function copyFieldDataFromSource(
       } else if (!possibleFields.includes(key)) {
         delete sourceFieldData[key];
       }
-    });
+    }
 
     Object.assign(validatedFieldData, sourceFieldData);
   }

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -1,5 +1,5 @@
 import { getReportFieldData } from "../../storage/reports";
-import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
+// import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
 import { getPossibleFieldsFromFormTemplate } from "../formTemplates/formTemplates";
 import { ReportFieldData, ReportJson, ReportType, State } from "../types";
 
@@ -71,14 +71,15 @@ const isExcludedFinancialReportNormalizedField = (
   );
 };
 
-const isExcludedInitiativeField = async (fieldKey: string) => {
-  const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
-  if (!wpSarRelease2025) return false;
+const isExcludedInitiativeField = async (_fieldKey: string) => {
+  return false;
+  // const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
+  // if (!wpSarRelease2025) return false;
 
-  return (
-    fieldKey.startsWith("defineInitiative") ||
-    ["evaluationPlan", "fundingSources"].includes(fieldKey)
-  );
+  // return (
+  //   fieldKey.startsWith("defineInitiative") ||
+  //   ["evaluationPlan", "fundingSources"].includes(fieldKey)
+  // );
 };
 
 const shouldExcludeCopiedField = async (

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -1,5 +1,5 @@
 import { getReportFieldData } from "../../storage/reports";
-// import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
+import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
 import { getPossibleFieldsFromFormTemplate } from "../formTemplates/formTemplates";
 import { ReportFieldData, ReportJson, ReportType, State } from "../types";
 
@@ -71,25 +71,27 @@ const isExcludedFinancialReportNormalizedField = (
   );
 };
 
-const isExcludedInitiativeField = async (_fieldKey: string) => {
-  return false;
-  // const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
-  // if (!wpSarRelease2025) return false;
+const isExcludedInitiativeField = (
+  fieldKey: string,
+  wpSarRelease2025: boolean
+) => {
+  if (!wpSarRelease2025) return false;
 
-  // return (
-  //   fieldKey.startsWith("defineInitiative") ||
-  //   ["evaluationPlan", "fundingSources"].includes(fieldKey)
-  // );
+  return (
+    fieldKey.startsWith("defineInitiative") ||
+    ["evaluationPlan", "fundingSources"].includes(fieldKey)
+  );
 };
 
-const shouldExcludeCopiedField = async (
+const shouldExcludeCopiedField = (
   reportType: ReportType | undefined,
   fieldKey: string,
-  entityType?: string
+  entityType: string | undefined,
+  wpSarRelease2025: boolean
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return await isExcludedInitiativeField(fieldKey);
+      return isExcludedInitiativeField(fieldKey, wpSarRelease2025);
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       const entityExcludedFields = entityType
@@ -110,13 +112,14 @@ const shouldExcludeCopiedField = async (
   }
 };
 
-const shouldExcludeCopiedEntityField = async (
+const shouldExcludeCopiedEntityField = (
   reportType: ReportType | undefined,
-  fieldKey: string
+  fieldKey: string,
+  wpSarRelease2025: boolean
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return await isExcludedInitiativeField(fieldKey);
+      return isExcludedInitiativeField(fieldKey, wpSarRelease2025);
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       return !financialReportEntityIncludedNormalizedFieldNames.includes(
@@ -137,7 +140,8 @@ async function pruneEntityData(
   key: string,
   entityData: ReportFieldData[],
   possibleFields: string[],
-  reportType?: ReportType
+  reportType: ReportType | undefined,
+  wpSarRelease2025: boolean
 ) {
   // adding fields to be copied over from entries
   const concatEntityFields = [...possibleFields, ...additionalFields];
@@ -158,18 +162,28 @@ async function pruneEntityData(
        */
       if (
         Array.isArray(entity[entityKey]) &&
-        !(await isExcludedInitiativeField(entityKey))
+        !isExcludedInitiativeField(entityKey, wpSarRelease2025)
       ) {
-        await pruneEntityData(
+        pruneEntityData(
           sourceFieldData,
           key,
           entity[entityKey] as ReportFieldData[],
           possibleFields,
-          reportType
+          reportType,
+          wpSarRelease2025
         );
       } else if (
-        (await shouldExcludeCopiedField(reportType, entityKey, key)) ||
-        ((await shouldExcludeCopiedEntityField(reportType, entityKey)) &&
+        shouldExcludeCopiedField(
+          reportType,
+          entityKey,
+          key,
+          wpSarRelease2025
+        ) ||
+        (shouldExcludeCopiedEntityField(
+          reportType,
+          entityKey,
+          wpSarRelease2025
+        ) &&
           !isNameField(entityKey) &&
           !isChoiceField(entityKey) &&
           !concatEntityFields.includes(entityKey))
@@ -204,6 +218,8 @@ export async function copyFieldDataFromSource(
   formTemplate: ReportJson,
   validatedFieldData: ReportFieldData
 ) {
+  const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
+
   const sourceFieldData = await getReportFieldData({
     reportType: formTemplate.type,
     state,
@@ -214,19 +230,27 @@ export async function copyFieldDataFromSource(
     const possibleFields = getPossibleFieldsFromFormTemplate(formTemplate);
 
     for (const key of Object.keys(sourceFieldData)) {
-      if (await shouldExcludeCopiedField(formTemplate.type, key)) {
+      if (
+        shouldExcludeCopiedField(
+          formTemplate.type,
+          key,
+          undefined,
+          wpSarRelease2025
+        )
+      ) {
         delete sourceFieldData[key];
         continue;
       }
 
       // Only iterate through entities, not choice lists
       if (Array.isArray(sourceFieldData[key])) {
-        await pruneEntityData(
+        pruneEntityData(
           sourceFieldData,
           key,
           sourceFieldData[key] as ReportFieldData[],
           possibleFields,
-          formTemplate.type
+          formTemplate.type,
+          wpSarRelease2025
         );
       } else if (!possibleFields.includes(key)) {
         delete sourceFieldData[key];

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -80,9 +80,9 @@ const isExcludedFinancialReportNormalizedField = (
 const isExcludedInitiativeV1Field = (
   fieldKey: string,
   sourceFieldData: ReportFieldData | undefined,
-  wpSarRelease2025: boolean
+  options?: { [key: string]: boolean }
 ) => {
-  if (!sourceFieldData?.[EntityType.INITIATIVE] || !wpSarRelease2025) {
+  if (!sourceFieldData?.[EntityType.INITIATIVE] || !options?.wpSarRelease2025) {
     return false;
   }
 
@@ -103,15 +103,11 @@ const shouldExcludeCopiedField = (
   fieldKey: string,
   entityType: string | undefined,
   sourceFieldData: ReportFieldData,
-  wpSarRelease2025: boolean
+  options?: { [key: string]: boolean }
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return isExcludedInitiativeV1Field(
-        fieldKey,
-        sourceFieldData,
-        wpSarRelease2025
-      );
+      return isExcludedInitiativeV1Field(fieldKey, sourceFieldData, options);
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       const entityExcludedFields = entityType
@@ -136,15 +132,11 @@ const shouldExcludeCopiedEntityField = (
   reportType: ReportType | undefined,
   fieldKey: string,
   sourceFieldData: ReportFieldData,
-  wpSarRelease2025: boolean
+  options?: { [key: string]: boolean }
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return isExcludedInitiativeV1Field(
-        fieldKey,
-        sourceFieldData,
-        wpSarRelease2025
-      );
+      return isExcludedInitiativeV1Field(fieldKey, sourceFieldData, options);
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       return !financialReportEntityIncludedNormalizedFieldNames.includes(
@@ -166,7 +158,7 @@ const pruneEntityData = async (
   entityData: ReportFieldData[],
   possibleFields: string[],
   reportType: ReportType | undefined,
-  wpSarRelease2025: boolean
+  options?: { [key: string]: boolean }
 ) => {
   // adding fields to be copied over from entries
   const concatEntityFields = [...possibleFields, ...additionalFields];
@@ -187,11 +179,7 @@ const pruneEntityData = async (
        */
       if (
         Array.isArray(entity[entityKey]) &&
-        !isExcludedInitiativeV1Field(
-          entityKey,
-          sourceFieldData,
-          wpSarRelease2025
-        )
+        !isExcludedInitiativeV1Field(entityKey, sourceFieldData, options)
       ) {
         pruneEntityData(
           sourceFieldData,
@@ -199,7 +187,7 @@ const pruneEntityData = async (
           entity[entityKey] as ReportFieldData[],
           possibleFields,
           reportType,
-          wpSarRelease2025
+          options
         );
       } else if (
         shouldExcludeCopiedField(
@@ -207,13 +195,13 @@ const pruneEntityData = async (
           entityKey,
           key,
           sourceFieldData,
-          wpSarRelease2025
+          options
         ) ||
         (shouldExcludeCopiedEntityField(
           reportType,
           entityKey,
           sourceFieldData,
-          wpSarRelease2025
+          options
         ) &&
           !isNameField(entityKey) &&
           !isChoiceField(entityKey) &&
@@ -250,6 +238,7 @@ export async function copyFieldDataFromSource(
   validatedFieldData: ReportFieldData
 ) {
   const wpSarRelease2025 = await isFeatureFlagEnabled("wpSarRelease2025");
+  const options = { wpSarRelease2025 };
 
   const sourceFieldData = await getReportFieldData({
     reportType: formTemplate.type,
@@ -267,7 +256,7 @@ export async function copyFieldDataFromSource(
           key,
           undefined,
           sourceFieldData,
-          wpSarRelease2025
+          options
         )
       ) {
         delete sourceFieldData[key];
@@ -282,7 +271,7 @@ export async function copyFieldDataFromSource(
           sourceFieldData[key] as ReportFieldData[],
           possibleFields,
           formTemplate.type,
-          wpSarRelease2025
+          options
         );
       } else if (!possibleFields.includes(key)) {
         delete sourceFieldData[key];

--- a/services/app-api/utils/other/copy.ts
+++ b/services/app-api/utils/other/copy.ts
@@ -1,7 +1,13 @@
 import { getReportFieldData } from "../../storage/reports";
 import { isFeatureFlagEnabled } from "../featureFlags/featureFlags";
 import { getPossibleFieldsFromFormTemplate } from "../formTemplates/formTemplates";
-import { ReportFieldData, ReportJson, ReportType, State } from "../types";
+import {
+  EntityType,
+  ReportFieldData,
+  ReportJson,
+  ReportType,
+  State,
+} from "../types";
 
 /**
  *
@@ -71,11 +77,20 @@ const isExcludedFinancialReportNormalizedField = (
   );
 };
 
-const isExcludedInitiativeField = (
+const isExcludedInitiativeV1Field = (
   fieldKey: string,
+  sourceFieldData: ReportFieldData | undefined,
   wpSarRelease2025: boolean
 ) => {
-  if (!wpSarRelease2025) return false;
+  if (!sourceFieldData?.[EntityType.INITIATIVE] || !wpSarRelease2025) {
+    return false;
+  }
+
+  const hasInitiativeV1 = (
+    sourceFieldData[EntityType.INITIATIVE] as ReportFieldData[]
+  ).some((t) => t.evaluationPlan || t.fundingSources);
+
+  if (!hasInitiativeV1) return false;
 
   return (
     fieldKey.startsWith("defineInitiative") ||
@@ -87,11 +102,16 @@ const shouldExcludeCopiedField = (
   reportType: ReportType | undefined,
   fieldKey: string,
   entityType: string | undefined,
+  sourceFieldData: ReportFieldData,
   wpSarRelease2025: boolean
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return isExcludedInitiativeField(fieldKey, wpSarRelease2025);
+      return isExcludedInitiativeV1Field(
+        fieldKey,
+        sourceFieldData,
+        wpSarRelease2025
+      );
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       const entityExcludedFields = entityType
@@ -115,11 +135,16 @@ const shouldExcludeCopiedField = (
 const shouldExcludeCopiedEntityField = (
   reportType: ReportType | undefined,
   fieldKey: string,
+  sourceFieldData: ReportFieldData,
   wpSarRelease2025: boolean
 ) => {
   switch (reportType) {
     case ReportType.WP:
-      return isExcludedInitiativeField(fieldKey, wpSarRelease2025);
+      return isExcludedInitiativeV1Field(
+        fieldKey,
+        sourceFieldData,
+        wpSarRelease2025
+      );
     case ReportType.FINANCIAL_REPORT: {
       const normalizedFieldName = getFieldKeySuffix(fieldKey);
       return !financialReportEntityIncludedNormalizedFieldNames.includes(
@@ -135,14 +160,14 @@ const isNameField = (entityKey: string) => entityKey.includes("name");
 const isChoiceField = (entityKey: string) =>
   ["key", "value"].includes(entityKey);
 
-async function pruneEntityData(
+const pruneEntityData = async (
   sourceFieldData: ReportFieldData,
   key: string,
   entityData: ReportFieldData[],
   possibleFields: string[],
   reportType: ReportType | undefined,
   wpSarRelease2025: boolean
-) {
+) => {
   // adding fields to be copied over from entries
   const concatEntityFields = [...possibleFields, ...additionalFields];
 
@@ -162,7 +187,11 @@ async function pruneEntityData(
        */
       if (
         Array.isArray(entity[entityKey]) &&
-        !isExcludedInitiativeField(entityKey, wpSarRelease2025)
+        !isExcludedInitiativeV1Field(
+          entityKey,
+          sourceFieldData,
+          wpSarRelease2025
+        )
       ) {
         pruneEntityData(
           sourceFieldData,
@@ -177,11 +206,13 @@ async function pruneEntityData(
           reportType,
           entityKey,
           key,
+          sourceFieldData,
           wpSarRelease2025
         ) ||
         (shouldExcludeCopiedEntityField(
           reportType,
           entityKey,
+          sourceFieldData,
           wpSarRelease2025
         ) &&
           !isNameField(entityKey) &&
@@ -210,7 +241,7 @@ async function pruneEntityData(
   if (entityData.every((e) => e === null)) {
     delete sourceFieldData[key];
   }
-}
+};
 
 export async function copyFieldDataFromSource(
   state: State,
@@ -235,6 +266,7 @@ export async function copyFieldDataFromSource(
           formTemplate.type,
           key,
           undefined,
+          sourceFieldData,
           wpSarRelease2025
         )
       ) {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -1,5 +1,5 @@
 import { FormJson } from "./formFields";
-import { AnyObject, CustomHtmlElement } from "./other";
+import { AnyObject, CustomHtmlElement, ErrorVerbiage } from "./other";
 
 // REPORT STRUCTURE
 
@@ -218,7 +218,7 @@ export interface ModalOverlayReportPageVerbiage extends EntityOverlayPageVerbiag
   emptyDashboardText?: string;
   accordion?: AnyObject;
   backButtonText?: string;
-  errorMessage?: AnyObject;
+  errorMessage?: ErrorVerbiage;
 }
 
 export interface EntityOverlayPageVerbiage extends ReportPageVerbiage {

--- a/services/app-api/utils/types/reports.ts
+++ b/services/app-api/utils/types/reports.ts
@@ -218,6 +218,7 @@ export interface ModalOverlayReportPageVerbiage extends EntityOverlayPageVerbiag
   emptyDashboardText?: string;
   accordion?: AnyObject;
   backButtonText?: string;
+  errorMessage?: AnyObject;
 }
 
 export interface EntityOverlayPageVerbiage extends ReportPageVerbiage {

--- a/services/app-api/utils/types/routes.ts
+++ b/services/app-api/utils/types/routes.ts
@@ -44,6 +44,7 @@ export enum ReportFormFieldType {
   NO_TYPE = "",
   NUMBER = "number",
   RADIO = "radio",
+  SECTION_CONTENT = "sectionContent",
   SECTION_HEADER = "sectionHeader",
   TEXT = "text",
   TEXTAREA = "textarea",

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -257,7 +257,10 @@ export const dynamic = (options?: DynamicOptions, min = 1) =>
     .of(
       object().shape({
         id: schemaMap[ValidationType.TEXT],
-        name: schemaMap[ValidationType.TEXT],
+        name:
+          min > 0
+            ? schemaMap[ValidationType.TEXT]
+            : schemaMap[ValidationType.TEXT_OPTIONAL],
         ...Object.fromEntries(
           Object.entries(options?.dynamicFieldValidations || {}).map(
             ([key, validation]) => [key, resolveSchema(validation)]

--- a/services/ui-src/src/components/fields/DynamicField.test.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.test.tsx
@@ -138,7 +138,7 @@ describe("<DynamicField />", () => {
       expect(appendButton).toBeVisible();
 
       // click remove
-      const removeButtons = screen.getAllByRole("button", { name: "Delete" });
+      const removeButtons = screen.getAllByRole("button", { name: /Delete/ });
       const removeButton = removeButtons[1];
       expect(removeButtons).toHaveLength(2);
 
@@ -164,7 +164,7 @@ describe("<DynamicField />", () => {
       expect(inputBoxLabel).toHaveLength(1);
 
       // click remove
-      const removeButton = screen.getAllByRole("button", { name: "Delete" })[0];
+      const removeButton = screen.getAllByRole("button", { name: /Delete/ })[0];
       await act(async () => {
         await userEvent.click(removeButton);
       });

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -234,7 +234,7 @@ export const DynamicField = ({
               errorMessage={fieldErrorState?.[index]?.name?.message}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={field.name}
+              value={field.name || ""}
             />
             {!disabled && (
               <Box sx={sx.removeBox}>
@@ -242,7 +242,7 @@ export const DynamicField = ({
                   <Image
                     sx={sx.removeImage}
                     src={cancelIcon}
-                    alt={`Delete ${field.name}`}
+                    alt={`Delete ${field.name || field.id}`}
                   />
                 </button>
               </Box>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -53,6 +53,7 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     autosave,
     className,
     children,
+    disabled = false,
     dontReset,
     formData,
     formJson,
@@ -77,7 +78,7 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
   const status = reportStatus || report?.status;
   const submittedReport = status === ReportStatus.SUBMITTED;
   const fieldInputDisabled =
-    !editableByAdmins && (!userIsEndUser || submittedReport);
+    disabled || (!editableByAdmins && (!userIsEndUser || submittedReport));
 
   // For the SAR RE&T sections, display an alert if the MFP WP does not contain any target populations
   const displayRetError =
@@ -346,6 +347,7 @@ interface Props {
   autosave?: boolean;
   children?: ReactNode;
   className?: string;
+  disabled?: boolean;
   dontReset: boolean;
   formData?: AnyObject;
   formJson: FormJson;

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -252,7 +252,7 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
     const renderedTableIds = new Set<string>();
     let tableIndex = 0;
 
-    const renderedFieldsAndTables = fields.map((field) => {
+    const renderedFieldsAndTables = fields.map((field, index) => {
       const { tableId } = getFieldParts(field.id);
 
       if (field.forTableOnly) {
@@ -276,7 +276,7 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
           : title;
 
       return (
-        <Fragment key={field.id}>
+        <Fragment key={`${field.id}-${index}`}>
           {titleText && (
             <Heading as="h3" className="verbiage-title">
               {titleText}

--- a/services/ui-src/src/components/modals/AddEditKeyMetricsModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditKeyMetricsModal.tsx
@@ -16,6 +16,7 @@ import { getFieldParts } from "utils";
 
 export const AddEditKeyMetricsModal = ({
   currentEntityId,
+  disabled = false,
   dynamicTemplateId,
   entityType,
   form,
@@ -36,7 +37,7 @@ export const AddEditKeyMetricsModal = ({
   const [submitting, setSubmitting] = useState<boolean>(false);
 
   const isReportSubmitted = report?.status === ReportStatus.SUBMITTED;
-  const viewOnly = userIsAdmin || isReportSubmitted;
+  const viewOnly = disabled || userIsAdmin || isReportSubmitted;
 
   const parentEntityFieldData = report?.fieldData?.[entityType] || [];
   const parentEntityIndex = parentEntityFieldData.findIndex(
@@ -173,6 +174,7 @@ export const AddEditKeyMetricsModal = ({
 
 interface Props {
   currentEntityId?: string;
+  disabled?: boolean;
   dynamicTemplateId: string;
   entityType: string;
   form: FormJson;

--- a/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditOverlayEntityModal.tsx
@@ -207,7 +207,6 @@ export const AddEditOverlayEntityModal = ({
         onSubmit={writeEntity}
         validateOnRender={false}
         dontReset={true}
-        disabled={true}
       />
       {objectiveProgressWithTargets && (
         <Text sx={sx.bottomModalMessage}>{verbiage.addEditModalMessage}</Text>

--- a/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
+++ b/services/ui-src/src/components/modals/CreateWorkPlanModal.tsx
@@ -121,7 +121,7 @@ export const CreateWorkPlanModal = ({
       },
       fieldData: {
         submissionName,
-        ["targetPopulations"]: DEFAULT_TARGET_POPULATIONS,
+        targetPopulations: DEFAULT_TARGET_POPULATIONS,
       },
     };
 

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.test.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.test.tsx
@@ -7,14 +7,17 @@ import {
   mockEntityStore,
   mockModalOverlayForm,
   mockModalOverlayReportPageJson,
+  mockModalOverlayReportPageVerbiage,
   mockStateUserStore,
   mockWpReportContext,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { useStore } from "utils";
 import { ReportContext } from "components";
+import { EntityShape } from "types";
 
 const mockCloseEntityDetailsOverlay = jest.fn();
+const mockSelectedEntity = jest.fn();
 const mockOnSubmit = jest.fn();
 
 jest.mock("utils/state/useStore");
@@ -37,7 +40,10 @@ jest.mock("utils/autosave/autosave", () => ({
   autosaveFieldData: jest.fn().mockImplementation(() => Promise.resolve("")),
 }));
 
-const entityDetailsOverlayComponent = (editable?: boolean) => (
+const entityDetailsOverlayComponent = (
+  editable: boolean = true,
+  selectedEntity: EntityShape = mockEntityStore.selectedEntity as EntityShape
+) => (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockWpReportContext}>
       <EntityDetailsOverlayV2
@@ -45,13 +51,14 @@ const entityDetailsOverlayComponent = (editable?: boolean) => (
         closeEntityDetailsOverlay={mockCloseEntityDetailsOverlay}
         disabled={false}
         editable={editable}
+        errorMessage={mockModalOverlayReportPageVerbiage.errorMessage}
         form={mockModalOverlayForm}
         onSubmit={mockOnSubmit}
         route={mockModalOverlayReportPageJson}
-        selectedEntity={mockEntityStore.selectedEntity}
+        selectedEntity={selectedEntity}
         submitting={false}
         setEntering={jest.fn()}
-        setSelectedEntity={jest.fn()}
+        setSelectedEntity={mockSelectedEntity}
         validateOnRender={false}
       />
     </ReportContext.Provider>
@@ -95,6 +102,52 @@ describe("<EntityDetailsOverlayV2 />", () => {
         name: "mock optional field (optional)",
       })
     ).toBeVisible();
+  });
+
+  test("updates initiative endDates", async () => {
+    render(entityDetailsOverlayComponent());
+
+    const endDate = screen.getByRole("textbox", {
+      name: "mock end date field",
+    });
+
+    await act(async () => {
+      await userEvent.type(endDate, "01/01/2026");
+      await userEvent.tab();
+    });
+
+    expect(mockSelectedEntity).toHaveBeenCalledWith({
+      ...mockEntityStore.selectedEntity,
+      defineInitiative_endDate: "01/01/2026",
+      closeOutInformation_projectedEndDate: "01/01/2026",
+    });
+  });
+
+  test("does not show alert for open initiative", async () => {
+    render(entityDetailsOverlayComponent());
+
+    expect(
+      screen.queryByRole("alert", { name: "Warning: Mock error title" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Mock error description")
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows alert for initiative close-out", async () => {
+    const closedOutEntity = {
+      ...mockEntityStore.selectedEntity,
+      closeOutInformation_actualEndDate: "01/01/2026",
+    } as EntityShape;
+
+    await act(async () => {
+      await render(entityDetailsOverlayComponent(true, closedOutEntity));
+    });
+
+    expect(
+      screen.getByRole("alert", { name: "Warning: Mock error title" })
+    ).toBeVisible();
+    expect(screen.getByText("Mock error description")).toBeVisible();
   });
 
   test("calls onSubmit function when clicking Save & return button", async () => {

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
@@ -64,7 +64,11 @@ export const EntityDetailsOverlayV2 = ({
 
   const onFormChange = (hookForm: UseFormReturn<FieldValues, any>) => {
     const currentValues = hookForm.getValues() as EntityShape;
-    updateCloseoutSection(currentValues);
+    updateCloseoutSection({
+      ...currentValues,
+      // Doesn't exist in form values, needs to be added here manually
+      isCopied: Boolean(selectedEntity?.isCopied),
+    });
   };
 
   useEffect(() => {

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
 // components
 import { Alert, Form, ReportPageIntro } from "components";
@@ -6,9 +6,9 @@ import { Alert, Form, ReportPageIntro } from "components";
 import { FieldValues, UseFormReturn } from "react-hook-form";
 import {
   AlertTypes,
-  AnyObject,
   DynamicModalOverlayReportPageShape,
   EntityShape,
+  ErrorVerbiage,
   FormJson,
   ModalOverlayReportPageShape,
 } from "types";
@@ -51,24 +51,25 @@ export const EntityDetailsOverlayV2 = ({
     return fields || [];
   };
 
+  const updateCloseoutSection = useCallback(
+    (entity: EntityShape) => {
+      const isClosed = isClosedInitiative(entity);
+      const fields = getFields(entity);
+
+      setShowAlert(isClosed);
+      setFormJson(toggleOptional({ ...form, fields }, isClosed));
+    },
+    [form]
+  );
+
   const onFormChange = (hookForm: UseFormReturn<FieldValues, any>) => {
     const currentValues = hookForm.getValues() as EntityShape;
-    const isClosed = isClosedInitiative(currentValues);
-    const fields = getFields(selectedEntity);
-
-    setShowAlert(isClosed);
-    setFormJson(toggleOptional({ ...form, fields }, isClosed));
+    updateCloseoutSection(currentValues);
   };
 
   useEffect(() => {
     setSelectedEntity(selectedEntity);
-
-    const isClosed = isClosedInitiative(selectedEntity);
-    const fields = getFields(selectedEntity);
-
-    setShowAlert(isClosed);
-    setFormJson(toggleOptional({ ...form, fields }, isClosed));
-
+    if (selectedEntity) updateCloseoutSection(selectedEntity);
     return () => {
       setSelectedEntity(undefined);
     };
@@ -137,7 +138,7 @@ interface Props {
   closeEntityDetailsOverlay: Function;
   disabled?: boolean;
   editable?: boolean;
-  errorMessage?: AnyObject;
+  errorMessage?: ErrorVerbiage;
   form?: FormJson;
   onSubmit: Function;
   route: ModalOverlayReportPageShape | DynamicModalOverlayReportPageShape;

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
@@ -19,6 +19,7 @@ import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
 
 export const EntityDetailsOverlayV2 = ({
+  autosaveState = false,
   backButtonText,
   closeEntityDetailsOverlay,
   disabled = false,
@@ -32,6 +33,8 @@ export const EntityDetailsOverlayV2 = ({
   setSelectedEntity,
   validateOnRender = false,
 }: Props) => {
+  const [autosave, setAutosave] = useState<boolean>(true);
+  const [disableSubmit, setDisableSubmit] = useState<boolean>(false);
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [formJson, setFormJson] = useState<FormJson>(form);
 
@@ -56,6 +59,7 @@ export const EntityDetailsOverlayV2 = ({
       const isClosed = isClosedInitiative(entity);
       const fields = getFields(entity);
 
+      setAutosave(!isClosed);
       setShowAlert(isClosed);
       setFormJson(toggleOptional({ ...form, fields }, isClosed));
     },
@@ -79,6 +83,10 @@ export const EntityDetailsOverlayV2 = ({
     };
   }, [selectedEntity]);
 
+  useEffect(() => {
+    setDisableSubmit(autosaveState || submitting);
+  }, [autosaveState, submitting]);
+
   return (
     <Box>
       <Button
@@ -100,7 +108,7 @@ export const EntityDetailsOverlayV2 = ({
       />
       {form.fields && (
         <Form
-          autosave={true}
+          autosave={autosave}
           className="overlay-form"
           disabled={isDisabled}
           dontReset={true}
@@ -128,8 +136,13 @@ export const EntityDetailsOverlayV2 = ({
           >
             Previous
           </Button>
-          <Button sx={sx.saveButton} type="submit" {...submitProps}>
-            {submitting ? <Spinner size="md" /> : getSaveButtonText()}
+          <Button
+            disabled={disableSubmit}
+            sx={sx.saveButton}
+            type="submit"
+            {...submitProps}
+          >
+            {disableSubmit ? <Spinner size="md" /> : getSaveButtonText()}
           </Button>
         </Flex>
       </Box>
@@ -138,6 +151,7 @@ export const EntityDetailsOverlayV2 = ({
 };
 
 interface Props {
+  autosaveState?: boolean;
   backButtonText?: string;
   closeEntityDetailsOverlay: Function;
   disabled?: boolean;

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
@@ -68,20 +68,31 @@ export const EntityDetailsOverlayV2 = ({
 
   const onFormChange = (hookForm: UseFormReturn<FieldValues, any>) => {
     const currentValues = hookForm.getValues() as EntityShape;
-    updateCloseoutSection({
+    const endDate = currentValues.defineInitiative_endDate;
+    const projectedEndDate = currentValues.closeOutInformation_projectedEndDate;
+
+    let updatedEntity = {
+      ...selectedEntity,
       ...currentValues,
-      // Doesn't exist in form values, needs to be added here manually
-      isCopied: Boolean(selectedEntity?.isCopied),
-    });
+    };
+
+    if (endDate !== projectedEndDate) {
+      hookForm.setValue("closeOutInformation_projectedEndDate", endDate);
+
+      updatedEntity = {
+        ...updatedEntity,
+        closeOutInformation_projectedEndDate: endDate,
+      };
+    }
+    setSelectedEntity(updatedEntity);
   };
 
   useEffect(() => {
-    setSelectedEntity(selectedEntity);
     if (selectedEntity) updateCloseoutSection(selectedEntity);
-    return () => {
-      setSelectedEntity(undefined);
-    };
-  }, [selectedEntity]);
+  }, [
+    selectedEntity?.closeOutInformation_actualEndDate,
+    selectedEntity?.isCopied,
+  ]);
 
   useEffect(() => {
     setDisableSubmit(autosaveState || submitting);

--- a/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
+++ b/services/ui-src/src/components/overlays/EntityDetailsOverlayV2.tsx
@@ -1,14 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Box, Button, Flex, Image, Spinner } from "@chakra-ui/react";
 // components
-import { Form, ReportPageIntro } from "components";
+import { Alert, Form, ReportPageIntro } from "components";
 // types
+import { FieldValues, UseFormReturn } from "react-hook-form";
 import {
+  AlertTypes,
+  AnyObject,
   DynamicModalOverlayReportPageShape,
   EntityShape,
   FormJson,
   ModalOverlayReportPageShape,
 } from "types";
+// utils
+import { isClosedInitiative, toggleOptional } from "utils";
 // assets
 import arrowLeftBlue from "assets/icons/icon_arrow_left_blue.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
@@ -18,22 +23,52 @@ export const EntityDetailsOverlayV2 = ({
   closeEntityDetailsOverlay,
   disabled = false,
   editable = true,
+  errorMessage,
   form = {} as FormJson,
   onSubmit,
   route,
   selectedEntity,
   submitting = false,
   setSelectedEntity,
-  validateOnRender,
+  validateOnRender = false,
 }: Props) => {
+  const [showAlert, setShowAlert] = useState<boolean>(false);
+  const [formJson, setFormJson] = useState<FormJson>(form);
+
+  const isDisabled = disabled || Boolean(selectedEntity?.isInitiativeClosed);
+  const viewOnly = !editable || isDisabled;
   const getSaveButtonText = () => {
-    return editable && !disabled && !selectedEntity?.isInitiativeClosed
-      ? "Save & return"
-      : "Return";
+    return viewOnly ? "Return" : "Save & return";
+  };
+  const submitProps = viewOnly
+    ? { onClick: () => closeEntityDetailsOverlay() }
+    : { form: form.id };
+
+  const getFields = (entity?: EntityShape) => {
+    const fields = entity?.isCopied
+      ? form.fields
+      : form.fields?.filter((f) => !f.forCopyoverOnly);
+    return fields || [];
+  };
+
+  const onFormChange = (hookForm: UseFormReturn<FieldValues, any>) => {
+    const currentValues = hookForm.getValues() as EntityShape;
+    const isClosed = isClosedInitiative(currentValues);
+    const fields = getFields(selectedEntity);
+
+    setShowAlert(isClosed);
+    setFormJson(toggleOptional({ ...form, fields }, isClosed));
   };
 
   useEffect(() => {
     setSelectedEntity(selectedEntity);
+
+    const isClosed = isClosedInitiative(selectedEntity);
+    const fields = getFields(selectedEntity);
+
+    setShowAlert(isClosed);
+    setFormJson(toggleOptional({ ...form, fields }, isClosed));
+
     return () => {
       setSelectedEntity(undefined);
     };
@@ -62,13 +97,21 @@ export const EntityDetailsOverlayV2 = ({
         <Form
           autosave={true}
           className="overlay-form"
-          disabled={disabled}
+          disabled={isDisabled}
           dontReset={true}
           formData={selectedEntity}
-          formJson={form}
+          formJson={formJson}
           id={form.id}
+          onFormChange={onFormChange}
           onSubmit={onSubmit}
-          validateOnRender={validateOnRender || false}
+          validateOnRender={validateOnRender}
+        />
+      )}
+      {showAlert && errorMessage && (
+        <Alert
+          description={errorMessage.description}
+          status={AlertTypes.WARNING}
+          title={errorMessage.title}
         />
       )}
       <Box sx={sx.footerBox}>
@@ -80,7 +123,7 @@ export const EntityDetailsOverlayV2 = ({
           >
             Previous
           </Button>
-          <Button type="submit" form={form.id} sx={sx.saveButton}>
+          <Button sx={sx.saveButton} type="submit" {...submitProps}>
             {submitting ? <Spinner size="md" /> : getSaveButtonText()}
           </Button>
         </Flex>
@@ -94,6 +137,7 @@ interface Props {
   closeEntityDetailsOverlay: Function;
   disabled?: boolean;
   editable?: boolean;
+  errorMessage?: AnyObject;
   form?: FormJson;
   onSubmit: Function;
   route: ModalOverlayReportPageShape | DynamicModalOverlayReportPageShape;

--- a/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPage.tsx
@@ -47,10 +47,6 @@ export const ModalOverlayReportPage = ({ route, setSidebarHidden }: Props) => {
   // Display Variables
   let reportFieldDataEntities = report?.fieldData[entityType] || [];
 
-  (reportFieldDataEntities as any[]).map(
-    (entity) => (entity["isOtherEntity"] = true)
-  );
-
   if (report?.reportType === ReportType.SAR) {
     (reportFieldDataEntities as any[]).map(
       (entity) => (entity["isCopied"] = true)

--- a/services/ui-src/src/components/reports/ModalOverlayReportPageV2.test.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPageV2.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { ModalOverlayReportPageV2, ReportContext } from "components";
 // types
 import {
-  EntityShape,
   ReportFormFieldType,
   ReportStatus,
   ReportType,
@@ -269,6 +268,7 @@ describe("<ModalOverlayReportPageV2 />", () => {
       editable: true,
       setAutosaveState: jest.fn(),
       setSelectedEntity: jest.fn(),
+      selectedEntity: mockReportFieldData.entityType[0],
     });
     render(modalOverlayReportPageComponent());
     const enterDetailsButton = screen.getByRole("button", {
@@ -346,7 +346,7 @@ describe("<ModalOverlayReportPageV2 />", () => {
     expect(mockWpReportContext.updateReport).not.toHaveBeenCalled();
   });
 
-  test("shows forCopyoverOnly fields for copied report", async () => {
+  test("shows forCopyoverOnly fields for copied report/entity", async () => {
     const route = {
       ...mockModalOverlayReportPageJson,
       overlayForm: {
@@ -369,12 +369,10 @@ describe("<ModalOverlayReportPageV2 />", () => {
       ...mockUseEntityStore,
       report: {
         ...mockUseEntityStore.report,
-        fieldData: {
-          ...mockUseEntityStore.report?.fieldData,
-          entityType: mockUseEntityStore.report?.fieldData.entityType.map(
-            (t: EntityShape) => ({ ...t, isCopied: true })
-          ),
-        },
+        isCopied: true,
+      },
+      selectedEntity: {
+        ...mockReportFieldData.entityType[0],
         isCopied: true,
       },
     });

--- a/services/ui-src/src/components/reports/ModalOverlayReportPageV2.test.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPageV2.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { ModalOverlayReportPageV2, ReportContext } from "components";
 // types
 import {
+  EntityShape,
   ReportFormFieldType,
   ReportStatus,
   ReportType,
@@ -368,6 +369,12 @@ describe("<ModalOverlayReportPageV2 />", () => {
       ...mockUseEntityStore,
       report: {
         ...mockUseEntityStore.report,
+        fieldData: {
+          ...mockUseEntityStore.report?.fieldData,
+          entityType: mockUseEntityStore.report?.fieldData.entityType.map(
+            (t: EntityShape) => ({ ...t, isCopied: true })
+          ),
+        },
         isCopied: true,
       },
     });

--- a/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
@@ -34,6 +34,7 @@ import {
   getReportVerbiage,
   resetClearProp,
   setClearedEntriesToDefaultValue,
+  isClosedInitiative,
   useBreakpoint,
   useStore,
 } from "utils";
@@ -70,10 +71,6 @@ export const ModalOverlayReportPageV2 = ({
 
   // Display route
   const reportFieldDataEntities = report?.fieldData[entityType] || [];
-
-  reportFieldDataEntities.map(
-    (entity: EntityShape) => (entity.isOtherEntity = true)
-  );
 
   if (report?.reportType === ReportType.SAR) {
     reportFieldDataEntities.map(
@@ -163,9 +160,16 @@ export const ModalOverlayReportPageV2 = ({
         .filter((f) => !f.forTableOnly);
       const filteredFormData = filterFormData(enteredData, nonTableFields);
       const entriesToClear = getEntriesToClear(enteredData, nonTableFields);
+      const closeOutInitiative = isClosedInitiative(enteredData)
+        ? {
+            closedBy: full_name,
+            isInitiativeClosed: true,
+          }
+        : {};
       const newEntity = {
         ...currentEntities[selectedEntityIndex],
         ...filteredFormData,
+        ...closeOutInitiative,
       };
       const newEntities = [...currentEntities];
       newEntities[selectedEntityIndex] = newEntity;
@@ -284,6 +288,7 @@ export const ModalOverlayReportPageV2 = ({
           closeEntityDetailsOverlay={closeEntityDetailsOverlay}
           disabled={isDisabled}
           editable={editable}
+          errorMessage={verbiage.errorMessage}
           form={form}
           onSubmit={onSubmit}
           route={route}

--- a/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
@@ -52,9 +52,6 @@ export const ModalOverlayReportPageV2 = ({
   const { isMobile, isTablet } = useBreakpoint();
   const { updateReport } = useContext(ReportContext);
   const [isEntityDetailsOpen, setIsEntityDetailsOpen] = useState<boolean>();
-  const [currentEntity, setCurrentEntity] = useState<EntityShape | undefined>(
-    undefined
-  );
   const [entering, setEntering] = useState<boolean>(false);
   const [form, setForm] = useState<FormJson>({} as FormJson);
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -67,6 +64,7 @@ export const ModalOverlayReportPageV2 = ({
     editable,
     report = {} as ReportShape,
     setSelectedEntity,
+    selectedEntity,
   } = useStore();
   const isDisabled = Boolean(userIsAdmin || userIsReadOnly);
 
@@ -102,12 +100,12 @@ export const ModalOverlayReportPageV2 = ({
   } = useDisclosure();
 
   const openAddEditEntityModal = (entity?: EntityShape) => {
-    if (entity) setCurrentEntity(entity);
+    if (entity) setSelectedEntity(entity);
     addEditEntityModalOnOpenHandler();
   };
 
   const closeAddEditEntityModal = () => {
-    setCurrentEntity(undefined);
+    setSelectedEntity(undefined);
     resetClearProp(modalForm.fields);
     addEditEntityModalOnCloseHandler();
   };
@@ -120,26 +118,35 @@ export const ModalOverlayReportPageV2 = ({
   } = useDisclosure();
 
   const openDeleteEntityModal = (entity: EntityShape) => {
-    setCurrentEntity(entity);
+    setSelectedEntity(entity);
     deleteEntityModalOnOpenHandler();
   };
 
   const closeDeleteEntityModal = () => {
-    setCurrentEntity(undefined);
+    setSelectedEntity(undefined);
     deleteEntityModalOnCloseHandler();
   };
 
   // Open/Close overlay action methods
   const openEntityDetailsOverlay = (entity: EntityShape) => {
     window.scrollTo(0, 0);
-    setCurrentEntity(entity);
+    // In copied report, set closeOutInformation_projectedEndDate to defineInitiative_endDate
+    const updatedEntity =
+      entity.isCopied && entity.defineInitiative_endDate
+        ? {
+            ...entity,
+            closeOutInformation_projectedEndDate:
+              entity.defineInitiative_endDate,
+          }
+        : entity;
+    setSelectedEntity(updatedEntity);
     setIsEntityDetailsOpen(true);
     setSidebarHidden(true);
   };
 
   const closeEntityDetailsOverlay = () => {
     window.scrollTo(0, 0);
-    setCurrentEntity(undefined);
+    setSelectedEntity(undefined);
     setIsEntityDetailsOpen(false);
     setSidebarHidden(false);
   };
@@ -154,7 +161,7 @@ export const ModalOverlayReportPageV2 = ({
       };
       const currentEntities = [...(report.fieldData[entityType] || [])];
       const selectedEntityIndex = report.fieldData[entityType].findIndex(
-        (entity: EntityShape) => entity.id === currentEntity?.id
+        (entity: EntityShape) => entity.id === selectedEntity?.id
       );
       const nonTableFields = form.fields
         .filter(isFieldElement)
@@ -204,7 +211,6 @@ export const ModalOverlayReportPageV2 = ({
     const fields = report.isCopied
       ? overlayForm.fields
       : overlayForm.fields.filter((f) => !f.forCopyoverOnly);
-
     setForm({
       ...overlayForm,
       fields,
@@ -263,7 +269,7 @@ export const ModalOverlayReportPageV2 = ({
             isOpen: addEditEntityModalIsOpen,
             onClose: closeAddEditEntityModal,
           }}
-          selectedEntity={currentEntity}
+          selectedEntity={selectedEntity}
           setError={() => {}}
           verbiage={verbiage}
         />
@@ -273,7 +279,7 @@ export const ModalOverlayReportPageV2 = ({
             isOpen: deleteEntityModalIsOpen,
             onClose: closeDeleteEntityModal,
           }}
-          selectedEntity={currentEntity}
+          selectedEntity={selectedEntity}
           verbiage={verbiage}
         />
         <ReportPageFooter verbiage={verbiage} />
@@ -294,7 +300,7 @@ export const ModalOverlayReportPageV2 = ({
           form={form}
           onSubmit={onSubmit}
           route={route}
-          selectedEntity={currentEntity}
+          selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
           submitting={submitting}
           setEntering={setEntering}

--- a/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
+++ b/services/ui-src/src/components/reports/ModalOverlayReportPageV2.tsx
@@ -63,6 +63,7 @@ export const ModalOverlayReportPageV2 = ({
   const { full_name, state, userIsAdmin, userIsEndUser, userIsReadOnly } =
     useStore().user ?? {};
   const {
+    autosaveState,
     editable,
     report = {} as ReportShape,
     setSelectedEntity,
@@ -144,7 +145,7 @@ export const ModalOverlayReportPageV2 = ({
   };
 
   const onSubmit = async (enteredData: AnyObject) => {
-    if (userIsEndUser) {
+    if (!autosaveState && userIsEndUser) {
       setSubmitting(true);
       const reportKeys = {
         reportType: report.reportType,
@@ -284,6 +285,7 @@ export const ModalOverlayReportPageV2 = ({
     return (
       <EntityProvider>
         <EntityDetailsOverlayV2
+          autosaveState={autosaveState}
           backButtonText={verbiage.backButtonText}
           closeEntityDetailsOverlay={closeEntityDetailsOverlay}
           disabled={isDisabled}

--- a/services/ui-src/src/components/tables/EntityModalTable.tsx
+++ b/services/ui-src/src/components/tables/EntityModalTable.tsx
@@ -170,6 +170,7 @@ export const EntityModalTable = ({
 
           <AddEditKeyMetricsModal
             currentEntityId={currentEntityId}
+            disabled={disabled}
             dynamicTemplateId={dynamicRowsTemplate.id}
             entityType={formData?.type}
             form={dynamicRowsTemplate.props?.dynamicModalForm}

--- a/services/ui-src/src/components/tables/EntityRow.test.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   RouterWrappedComponent,
@@ -13,7 +13,14 @@ import { useStore } from "utils";
 // constants
 import { EntityRow } from "./EntityRow";
 import { Table } from "components";
-import { ModalDrawerEntityTypes } from "types";
+import {
+  EntityDetailsOverlayShape,
+  EntityDetailsOverlayTypes,
+  EntityShape,
+  ModalDrawerEntityTypes,
+  OverlayModalStepTypes,
+  OverlayModalTypes,
+} from "types";
 import { testA11yAct } from "utils/testing/commonTests";
 
 const mockUseNavigate = jest.fn();
@@ -51,7 +58,12 @@ const tableContent = {
 };
 
 const mockEntityInfo = ["transitionBenchmarks_targetPopulationName"];
-const mockEntityClosed = { ...mockGenericEntity, isInitiativeClosed: true };
+const mockEntityClosed = {
+  ...mockGenericEntity,
+  isInitiativeClosed: true,
+  closeOutInformation_actualEndDate: "01/01/2026",
+  closedBy: "Mock User",
+};
 
 const entityRowWithEntities = (
   <RouterWrappedComponent>
@@ -97,6 +109,26 @@ const entityRowWithCloseoutDetails = (
         openAddEditEntityModal={mockOpenAddEditEntityModal}
         openDeleteEntityModal={mockOpenDeleteEntityModal}
         openOverlayOrDrawer={mockOpenDrawer}
+      />
+    </Table>
+  </RouterWrappedComponent>
+);
+
+const entityRowInitiative = (
+  entity: EntityShape,
+  formEntity?: EntityDetailsOverlayShape
+) => (
+  <RouterWrappedComponent>
+    <Table content={tableContent}>
+      <EntityRow
+        entity={entity}
+        entityInfo={["initiative_name", "initiative_wpTopic"]}
+        entityType={OverlayModalTypes.INITIATIVE}
+        formEntity={formEntity}
+        openAddEditEntityModal={mockOpenAddEditEntityModal}
+        openDeleteEntityModal={mockOpenDeleteEntityModal}
+        openOverlayOrDrawer={mockOpenDrawer}
+        verbiage={verbiage}
       />
     </Table>
   </RouterWrappedComponent>
@@ -171,7 +203,148 @@ describe("<EntityRow />", () => {
     test("should show closeout details if specified", () => {
       mockedUseStore.mockReturnValue(mockReportStore);
       render(entityRowWithCloseoutDetails);
-      expect(screen.getByText("Closed by")).toBeVisible();
+      expect(
+        screen.getByRole("columnheader", { name: "Actual end date" })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("columnheader", { name: "Closed by" })
+      ).toBeVisible();
+      expect(screen.getByRole("cell", { name: "01/01/2026" })).toBeVisible();
+      expect(screen.getByRole("cell", { name: "Mock User" })).toBeVisible();
+    });
+  });
+
+  describe("EntityRow with initiative", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("show initiative with close-out step", () => {
+      const entity = {
+        ...mockGenericEntity,
+        initiative_name: "Mock initiative name",
+        initiative_wpTopic: [
+          {
+            key: "mockId",
+            value: "Mock topic",
+          },
+        ],
+      };
+
+      const formEntity = {
+        stepType: EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
+      } as EntityDetailsOverlayShape;
+
+      mockedUseStore.mockReturnValue(mockReportStore);
+      render(entityRowInitiative(entity, formEntity));
+
+      const cells = screen.getAllByRole("cell");
+      const firstCell = cells[0];
+      const statusIcon = within(firstCell).queryByRole("img");
+      expect(statusIcon).not.toBeInTheDocument();
+      expect(screen.getByText("Mock initiative name")).toBeVisible();
+      expect(screen.getByText("Mock topic")).toBeVisible();
+    });
+
+    test("show initiative with other step", () => {
+      const entity = {
+        ...mockGenericEntity,
+        initiative_name: "Mock initiative name",
+        initiative_wpTopic: [
+          {
+            key: "mockId",
+            value: "Mock topic",
+          },
+        ],
+      };
+
+      const formEntity = {
+        stepType: OverlayModalStepTypes.EVALUATION_PLAN,
+      } as EntityDetailsOverlayShape;
+
+      mockedUseStore.mockReturnValue(mockReportStore);
+      render(entityRowInitiative(entity, formEntity));
+
+      const cells = screen.getAllByRole("cell");
+      const firstCell = cells[0];
+      const statusIcon = within(firstCell).getByRole("img", {
+        name: "warning icon",
+      });
+      expect(statusIcon).toBeVisible();
+      expect(screen.getByText("Mock initiative name")).toBeVisible();
+      expect(screen.getByText("Mock topic")).toBeVisible();
+      expect(screen.getByText('Select "Edit" to report data.')).toBeVisible();
+    });
+
+    test("show closed initiative with close-out step", () => {
+      const entity = {
+        ...mockEntityClosed,
+        initiative_name: "Mock initiative name",
+        initiative_wpTopic: [
+          {
+            key: "mockId",
+            value: "Mock topic",
+          },
+        ],
+      };
+
+      const formEntity = {
+        stepType: EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
+      } as EntityDetailsOverlayShape;
+
+      mockedUseStore.mockReturnValue(mockReportStore);
+      render(entityRowInitiative(entity, formEntity));
+
+      const cells = screen.getAllByRole("cell");
+      const firstCell = cells[0];
+      const statusIcon = within(firstCell).getByRole("img", {
+        name: "close icon",
+      });
+      expect(statusIcon).toBeVisible();
+      expect(screen.getByText("Mock initiative name")).toBeVisible();
+      expect(screen.getByText("Mock topic")).toBeVisible();
+    });
+
+    test("show closed initiative details", () => {
+      const entity = {
+        ...mockEntityClosed,
+        initiative_name: "Mock initiative name",
+        initiative_wpTopic: [
+          {
+            key: "mockId",
+            value: "Mock topic",
+          },
+        ],
+      };
+
+      mockedUseStore.mockReturnValue(mockReportStore);
+      render(entityRowInitiative(entity));
+
+      const cells = screen.getAllByRole("cell");
+      const firstCell = cells[0];
+      const statusIcon = within(firstCell).getByRole("img", {
+        name: "close icon",
+      });
+      expect(statusIcon).toBeVisible();
+      expect(screen.getByText("[Closed] Mock initiative name")).toBeVisible();
+      expect(screen.getByText("Mock topic")).toBeVisible();
+    });
+
+    test("show closed initiative details with other topic", () => {
+      const entity = {
+        ...mockEntityClosed,
+        initiative_wpTopic: [
+          {
+            key: "mockId",
+            value: "Other, specify",
+          },
+        ],
+        initiative_wp_otherTopic: "Mock other topic",
+      };
+
+      mockedUseStore.mockReturnValue(mockReportStore);
+      render(entityRowInitiative(entity));
+      expect(screen.getByText("Mock other topic")).toBeVisible();
     });
   });
 

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -5,13 +5,14 @@ import { EntityStatusIcon, Table } from "components";
 // types
 import {
   AnyObject,
+  EntityDetailsOverlayShape,
+  EntityDetailsOverlayTypes,
   EntityShape,
   EntityStatuses,
   ModalDrawerEntityTypes,
-  OverlayModalTypes,
-  EntityDetailsOverlayTypes,
-  EntityDetailsOverlayShape,
   OverlayModalPageShape,
+  OverlayModalTypes,
+  ReportShape,
   ReportType,
 } from "types";
 // utils
@@ -45,49 +46,51 @@ export const EntityRow = ({
   // check for "other" target population entities
   const { isRequired, isCopied, isInitiativeClosed, closedBy } = entity;
   const stepType = formEntity?.stepType;
-  const isSAR = report?.reportType === ReportType.SAR;
+  const isWP = report?.reportType === ReportType.WP;
+  const isReadOnly = !editable || (isInitiativeClosed && isWP);
+  const isNewAndRequired = !isCopied && !isRequired;
+
+  const getInitiativeStatusValue = (report: ReportShape) => {
+    const isCloseoutStep =
+      stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION;
+
+    if (formEntity && !isCloseoutStep) {
+      return getInitiativeDashboardStatus(formEntity, entity);
+    }
+
+    if (isCloseoutStep) {
+      if (isInitiativeClosed) return EntityStatuses.CLOSE;
+
+      const isCloseOutEnabled = getInitiativeStatus(report, entity, false, [
+        stepType,
+      ]);
+      return isCloseOutEnabled && isCopied
+        ? EntityStatuses.NO_STATUS
+        : EntityStatuses.DISABLED;
+    }
+
+    return getInitiativeStatus(report, entity, false, [
+      EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
+    ]);
+  };
 
   const setStatusByType = (entityType: string) => {
+    if (!report) return EntityStatuses.NO_STATUS;
+
     switch (entityType) {
       case OverlayModalTypes.INITIATIVE:
-        //the entityType for initiative is being shared for both the parent and the child status to differentiate, check if formEntity is filled
-        if (
-          formEntity &&
-          stepType !== EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
-        ) {
-          return getInitiativeDashboardStatus(formEntity, entity);
-        } else if (
-          stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
-        ) {
-          if (isInitiativeClosed) {
-            return EntityStatuses.CLOSE;
-          } else {
-            const isCloseOutEnabled = getInitiativeStatus(
-              report!,
-              entity,
-              false,
-              [stepType]
-            );
-            return isCloseOutEnabled && isCopied
-              ? EntityStatuses.NO_STATUS
-              : EntityStatuses.DISABLED;
-          }
-        } else {
-          return getInitiativeStatus(report!, entity, false, [
-            EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
-          ]);
-        }
+        return getInitiativeStatusValue(report);
       default:
-        return report && getEntityStatus(report, entity, entityType);
+        return getEntityStatus(report, entity, entityType);
     }
   };
 
-  let entityStatus = useMemo(() => {
+  const entityStatus = useMemo(() => {
     if (
       OverlayModalTypes.INITIATIVE &&
       formEntity &&
       isInitiativeClosed &&
-      report?.reportType === ReportType.WP
+      isWP
     ) {
       return EntityStatuses.CLOSE;
     }
@@ -117,9 +120,9 @@ export const EntityRow = ({
   const appendToEntityName = () => {
     switch (entityType) {
       case ModalDrawerEntityTypes.TARGET_POPULATIONS:
-        return !isRequired && `Other: `;
+        return !isRequired ? "Other: " : "";
       case OverlayModalTypes.INITIATIVE:
-        return isInitiativeClosed && !formEntity && "[Closed] ";
+        return isInitiativeClosed && !formEntity ? "[Closed] " : "";
       default:
         return "";
     }
@@ -174,7 +177,7 @@ export const EntityRow = ({
             justifyContent={isMobile ? "flex-start" : "flex-end"}
             display={"inline-block"}
           >
-            {!isRequired && !isCopied && openAddEditEntityModal && (
+            {isNewAndRequired && openAddEditEntityModal && (
               <Button
                 sx={sx.editNameButton}
                 id={editNameButtonId}
@@ -184,14 +187,14 @@ export const EntityRow = ({
                 pl={isMobile ? "0" : "1rem"}
                 pr={isMobile ? "1.5rem" : "2.5rem"}
               >
-                {!editable || (!isSAR && isInitiativeClosed)
+                {isReadOnly
                   ? verbiage.readOnlyEntityButtonText
                   : verbiage.editEntityButtonText}
               </Button>
             )}
             <Button
               sx={
-                !isRequired && !isCopied
+                isNewAndRequired
                   ? sx.editOtherEntityButton
                   : sx.editEntityButton
               }
@@ -201,11 +204,11 @@ export const EntityRow = ({
               disabled={entityStatus === EntityStatuses.DISABLED}
               aria-labelledby={`${editButtonId} ${rowId}`}
             >
-              {!editable || (!isSAR && isInitiativeClosed)
+              {isReadOnly
                 ? verbiage.readOnlyEntityDetailsButtonText
                 : verbiage.enterEntityDetailsButtonText}
             </Button>
-            {!isRequired && !isCopied && openDeleteEntityModal && (
+            {isNewAndRequired && openDeleteEntityModal && (
               <Button
                 sx={sx.deleteButton}
                 id={deleteButtonId}

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -90,7 +90,7 @@ export const EntityRow = ({
     }
 
     return setStatusByType(entityType!);
-  }, [entityType, formEntity, isInitiativeClosed, isWP]);
+  }, [report, entity]);
 
   let programInfo = [];
   if (entityInfo) {

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -50,34 +50,28 @@ export const EntityRow = ({
   const viewOnly = !editable || (isInitiativeClosed && isWP);
 
   const setStatusByType = (entityType: string) => {
-    if (!report) return EntityStatuses.NO_STATUS;
-
     switch (entityType) {
       case OverlayModalTypes.INITIATIVE:
-        //the entityType for initiative is being shared for both the parent and the child status to differentiate, check if formEntity is filled
-        if (
-          formEntity &&
-          stepType !== EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
-        ) {
-          return getInitiativeDashboardStatus(formEntity, entity);
-        } else if (
-          stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
-        ) {
-          if (isInitiativeClosed) return EntityStatuses.CLOSE;
-
-          const isCloseOutEnabled = getInitiativeStatus(report, entity, false, [
-            stepType,
-          ]);
+        if (stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION) {
+          const isCloseOutEnabled = getInitiativeStatus(
+            report!,
+            entity,
+            false,
+            [stepType]
+          );
           return isCloseOutEnabled && isCopied
             ? EntityStatuses.NO_STATUS
             : EntityStatuses.DISABLED;
+        } else if (stepType) {
+          //the entityType for initiative is being shared for both the parent and the child status to differentiate, check if formEntity is filled
+          return getInitiativeDashboardStatus(formEntity, entity);
         }
 
-        return getInitiativeStatus(report, entity, false, [
+        return getInitiativeStatus(report!, entity, false, [
           EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
         ]);
       default:
-        return getEntityStatus(report, entity, entityType);
+        return getEntityStatus(report!, entity, entityType);
     }
   };
 

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -63,7 +63,11 @@ export const EntityRow = ({
             ? EntityStatuses.NO_STATUS
             : EntityStatuses.DISABLED;
         } else if (stepType) {
-          //the entityType for initiative is being shared for both the parent and the child status to differentiate, check if formEntity is filled
+          /**
+           * the entityType for initiative is being shared for
+           * both the parent and the child status to differentiate,
+           * check if formEntity is filled
+           */
           return getInitiativeDashboardStatus(formEntity, entity);
         }
 

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -46,7 +46,7 @@ export const EntityRow = ({
   const { isRequired, isCopied, isInitiativeClosed, closedBy } = entity;
   const stepType = formEntity?.stepType;
   const isWP = report?.reportType === ReportType.WP;
-  const isNewAndRequired = !isCopied && !isRequired;
+  const isNewAndOptional = !isCopied && !isRequired;
   const viewOnly = !editable || (isInitiativeClosed && isWP);
 
   const setStatusByType = (entityType: string) => {
@@ -77,7 +77,7 @@ export const EntityRow = ({
 
   const entityStatus = useMemo(() => {
     if (
-      OverlayModalTypes.INITIATIVE &&
+      entityType === OverlayModalTypes.INITIATIVE &&
       formEntity &&
       isInitiativeClosed &&
       isWP
@@ -86,7 +86,7 @@ export const EntityRow = ({
     }
 
     return setStatusByType(entityType!);
-  }, [report, entity]);
+  }, [entityType, formEntity, isInitiativeClosed, isWP]);
 
   let programInfo = [];
   if (entityInfo) {
@@ -167,7 +167,7 @@ export const EntityRow = ({
             justifyContent={isMobile ? "flex-start" : "flex-end"}
             display={"inline-block"}
           >
-            {isNewAndRequired && openAddEditEntityModal && (
+            {isNewAndOptional && openAddEditEntityModal && (
               <Button
                 sx={sx.editNameButton}
                 id={editNameButtonId}
@@ -184,7 +184,7 @@ export const EntityRow = ({
             )}
             <Button
               sx={
-                isNewAndRequired
+                isNewAndOptional
                   ? sx.editOtherEntityButton
                   : sx.editEntityButton
               }
@@ -198,7 +198,7 @@ export const EntityRow = ({
                 ? verbiage.readOnlyEntityDetailsButtonText
                 : verbiage.enterEntityDetailsButtonText}
             </Button>
-            {isNewAndRequired && openDeleteEntityModal && (
+            {isNewAndOptional && openDeleteEntityModal && (
               <Button
                 sx={sx.deleteButton}
                 id={deleteButtonId}

--- a/services/ui-src/src/components/tables/EntityRow.tsx
+++ b/services/ui-src/src/components/tables/EntityRow.tsx
@@ -12,7 +12,6 @@ import {
   ModalDrawerEntityTypes,
   OverlayModalPageShape,
   OverlayModalTypes,
-  ReportShape,
   ReportType,
 } from "types";
 // utils
@@ -47,39 +46,36 @@ export const EntityRow = ({
   const { isRequired, isCopied, isInitiativeClosed, closedBy } = entity;
   const stepType = formEntity?.stepType;
   const isWP = report?.reportType === ReportType.WP;
-  const isReadOnly = !editable || (isInitiativeClosed && isWP);
   const isNewAndRequired = !isCopied && !isRequired;
-
-  const getInitiativeStatusValue = (report: ReportShape) => {
-    const isCloseoutStep =
-      stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION;
-
-    if (formEntity && !isCloseoutStep) {
-      return getInitiativeDashboardStatus(formEntity, entity);
-    }
-
-    if (isCloseoutStep) {
-      if (isInitiativeClosed) return EntityStatuses.CLOSE;
-
-      const isCloseOutEnabled = getInitiativeStatus(report, entity, false, [
-        stepType,
-      ]);
-      return isCloseOutEnabled && isCopied
-        ? EntityStatuses.NO_STATUS
-        : EntityStatuses.DISABLED;
-    }
-
-    return getInitiativeStatus(report, entity, false, [
-      EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
-    ]);
-  };
+  const viewOnly = !editable || (isInitiativeClosed && isWP);
 
   const setStatusByType = (entityType: string) => {
     if (!report) return EntityStatuses.NO_STATUS;
 
     switch (entityType) {
       case OverlayModalTypes.INITIATIVE:
-        return getInitiativeStatusValue(report);
+        //the entityType for initiative is being shared for both the parent and the child status to differentiate, check if formEntity is filled
+        if (
+          formEntity &&
+          stepType !== EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
+        ) {
+          return getInitiativeDashboardStatus(formEntity, entity);
+        } else if (
+          stepType === EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION
+        ) {
+          if (isInitiativeClosed) return EntityStatuses.CLOSE;
+
+          const isCloseOutEnabled = getInitiativeStatus(report, entity, false, [
+            stepType,
+          ]);
+          return isCloseOutEnabled && isCopied
+            ? EntityStatuses.NO_STATUS
+            : EntityStatuses.DISABLED;
+        }
+
+        return getInitiativeStatus(report, entity, false, [
+          EntityDetailsOverlayTypes.CLOSEOUT_INFORMATION,
+        ]);
       default:
         return getEntityStatus(report, entity, entityType);
     }
@@ -187,7 +183,7 @@ export const EntityRow = ({
                 pl={isMobile ? "0" : "1rem"}
                 pr={isMobile ? "1.5rem" : "2.5rem"}
               >
-                {isReadOnly
+                {viewOnly
                   ? verbiage.readOnlyEntityButtonText
                   : verbiage.editEntityButtonText}
               </Button>
@@ -204,7 +200,7 @@ export const EntityRow = ({
               disabled={entityStatus === EntityStatuses.DISABLED}
               aria-labelledby={`${editButtonId} ${rowId}`}
             >
-              {isReadOnly
+              {viewOnly
                 ? verbiage.readOnlyEntityDetailsButtonText
                 : verbiage.enterEntityDetailsButtonText}
             </Button>

--- a/services/ui-src/src/types/formFields.ts
+++ b/services/ui-src/src/types/formFields.ts
@@ -144,8 +144,11 @@ export function isFieldElement(
    * This function is duplicated in app-api/utils/formTemplates/formTemplates.ts
    * If you change it here, change it there!
    */
-  const formLayoutElementTypes = ["sectionHeader", "sectionContent"];
-  return !formLayoutElementTypes.includes(field.type);
+  const formLayoutElementTypes = [
+    ReportFormFieldType.SECTION_HEADER,
+    ReportFormFieldType.SECTION_CONTENT,
+  ];
+  return !formLayoutElementTypes.includes(field.type as ReportFormFieldType);
 }
 
 export interface FormLayoutElement {
@@ -199,6 +202,7 @@ export enum ReportFormFieldType {
   NO_TYPE = "",
   NUMBER = "number",
   RADIO = "radio",
+  SECTION_CONTENT = "sectionContent",
   SECTION_HEADER = "sectionHeader",
   TEXT = "text",
   TEXTAREA = "textarea",

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -231,6 +231,7 @@ export interface ModalOverlayReportPageVerbiage extends ReportPageVerbiage {
   emptyDashboardText?: string;
   accordion?: AnyObject;
   backButtonText?: string;
+  errorMessage?: AnyObject;
 }
 
 export interface EntityOverlayPageVerbiage extends ReportPageVerbiage {

--- a/services/ui-src/src/types/reports.ts
+++ b/services/ui-src/src/types/reports.ts
@@ -3,6 +3,7 @@ import {
   Choice,
   CustomHtmlElement,
   EntityShape,
+  ErrorVerbiage,
   FormJson,
 } from "types";
 
@@ -231,7 +232,7 @@ export interface ModalOverlayReportPageVerbiage extends ReportPageVerbiage {
   emptyDashboardText?: string;
   accordion?: AnyObject;
   backButtonText?: string;
-  errorMessage?: AnyObject;
+  errorMessage?: ErrorVerbiage;
 }
 
 export interface EntityOverlayPageVerbiage extends ReportPageVerbiage {

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -21,6 +21,7 @@ export * from "./forms/forms";
 // reports
 export * from "./reports/entities";
 export * from "./reports/entitySteps";
+export * from "./reports/initiatives";
 export * from "./reports/reports";
 export * from "./reports/routing";
 // statusing

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -216,15 +216,28 @@ describe("utils/parsing", () => {
   });
 
   describe("labelTextWithOptional()", () => {
-    // labelTextWithOptional test
-    describe("Test labelTextWithOptional", () => {
-      test("if a string gets passed into labelTextWithOptional, the 'optional' text will appear", () => {
-        const label = "field title";
-        const testComponent = <div>{labelTextWithOptional(label)}</div>;
-        render(testComponent);
-        const optionalText = screen.getByText("(optional)");
-        expect(optionalText).toBeVisible();
-      });
+    test("if a string gets passed into labelTextWithOptional, the 'optional' text will appear", () => {
+      const label = "field title";
+      const testComponent = <>{labelTextWithOptional(label)}</>;
+      render(testComponent);
+
+      const fieldText = screen.getByText("field title");
+      expect(fieldText).toBeVisible();
+
+      const optionalText = screen.getByText("(optional)");
+      expect(optionalText).toBeVisible();
+    });
+
+    test("string with colon puts colon after optional text", () => {
+      const label = "field title:";
+      const testComponent = <>{labelTextWithOptional(label)}</>;
+      render(testComponent);
+
+      const fieldText = screen.getByText("field title");
+      expect(fieldText).toBeVisible();
+
+      const optionalText = screen.getByText("(optional):");
+      expect(optionalText).toBeVisible();
     });
   });
 });

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -117,11 +117,12 @@ export const sanitizeAndParseHtml = (html: string) => {
 };
 
 export const labelTextWithOptional = (label: string) => {
-  const endsWithColon = label.endsWith(":");
-  const baseLabel = endsWithColon ? label.slice(0, -1) : label;
-  const suffix = endsWithColon ? ":" : "";
+  const cleanLabel = label.trim();
+  const endsWithColon = cleanLabel.endsWith(":");
+  const parsedLabel = endsWithColon ? cleanLabel.slice(0, -1) : cleanLabel;
+  const colon = endsWithColon ? ":" : "";
 
   return parseCustomHtml(
-    `${baseLabel}<span class='optional-text'> (optional)${suffix}</span>`
+    `${parsedLabel}<span class='optional-text'> (optional)${colon}</span>`
   );
 };

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -116,5 +116,12 @@ export const sanitizeAndParseHtml = (html: string) => {
   return parsedHtml;
 };
 
-export const labelTextWithOptional = (label: string) =>
-  parseCustomHtml(label + "<span class='optional-text'> (optional)</span>");
+export const labelTextWithOptional = (label: string) => {
+  const endsWithColon = label.endsWith(":");
+  const baseLabel = endsWithColon ? label.slice(0, -1) : label;
+  const suffix = endsWithColon ? ":" : "";
+
+  return parseCustomHtml(
+    `${baseLabel}<span class='optional-text'> (optional)${suffix}</span>`
+  );
+};

--- a/services/ui-src/src/utils/reports/initiatives.test.ts
+++ b/services/ui-src/src/utils/reports/initiatives.test.ts
@@ -1,0 +1,98 @@
+import { isClosedInitiative, toggleOptional } from "./initiatives";
+// types
+import { ReportFormFieldType, ValidationType } from "types";
+
+describe("utils/reports/initiatives", () => {
+  describe("isClosedInitiative()", () => {
+    test("returns true for actualEndDate", () => {
+      const entity = {
+        closeOutInformation_actualEndDate: "01/01/2026",
+      };
+
+      const result = isClosedInitiative(entity);
+      expect(result).toBe(true);
+    });
+
+    test("returns true for initiativeStatus", () => {
+      const entity = {
+        closeOutInformation_initiativeStatus: [
+          {
+            key: "mockId",
+            value: "mock value",
+          },
+        ],
+      };
+
+      const result = isClosedInitiative(entity);
+      expect(result).toBe(true);
+    });
+
+    test("returns false", () => {
+      const result = isClosedInitiative({});
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("toggleOptional()", () => {
+    const form = {
+      id: "mockId",
+      fields: [
+        {
+          id: "mockSectionHeaderId",
+          type: ReportFormFieldType.SECTION_HEADER,
+        },
+        {
+          id: "mockNumberFieldId",
+          type: ReportFormFieldType.TEXT,
+          validation: ValidationType.NUMBER,
+        },
+        {
+          id: "mockCustomFieldId",
+          type: ReportFormFieldType.TEXT,
+          validation: {
+            type: ValidationType.TEXT_CUSTOM,
+          },
+        },
+        {
+          id: "mockTextFieldId",
+          type: ReportFormFieldType.TEXT,
+          validation: ValidationType.TEXT_OPTIONAL,
+        },
+      ],
+    };
+    test("changes validation to optional", () => {
+      const result = toggleOptional(form, true);
+      expect(result).toEqual({
+        ...form,
+        fields: [
+          {
+            id: "mockSectionHeaderId",
+            type: ReportFormFieldType.SECTION_HEADER,
+          },
+          {
+            id: "mockNumberFieldId",
+            type: ReportFormFieldType.TEXT,
+            validation: ValidationType.NUMBER_OPTIONAL,
+          },
+          {
+            id: "mockCustomFieldId",
+            type: ReportFormFieldType.TEXT,
+            validation: {
+              type: ValidationType.TEXT_CUSTOM_OPTIONAL,
+            },
+          },
+          {
+            id: "mockTextFieldId",
+            type: ReportFormFieldType.TEXT,
+            validation: ValidationType.TEXT_OPTIONAL,
+          },
+        ],
+      });
+    });
+
+    test("leaves validation as-is", () => {
+      const result = toggleOptional(form, false);
+      expect(result).toEqual(form);
+    });
+  });
+});

--- a/services/ui-src/src/utils/reports/initiatives.ts
+++ b/services/ui-src/src/utils/reports/initiatives.ts
@@ -1,0 +1,31 @@
+// types
+import { AnyObject, FormJson, isFieldElement } from "types";
+
+export const isClosedInitiative = (data?: AnyObject) => {
+  return Boolean(
+    data?.closeOutInformation_actualEndDate ||
+    data?.closeOutInformation_initiativeStatus?.length > 0
+  );
+};
+
+export const toggleOptional = (form: FormJson, updateAlert: boolean) => {
+  if (!updateAlert) return form;
+
+  const changeToOptional = (type: string) =>
+    type.endsWith("Optional") ? type : `${type}Optional`;
+
+  const fields = form.fields.map((field) => {
+    if (!isFieldElement(field)) return field;
+
+    const { validation } = field;
+
+    const updatedValidation =
+      typeof validation === "string"
+        ? changeToOptional(validation)
+        : { ...validation, type: changeToOptional(validation.type) };
+
+    return { ...field, validation: updatedValidation };
+  });
+
+  return { ...form, fields };
+};

--- a/services/ui-src/src/utils/testing/mockForm.tsx
+++ b/services/ui-src/src/utils/testing/mockForm.tsx
@@ -565,11 +565,43 @@ export const mockModalOverlayReportPageVerbiage = {
   addEditModalEditTitle: "Mock Edit Modal Text",
   reportProgressButtonText: "Mock report progress button text",
   backButtonText: "Mock back button text",
+  errorMessage: {
+    description: "Mock error description",
+    title: "Mock error title",
+  },
 };
 
 export const mockModalOverlayForm = {
   id: "mock-modal-overlay-form-id",
-  fields: [mockFormField, mockNumberField, mockOptionalFormField],
+  fields: [
+    mockFormField,
+    mockNumberField,
+    mockOptionalFormField,
+    {
+      id: "defineInitiative_endDate",
+      type: ReportFormFieldType.DATE,
+      validation: ValidationType.DATE_OPTIONAL,
+      props: {
+        label: "mock end date field",
+      },
+    },
+    {
+      id: "closeOutInformation_projectedEndDate",
+      type: ReportFormFieldType.DATE,
+      validation: ValidationType.DATE_OPTIONAL,
+      props: {
+        label: "mock projected end date field",
+      },
+    },
+    {
+      id: "closeOutInformation_actualEndDate",
+      type: ReportFormFieldType.DATE,
+      validation: ValidationType.DATE_OPTIONAL,
+      props: {
+        label: "mock close out actual end date field",
+      },
+    },
+  ],
 };
 
 export const mockOverlayModalPageJson2 = {

--- a/services/ui-src/src/utils/testing/mockReport.ts
+++ b/services/ui-src/src/utils/testing/mockReport.ts
@@ -1,4 +1,9 @@
-import { OverlayModalTypes, ReportRoute, ReportStatus } from "types";
+import {
+  EntityType,
+  OverlayModalTypes,
+  ReportRoute,
+  ReportStatus,
+} from "types";
 import { genericErrorContent } from "verbiage/errors";
 import {
   mockStandardReportPageJson,
@@ -145,13 +150,14 @@ export const mockReportFieldData = {
       name: "entity-name",
       entityType_one: "hello",
       transitionBenchmarks_targetPopulationName: "mock benchmark name",
-      type: "mock-type",
+      type: "entityType",
     },
   ],
   initiative: [
     {
       id: "mock-initiative-id",
       name: "mock-name",
+      type: EntityType.INITIATIVE,
       mockObjectiveProgress: [
         {
           id: "mock-objective-1",
@@ -190,12 +196,14 @@ export const mockSARReportFieldData = {
       name: "entity-name",
       entityType_one: "hello",
       transitionBenchmarks_targetPopulationName: "mock benchmark name",
+      type: "entityType",
     },
   ],
   initiative: [
     {
       id: "mock-initiative-id",
       name: "mock-name",
+      type: EntityType.INITIATIVE,
       mockObjectiveProgress: [
         {
           id: "mock-objective-1",

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -260,7 +260,10 @@ export const dynamic = (options?: DynamicOptions, min = 1) =>
     .of(
       object().shape({
         id: schemaMap[ValidationType.TEXT],
-        name: schemaMap[ValidationType.TEXT],
+        name:
+          min > 0
+            ? schemaMap[ValidationType.TEXT]
+            : schemaMap[ValidationType.TEXT_OPTIONAL],
         ...Object.fromEntries(
           Object.entries(options?.dynamicFieldValidations || {}).map(
             ([key, validation]) => [key, resolveSchema(validation)]

--- a/tests/seeds/fixtures/work-plan.ts
+++ b/tests/seeds/fixtures/work-plan.ts
@@ -177,7 +177,7 @@ const addInitiative = (
     },
   ];
 
-  const initativeWorkPlanTopics = [
+  const initiativeWorkPlanTopics = [
     {
       key: "initiative_wpTopic-VjQ0OFqior9Dxu5RRNiZ5u",
       value: "Transitions and transition coordination services*",
@@ -189,6 +189,10 @@ const addInitiative = (
     {
       key: "initiative_wpTopic-SdaFlF3DJyzKcHCCu3Zylm",
       value: "Quality measurement and improvement*",
+    },
+    {
+      key: "initiative_wpTopic-8CpFrev6sMfRijIhafMj7V",
+      value: "Self-direction (*if applicable)",
     },
   ];
 
@@ -241,13 +245,15 @@ const addInitiative = (
     };
   } else {
     flaggedData = {
-      defineInitiative_projectedEndDate_value: "",
       defineInitiative_projectedEndDate: [
         {
-          key: "defineInitiative_projectedEndDate-TR6HoXF3Unf2QX0zzDg2Kp",
-          value: "No",
+          key: "defineInitiative_projectedEndDate-WNsSaAHeDvRD2Pjkz6DcOE",
+          value: "Yes",
         },
       ],
+      defineInitiative_projectedEndDate_value: dateFormat.format(
+        faker.date.future()
+      ),
       defineInitiative_projectedStartDate: dateFormat.format(faker.date.past()),
       evaluationPlan: addEvaluationPlan(year, period, 2),
       fundingSources: [
@@ -278,13 +284,12 @@ const addInitiative = (
     defineInitiative_targetPopulations: initiativeTargetPopulations,
     initiative_name: faker.music.songName(),
     initiative_wp_otherTopic: "",
-    isOtherEntity: true,
-    initiative_wpTopic: [initativeWorkPlanTopics[index]],
+    initiative_wpTopic: [initiativeWorkPlanTopics[index]],
     type: "initiative",
     ...flaggedData,
   });
 
-  return Array.from({ length: 3 }).map((_, index: number) =>
+  return Array.from({ length: 4 }).map((_, index: number) =>
     createInitiative(index)
   );
 };

--- a/tests/seeds/fixtures/work-plan.ts
+++ b/tests/seeds/fixtures/work-plan.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { faker } from "@faker-js/faker";
 // types
 import {
+  EntityType,
   ReportFieldData,
   ReportStatus,
   ReportType,
@@ -285,7 +286,7 @@ const addInitiative = (
     initiative_name: faker.music.songName(),
     initiative_wp_otherTopic: "",
     initiative_wpTopic: [initiativeWorkPlanTopics[index]],
-    type: "initiative",
+    type: EntityType.INITIATIVE,
     ...flaggedData,
   });
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Shows close-out section for a copied over initiative.

Changes:
- Initiatives copy over only name and topic when going from old design -> new design (checking for presence of `evaluationPlan` or `fundingSources` and `wpSarRelease2025` flag)
- Initiatives copy over all Initiative fields when going from new design -> new design
- Whether to show close-out section is tied to `isCopied` on initiative, not on the report
- Updating initiative end date also updates it in close-out section 
- Entering in close-out info shows alert and changes field validations to optional so the form can be submitted
- Entering in close-out info temporarily disables autosave to prevent race condition with form submit button
- Removed `isOtherEntity` prop from copyover - it was removed from UI usage in https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/106

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5332, CMDCT-5603

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

1. Start MFP locally, make sure `wpSarRelease2025` flag is false in your `.env`
2. Log in as state user
3. Create and approve a Work Plan for Report Year 2025, Period 1 (you can use `yarn db:seed` for this step)
<img width="327" height="239" alt="Screenshot 2026-04-29 at 12 49 01 AM" src="https://github.com/user-attachments/assets/45a8184e-35ae-4a56-ab7f-6225298b613a" />

4. Change the `wpSarRelease2025` flag to true in your `.env`
5. Because the flag is sticky in the backend, it'll have to be manually edited in `services/app-api/utils/featureFlags/featureFlags.ts` by changing `JSON.parse(process.env.launchDarklyLocalFlags)` to `JSON.parse('{"local": true, "flags": { "abcdReport": true, "wpSarRelease2025": true}}')`
<img width="693" height="101" alt="Screenshot 2026-05-01 at 1 30 36 PM" src="https://github.com/user-attachments/assets/8ad8410c-a147-4777-89a6-07bf3bed5bfa" />

6. Wait for app-api to rebuild
7. On the Work Plan dashboard, select `Continue MFP Work Plan for next Period`
8. This should create a copied report for Report Year 2025, Period 2
9. In the copied report, confirm initiatives copied over only name and topic
10. Select at least one initiative to close out
11. Alert should appear when you enter close-out info
<img width="767" height="451" alt="Screenshot 2026-04-29 at 12 47 38 AM" src="https://github.com/user-attachments/assets/07c07382-3d25-4607-840d-2d364f9dc65f" />

12. Create a new initiative to replace the closed out one, confirm the close-out section is hidden in the new initiative
13. Fill out missing fields and submit the report
14. Log in as admin user and approve the Report Year 2025, Period 2 report
15. Log in as state user again
16. On the Work Plan dashboard, select `Continue MFP Work Plan for next Period`
17. This should create a copied report for Report Year 2026, Period 1
18. Confirm that closed out initiatives did not copy over
19. Confirm that all initiative fields copied over

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

Completion status for Initiatives will be addressed in a different PR.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

<!-- #### Security -->
<!-- _If either of the following are true, notify the team's ISSO (Information System Security Officer)._ -->

<!-- - [ ] These changes are significant enough to require an update to the SIA. -->
<!-- - [ ] These changes are significant enough to require a penetration test. -->
