### PR TITLE
simply MainSkipNav, remove SkipNav in Sidebar

### DIFF
--- a/services/ui-src/src/components/app/MainSkipNav.test.tsx
+++ b/services/ui-src/src/components/app/MainSkipNav.test.tsx
@@ -1,71 +1,21 @@
 import { render, screen } from "@testing-library/react";
 //components
-import { MainSkipNav, ReportContext } from "components";
-import { ReportContextShape } from "types";
+import { MainSkipNav } from "components";
 import { testA11yAct } from "utils/testing/commonTests";
 
-const mockUseLocation = jest.fn();
-jest.mock("react-router", () => ({
-  useLocation: () => mockUseLocation(),
-}));
-
-const mainSkipNavOutsideReport = (
-  <ReportContext.Provider
-    value={
-      {
-        isReportPage: false,
-      } as ReportContextShape
-    }
-  >
-    <MainSkipNav />
-  </ReportContext.Provider>
-);
-
-const mainSkipNavInsideReport = (
-  <ReportContext.Provider
-    value={
-      {
-        isReportPage: true,
-      } as ReportContextShape
-    }
-  >
-    <MainSkipNav />
-  </ReportContext.Provider>
-);
+const mainSkipNav = <MainSkipNav />;
 
 describe("<MainSkipNav />", () => {
   test("should be visible and focusable", async () => {
-    mockUseLocation.mockReturnValue({ pathname: "/home" });
-    render(mainSkipNavOutsideReport);
+    render(mainSkipNav);
     const skipNav = document.getElementById("skip-nav-main")!;
     skipNav.focus();
 
     const skipNavLink = screen.getByText("Skip to main content");
     await expect(skipNavLink).toHaveFocus();
     await expect(skipNavLink).toBeVisible();
+    await expect(skipNavLink).toHaveAttribute("href", "#main-content");
   });
 
-  test("should skip to report content when on a report page", async () => {
-    mockUseLocation.mockReturnValue({ pathname: "/report-page" });
-    render(mainSkipNavInsideReport);
-    const skipNav = document.getElementById("skip-nav-main")!;
-    skipNav.focus();
-
-    const skipNavLink = screen.getByText("Skip to report sidebar");
-    await expect(skipNavLink).toHaveFocus();
-    await expect(skipNavLink).toBeVisible();
-  });
-
-  test("should skip to main content when on an export page", async () => {
-    mockUseLocation.mockReturnValue({ pathname: "/export" });
-    render(mainSkipNavInsideReport);
-    const skipNav = document.getElementById("skip-nav-main")!;
-    skipNav.focus();
-
-    const skipNavLink = screen.getByText("Skip to main content");
-    await expect(skipNavLink).toHaveFocus();
-    await expect(skipNavLink).toBeVisible();
-  });
-
-  testA11yAct(mainSkipNavOutsideReport);
+  testA11yAct(mainSkipNav);
 });

--- a/services/ui-src/src/components/app/MainSkipNav.tsx
+++ b/services/ui-src/src/components/app/MainSkipNav.tsx
@@ -1,33 +1,14 @@
-import { useContext } from "react";
-import { useLocation } from "react-router";
-// components
-import { ReportContext } from "components/reports/ReportProvider";
 import { SkipNav } from "components";
 
 /**
- * The app's main skip nav changes its target, if we are on a report route.
- *
- * Note this this behavior might not actually matter. It seems that when
- * there are multiple SkipNav components on the page, the last one takes
- * priority. And when we are on a report page, there will be a second SkipNav,
- * in the sidebar.
- *
- * So it is possible that the conditional logic for isReportPage could be
- * removed, and the SkipNav below could be inlined directly in App.tsx,
- * with no change to the overall behavior of the application.
+ * The app's top-level skip nav always targets the main content region.
  */
 export const MainSkipNav = () => {
-  const { isReportPage } = useContext(ReportContext);
-  const { pathname } = useLocation();
-  const isExportPage = pathname.includes("/export");
-
-  const skipSidebarNav = isReportPage && !isExportPage;
-
   return (
     <SkipNav
       id="skip-nav-main"
-      href={skipSidebarNav ? "#skip-nav-sidebar" : "#main-content"}
-      text={`Skip to ${skipSidebarNav ? "report sidebar" : "main content"}`}
+      href="#main-content"
+      text="Skip to main content"
       sxOverride={sx.skipnav}
     />
   );

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -41,28 +41,28 @@ export const Sidebar = ({ isHidden }: SidebarProps) => {
       role="navigation"
       aria-label="Sidebar menu"
     >
-          <Box
-            as="button"
-            sx={sx.closeButton}
-            onClick={() => toggleSidebar(!isOpen)}
-            aria-label="Open/Close sidebar menu"
-          >
-            <Image
-              src={arrowDownIcon}
-              alt={isOpen ? "Arrow left" : "Arrow right"}
-              sx={sx.sidebarIcon}
-              className={isOpen ? "left" : "right"}
-            />
-          </Box>
-          <Box id="sidebar-title-box" sx={sx.topBox}>
-            <Text sx={sx.title}>{reportJson?.name}</Text>
-          </Box>
-          <Box sx={sx.navSectionsBox} className="nav-sections-box">
-            {reportJson.routes.map((section) => (
-              <NavSection key={section.name} section={section} level={1} />
-            ))}
-          </Box>
-        </Box>
+      <Box
+        as="button"
+        sx={sx.closeButton}
+        onClick={() => toggleSidebar(!isOpen)}
+        aria-label="Open/Close sidebar menu"
+      >
+        <Image
+          src={arrowDownIcon}
+          alt={isOpen ? "Arrow left" : "Arrow right"}
+          sx={sx.sidebarIcon}
+          className={isOpen ? "left" : "right"}
+        />
+      </Box>
+      <Box id="sidebar-title-box" sx={sx.topBox}>
+        <Text sx={sx.title}>{reportJson?.name}</Text>
+      </Box>
+      <Box sx={sx.navSectionsBox} className="nav-sections-box">
+        {reportJson.routes.map((section) => (
+          <NavSection key={section.name} section={section} level={1} />
+        ))}
+      </Box>
+    </Box>
   );
 };
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { Link as RouterLink, useLocation } from "react-router";
 // components
 import { Box, Collapse, Flex, Image, Link, Text } from "@chakra-ui/react";
-import { SkipNav } from "components";
 
 // utils
 import { useBreakpoint, useStore } from "utils";
@@ -35,12 +34,6 @@ export const Sidebar = ({ isHidden }: SidebarProps) => {
     <>
       {reportJson && (
         <>
-          <SkipNav
-            id="skip-nav-sidebar"
-            href="#report-content"
-            text="Skip to main content"
-            sxOverride={sx.sideBarSkipNav}
-          />
           <Box
             id="sidebar"
             sx={sx.root}
@@ -196,9 +189,6 @@ const sx = {
       zIndex: "dropdown",
       height: "100%",
     },
-  },
-  sideBarSkipNav: {
-    position: "fixed",
   },
   topBox: {
     borderBottom: "1px solid var(--mdct-colors-gray_lighter)",

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -30,43 +30,39 @@ export const Sidebar = ({ isHidden }: SidebarProps) => {
     toggleSidebar(isDesktop);
   }, [isDesktop]);
 
+  if (!reportJson) return null;
+
   return (
-    <>
-      {reportJson && (
-        <>
+    <Box
+      id="sidebar"
+      sx={sx.root}
+      display={isHidden ? "none" : "block"}
+      className={isOpen ? "open" : "closed"}
+      role="navigation"
+      aria-label="Sidebar menu"
+    >
           <Box
-            id="sidebar"
-            sx={sx.root}
-            display={isHidden ? "none" : "block"}
-            className={isOpen ? "open" : "closed"}
-            role="navigation"
-            aria-label="Sidebar menu"
+            as="button"
+            sx={sx.closeButton}
+            onClick={() => toggleSidebar(!isOpen)}
+            aria-label="Open/Close sidebar menu"
           >
-            <Box
-              as="button"
-              sx={sx.closeButton}
-              onClick={() => toggleSidebar(!isOpen)}
-              aria-label="Open/Close sidebar menu"
-            >
-              <Image
-                src={arrowDownIcon}
-                alt={isOpen ? "Arrow left" : "Arrow right"}
-                sx={sx.sidebarIcon}
-                className={isOpen ? "left" : "right"}
-              />
-            </Box>
-            <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Text sx={sx.title}>{reportJson?.name}</Text>
-            </Box>
-            <Box sx={sx.navSectionsBox} className="nav-sections-box">
-              {reportJson.routes.map((section) => (
-                <NavSection key={section.name} section={section} level={1} />
-              ))}
-            </Box>
+            <Image
+              src={arrowDownIcon}
+              alt={isOpen ? "Arrow left" : "Arrow right"}
+              sx={sx.sidebarIcon}
+              className={isOpen ? "left" : "right"}
+            />
           </Box>
-        </>
-      )}
-    </>
+          <Box id="sidebar-title-box" sx={sx.topBox}>
+            <Text sx={sx.title}>{reportJson?.name}</Text>
+          </Box>
+          <Box sx={sx.navSectionsBox} className="nav-sections-box">
+            {reportJson.routes.map((section) => (
+              <NavSection key={section.name} section={section} level={1} />
+            ))}
+          </Box>
+        </Box>
   );
 };
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
Per the card: 

Simplify MainSkipNav to only link to #main. No need to dynamically change between main and report nav. So no matter which page you're on, there's only one skip link and only skip to #main.



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5589

---
### How to test
Login, confirm that when you are on any page, the `Skip to main content` will change focus to the content of the page. 


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
