### PR TITLE
Change endDate validation to accept dependentFieldName array

### DIFF
--- a/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
+++ b/services/app-api/forms/routes/wp/flags/wpSarRelease2025/state-or-territory-specific-initiatives/initiatives.ts
@@ -329,7 +329,10 @@ export const initiativesRoute: WPStateOrTerritorySpecificInitiativesV2Route = {
         type: ReportFormFieldType.DATE,
         validation: {
           type: ValidationType.END_DATE,
-          dependentFieldName: "defineInitiative_expectedStartDate_value",
+          dependentFieldName: [
+            "defineInitiative_actualStartDate_value",
+            "defineInitiative_expectedStartDate_value",
+          ],
         },
         props: {
           label:

--- a/services/app-api/utils/types/formFields.ts
+++ b/services/app-api/utils/types/formFields.ts
@@ -37,7 +37,7 @@ export interface FormJson {
 
 export interface DependentFieldValidation {
   type: string;
-  dependentFieldName: string;
+  dependentFieldName: string | string[];
   parentOptionId?: never;
 }
 
@@ -50,7 +50,7 @@ export interface NestedFieldValidation {
 
 export interface NestedDependentFieldValidation {
   type: string;
-  dependentFieldName: string;
+  dependentFieldName: string | string[];
   nested: true;
   parentFieldName: string;
   parentOptionId: string;

--- a/services/app-api/utils/validation/completionSchemas.ts
+++ b/services/app-api/utils/validation/completionSchemas.ts
@@ -1,9 +1,9 @@
 import { mixed, string, number as yupNumber } from "yup";
 // utils
 import {
-  endDate as schamaMapEndDate,
-  isEndDateAfterStartDate as schamaMapIsEndDateAfterStartDate,
-  nested as schamaMapEndDateNested,
+  endDate as schemaMapEndDate,
+  isEndDateAfterStartDate as schemaMapIsEndDateAfterStartDate,
+  nested as schemaMapEndDateNested,
   schemaMap,
 } from "./schemaMap";
 
@@ -136,19 +136,18 @@ export const ratio = () =>
     });
 
 // DATE
-export const endDate = (startDateField: string) =>
-  schamaMapEndDate(startDateField);
+export const endDate = (fields: string[]) => schemaMapEndDate(fields);
 export const isEndDateAfterStartDate = (
   startDateField: string,
   endDateString: string
-) => schamaMapIsEndDateAfterStartDate(startDateField, endDateString);
+) => schemaMapIsEndDateAfterStartDate(startDateField, endDateString);
 
 // NESTED
 export const nested = (
   fieldSchema: Function,
   parentFieldName: string,
   parentOptionId: string
-) => schamaMapEndDateNested(fieldSchema, parentFieldName, parentOptionId);
+) => schemaMapEndDateNested(fieldSchema, parentFieldName, parentOptionId);
 
 // SCHEMA MAP
 export const completionSchemaMap: any = {

--- a/services/app-api/utils/validation/completionValidation.test.ts
+++ b/services/app-api/utils/validation/completionValidation.test.ts
@@ -77,7 +77,7 @@ describe("Test mapValidationTypesToSchema", () => {
     const result = mapValidationTypesToSchema(mockDependentValidationType);
     expect(JSON.stringify(result)).toEqual(
       JSON.stringify({
-        key: endDate("mock-dependent-field-name"),
+        key: endDate(["mock-dependent-field-name"]),
       })
     );
   });
@@ -89,7 +89,7 @@ describe("Test mapValidationTypesToSchema", () => {
     expect(JSON.stringify(result)).toEqual(
       JSON.stringify({
         key: nested(
-          () => endDate("mock-dependent-field-name"),
+          () => endDate(["mock-dependent-field-name"]),
           "mock-parent-field-name",
           "mock-parent-option-name"
         ),

--- a/services/app-api/utils/validation/completionValidation.ts
+++ b/services/app-api/utils/validation/completionValidation.ts
@@ -50,7 +50,10 @@ export const mapValidationTypesToSchema = (fieldValidationTypes: AnyObject) => {
 // return created endDate schema
 export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
   const { dependentFieldName } = fieldValidationObject;
-  return endDate(dependentFieldName);
+  const fields = Array.isArray(dependentFieldName)
+    ? dependentFieldName
+    : [dependentFieldName];
+  return endDate(fields);
 };
 
 // return created nested field schema

--- a/services/app-api/utils/validation/schemaMap.test.ts
+++ b/services/app-api/utils/validation/schemaMap.test.ts
@@ -1,5 +1,11 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { isEndDateAfterStartDate, nested, schemaMap } from "./schemaMap";
+import { object } from "yup";
+import {
+  endDate,
+  isEndDateAfterStartDate,
+  nested,
+  schemaMap,
+} from "./schemaMap";
 import {
   AnyObject,
   ValidationType,
@@ -218,6 +224,178 @@ describe("utils/validation/schemaMap", () => {
 
     test("returns false", () => {
       expect(isEndDateAfterStartDate("01/01/1990", "01/01/1989")).toBe(false);
+    });
+
+    test("returns true when dates are the same", () => {
+      expect(isEndDateAfterStartDate("01/01/1990", "01/01/1990")).toBe(true);
+    });
+
+    test("handles empty and invalid inputs", () => {
+      expect(isEndDateAfterStartDate("", "01/01/1990")).toBe(true);
+      expect(isEndDateAfterStartDate("01/01/1990", "")).toBe(true);
+      expect(isEndDateAfterStartDate(undefined as any, "01/01/1990")).toBe(
+        true
+      );
+      expect(isEndDateAfterStartDate(null as any, "01/01/1990")).toBe(true);
+    });
+
+    test("handles invalid date formats", () => {
+      expect(isEndDateAfterStartDate("invalid", "01/01/1990")).toBe(true);
+      expect(isEndDateAfterStartDate("01/01/1990", "invalid")).toBe(true);
+      expect(isEndDateAfterStartDate("13/32/1990", "01/01/1990")).toBe(true);
+    });
+  });
+
+  describe("endDate with conditional start dates", () => {
+    test("validates with single conditional field (legacy behavior)", async () => {
+      const testSchema = object({
+        startDate: schemaMap.date,
+        endDate: endDate(["startDate"]),
+      });
+      const validData = {
+        startDate: "01/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("validates against actual start date when it has a value", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const validData = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("validates against expected start date when actual is empty", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const validData = {
+        actualStartDate: "",
+        expectedStartDate: "01/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("fails when end date is before actual start date", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const invalidData = {
+        actualStartDate: "12/31/1990",
+        expectedStartDate: "",
+        endDate: "01/01/1990",
+      };
+      expect(await testSchema.isValid(invalidData)).toBe(false);
+    });
+
+    test("fails when end date is before expected start date", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const invalidData = {
+        actualStartDate: "",
+        expectedStartDate: "12/31/1990",
+        endDate: "01/01/1990",
+      };
+      expect(await testSchema.isValid(invalidData)).toBe(false);
+    });
+
+    test("passes when end date is entered but no start date selected", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const dataWithOnlyEndDate = {
+        actualStartDate: "",
+        expectedStartDate: "",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(dataWithOnlyEndDate)).toBe(true);
+    });
+
+    test("uses first real value when multiple start dates provided", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const bothDatesValid = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "06/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(bothDatesValid)).toBe(true);
+
+      const betweenDates = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "06/01/1990",
+        endDate: "03/01/1990",
+      };
+      expect(await testSchema.isValid(betweenDates)).toBe(true);
+    });
+
+    test("works with three conditional fields", async () => {
+      const testSchema = object({
+        plannedStartDate: schemaMap.dateOptional,
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate([
+          "plannedStartDate",
+          "actualStartDate",
+          "expectedStartDate",
+        ]),
+      });
+
+      const onlyExpected = {
+        plannedStartDate: "",
+        actualStartDate: "",
+        expectedStartDate: "03/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(onlyExpected)).toBe(true);
+
+      const actualHasValue = {
+        plannedStartDate: "",
+        actualStartDate: "02/01/1990",
+        expectedStartDate: "03/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(actualHasValue)).toBe(true);
+    });
+
+    test("properly validates error message structure", async () => {
+      const testSchema = object({
+        startDate: schemaMap.date,
+        endDate: endDate(["startDate"]),
+      });
+
+      const invalidData = {
+        startDate: "12/31/1990",
+        endDate: "01/01/1990",
+      };
+
+      try {
+        await testSchema.validate(invalidData, { abortEarly: false });
+        fail("Should have thrown validation error");
+      } catch (error: any) {
+        expect(error.errors).toContain("End date can't be before start date");
+      }
     });
   });
 

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -201,26 +201,53 @@ export const dateOptional = () =>
       test: (value) => (value ? dateFormatRegex.test(value) : true),
     });
 
+const findFirstPopulatedValue = (
+  fieldNames: string[],
+  parentData: Record<string, any>
+): string | undefined => {
+  return fieldNames.map((fieldName) => parentData[fieldName]).find(Boolean);
+};
+
+const areBothDatesValid = (date1: Date, date2: Date): boolean => {
+  return !isNaN(date1.getTime()) && !isNaN(date2.getTime());
+};
+
 export const endDate = (fields: string[]) =>
   date()
     .typeError(error.INVALID_DATE)
     .test({
       message: error.INVALID_END_DATE,
       test: (endDateString = "", context) => {
-        const startDateValue = fields
-          .map((f) => context.parent[f])
-          .find(Boolean);
-        return isEndDateAfterStartDate(startDateValue, endDateString);
+        const firstPopulatedStartDate = findFirstPopulatedValue(
+          fields,
+          context.parent
+        );
+
+        if (!firstPopulatedStartDate) {
+          return true;
+        }
+
+        return isEndDateAfterStartDate(firstPopulatedStartDate, endDateString);
       },
     });
 
 export const isEndDateAfterStartDate = (
   startDateString: string,
   endDateString: string
-) => {
+): boolean => {
+  if (!startDateString || !endDateString) {
+    return true;
+  }
+
   const startDate = new Date(startDateString);
-  const endDate = new Date(endDateString!);
-  return endDate >= startDate;
+  const endDate = new Date(endDateString);
+
+  if (!areBothDatesValid(startDate, endDate)) {
+    return true;
+  }
+
+  const endDateIsOnOrAfterStartDate = endDate >= startDate;
+  return endDateIsOnOrAfterStartDate;
 };
 
 // DROPDOWN

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -201,16 +201,16 @@ export const dateOptional = () =>
       test: (value) => (value ? dateFormatRegex.test(value) : true),
     });
 
-export const endDate = (startDateField: string) =>
+export const endDate = (fields: string[]) =>
   date()
     .typeError(error.INVALID_DATE)
     .test({
       message: error.INVALID_END_DATE,
-      test: (endDateString, context) => {
-        return isEndDateAfterStartDate(
-          context.parent[startDateField],
-          endDateString as string
-        );
+      test: (endDateString = "", context) => {
+        const startDateValue = fields
+          .map((f) => context.parent[f])
+          .find(Boolean);
+        return isEndDateAfterStartDate(startDateValue, endDateString);
       },
     });
 

--- a/services/app-api/utils/validation/validation.test.ts
+++ b/services/app-api/utils/validation/validation.test.ts
@@ -76,7 +76,7 @@ describe("Test mapValidationTypesToSchema", () => {
     const result = mapValidationTypesToSchema(mockDependentValidationType);
     expect(JSON.stringify(result)).toEqual(
       JSON.stringify({
-        key: schema.endDate("mock-dependent-field-name"),
+        key: schema.endDate(["mock-dependent-field-name"]),
       })
     );
   });
@@ -88,7 +88,7 @@ describe("Test mapValidationTypesToSchema", () => {
     expect(JSON.stringify(result)).toEqual(
       JSON.stringify({
         key: schema.nested(
-          () => schema.endDate("mock-dependent-field-name"),
+          () => schema.endDate(["mock-dependent-field-name"]),
           "mock-parent-field-name",
           "mock-parent-option-name"
         ),

--- a/services/app-api/utils/validation/validation.ts
+++ b/services/app-api/utils/validation/validation.ts
@@ -77,7 +77,10 @@ export const mapValidationTypesToSchema = (fieldValidationTypes: AnyObject) => {
 // return created endDate schema
 export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
   const { dependentFieldName } = fieldValidationObject;
-  return endDate(dependentFieldName);
+  const fields = Array.isArray(dependentFieldName)
+    ? dependentFieldName
+    : [dependentFieldName];
+  return endDate(fields);
 };
 
 // return created nested field schema

--- a/services/ui-src/src/types/formFields.ts
+++ b/services/ui-src/src/types/formFields.ts
@@ -89,7 +89,7 @@ export interface CustomFieldValidation {
 
 export interface DependentFieldValidation {
   type: string;
-  dependentFieldName: string;
+  dependentFieldName: string | string[];
   options?: never;
   parentOptionId?: never;
 }
@@ -104,7 +104,7 @@ export interface NestedFieldValidation {
 
 export interface NestedDependentFieldValidation {
   type: string;
-  dependentFieldName: string;
+  dependentFieldName: string | string[];
   options?: never;
   nested: true;
   parentFieldName: string;

--- a/services/ui-src/src/utils/validation/schemas.test.ts
+++ b/services/ui-src/src/utils/validation/schemas.test.ts
@@ -1,5 +1,6 @@
 import { MixedSchema } from "yup/lib/mixed";
-import { isEndDateAfterStartDate, nested, schemaMap } from "./schemas";
+import { object } from "yup";
+import { endDate, isEndDateAfterStartDate, nested, schemaMap } from "./schemas";
 import {
   AnyObject,
   NumberOptions,
@@ -220,6 +221,178 @@ describe("utils/validation/schemas", () => {
 
     test("returns false", () => {
       expect(isEndDateAfterStartDate("01/01/1990", "01/01/1989")).toBe(false);
+    });
+
+    test("returns true when dates are the same", () => {
+      expect(isEndDateAfterStartDate("01/01/1990", "01/01/1990")).toBe(true);
+    });
+
+    test("handles empty and invalid inputs", () => {
+      expect(isEndDateAfterStartDate("", "01/01/1990")).toBe(true);
+      expect(isEndDateAfterStartDate("01/01/1990", "")).toBe(true);
+      expect(isEndDateAfterStartDate(undefined as any, "01/01/1990")).toBe(
+        true
+      );
+      expect(isEndDateAfterStartDate(null as any, "01/01/1990")).toBe(true);
+    });
+
+    test("handles invalid date formats", () => {
+      expect(isEndDateAfterStartDate("invalid", "01/01/1990")).toBe(true);
+      expect(isEndDateAfterStartDate("01/01/1990", "invalid")).toBe(true);
+      expect(isEndDateAfterStartDate("13/32/1990", "01/01/1990")).toBe(true);
+    });
+  });
+
+  describe("endDate with conditional start dates", () => {
+    test("validates with single conditional field (legacy behavior)", async () => {
+      const testSchema = object({
+        startDate: schemaMap.date,
+        endDate: endDate(["startDate"]),
+      });
+      const validData = {
+        startDate: "01/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("validates against actual start date when it has a value", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const validData = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("validates against expected start date when actual is empty", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const validData = {
+        actualStartDate: "",
+        expectedStartDate: "01/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(validData)).toBe(true);
+    });
+
+    test("fails when end date is before actual start date", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const invalidData = {
+        actualStartDate: "12/31/1990",
+        expectedStartDate: "",
+        endDate: "01/01/1990",
+      };
+      expect(await testSchema.isValid(invalidData)).toBe(false);
+    });
+
+    test("end date is before expected start date", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const invalidData = {
+        actualStartDate: "",
+        expectedStartDate: "12/31/1990",
+        endDate: "01/01/1990",
+      };
+      expect(await testSchema.isValid(invalidData)).toBe(false);
+    });
+
+    test("end date is entered but no start date selected yet", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.dateOptional,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const dataWithOnlyEndDate = {
+        actualStartDate: "",
+        expectedStartDate: "",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(dataWithOnlyEndDate)).toBe(true);
+    });
+
+    test("use first defined value when multiple start dates provided", async () => {
+      const testSchema = object({
+        actualStartDate: schemaMap.date,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate(["actualStartDate", "expectedStartDate"]),
+      });
+      const bothDatesValid = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "06/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(bothDatesValid)).toBe(true);
+
+      const betweenDates = {
+        actualStartDate: "01/01/1990",
+        expectedStartDate: "06/01/1990",
+        endDate: "03/01/1990",
+      };
+      expect(await testSchema.isValid(betweenDates)).toBe(true);
+    });
+
+    test("works with three conditional fields", async () => {
+      const testSchema = object({
+        plannedStartDate: schemaMap.dateOptional,
+        actualStartDate: schemaMap.dateOptional,
+        expectedStartDate: schemaMap.date,
+        endDate: endDate([
+          "plannedStartDate",
+          "actualStartDate",
+          "expectedStartDate",
+        ]),
+      });
+
+      const onlyExpected = {
+        plannedStartDate: "",
+        actualStartDate: "",
+        expectedStartDate: "03/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(onlyExpected)).toBe(true);
+
+      const actualHasValue = {
+        plannedStartDate: "",
+        actualStartDate: "02/01/1990",
+        expectedStartDate: "03/01/1990",
+        endDate: "12/31/1990",
+      };
+      expect(await testSchema.isValid(actualHasValue)).toBe(true);
+    });
+
+    test("validates error message structure correctly", async () => {
+      const testSchema = object({
+        startDate: schemaMap.date,
+        endDate: endDate(["startDate"]),
+      });
+
+      const invalidData = {
+        startDate: "12/31/1990",
+        endDate: "01/01/1990",
+      };
+
+      try {
+        await testSchema.validate(invalidData, { abortEarly: false });
+        fail("Should have thrown validation error");
+      } catch (error: any) {
+        expect(error.errors).toContain("End date can't be before start date");
+      }
     });
   });
 

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -202,16 +202,16 @@ export const dateOptional = () =>
       test: (value) => (value ? dateFormatRegex.test(value) : true),
     });
 
-export const endDate = (startDateField: string) =>
+export const endDate = (fields: string[]) =>
   date()
     .typeError(error.INVALID_DATE)
     .test({
       message: error.INVALID_END_DATE,
-      test: (endDateString, context) => {
-        return isEndDateAfterStartDate(
-          context.parent[startDateField],
-          endDateString as string
-        );
+      test: (endDateString = "", context) => {
+        const startDateValue = fields
+          .map((f) => context.parent[f])
+          .find(Boolean);
+        return isEndDateAfterStartDate(startDateValue, endDateString);
       },
     });
 
@@ -220,7 +220,7 @@ export const isEndDateAfterStartDate = (
   endDateString: string
 ) => {
   const startDate = new Date(startDateString);
-  const endDate = new Date(endDateString!);
+  const endDate = new Date(endDateString);
   return endDate >= startDate;
 };
 

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -202,26 +202,53 @@ export const dateOptional = () =>
       test: (value) => (value ? dateFormatRegex.test(value) : true),
     });
 
+const findFirstPopulatedValue = (
+  fieldNames: string[],
+  parentData: Record<string, any>
+): string | undefined => {
+  return fieldNames.map((fieldName) => parentData[fieldName]).find(Boolean);
+};
+
+const areBothDatesValid = (date1: Date, date2: Date): boolean => {
+  return !isNaN(date1.getTime()) && !isNaN(date2.getTime());
+};
+
 export const endDate = (fields: string[]) =>
   date()
     .typeError(error.INVALID_DATE)
     .test({
       message: error.INVALID_END_DATE,
       test: (endDateString = "", context) => {
-        const startDateValue = fields
-          .map((f) => context.parent[f])
-          .find(Boolean);
-        return isEndDateAfterStartDate(startDateValue, endDateString);
+        const firstPopulatedStartDate = findFirstPopulatedValue(
+          fields,
+          context.parent
+        );
+
+        if (!firstPopulatedStartDate) {
+          return true;
+        }
+
+        return isEndDateAfterStartDate(firstPopulatedStartDate, endDateString);
       },
     });
 
 export const isEndDateAfterStartDate = (
   startDateString: string,
   endDateString: string
-) => {
+): boolean => {
+  if (!startDateString || !endDateString) {
+    return true;
+  }
+
   const startDate = new Date(startDateString);
   const endDate = new Date(endDateString);
-  return endDate >= startDate;
+
+  if (!areBothDatesValid(startDate, endDate)) {
+    return true;
+  }
+
+  const endDateIsOnOrAfterStartDate = endDate >= startDate;
+  return endDateIsOnOrAfterStartDate;
 };
 
 // DROPDOWN

--- a/services/ui-src/src/utils/validation/validation.test.ts
+++ b/services/ui-src/src/utils/validation/validation.test.ts
@@ -77,7 +77,7 @@ describe("utils/validation", () => {
       const result = mapValidationTypesToSchema(mockDependentValidationType);
       expect(JSON.stringify(result)).toEqual(
         JSON.stringify({
-          key: schema.endDate("mock-dependent-field-name"),
+          key: schema.endDate(["mock-dependent-field-name"]),
         })
       );
     });
@@ -89,7 +89,7 @@ describe("utils/validation", () => {
       expect(JSON.stringify(result)).toEqual(
         JSON.stringify({
           key: schema.nested(
-            () => schema.endDate("mock-dependent-field-name"),
+            () => schema.endDate(["mock-dependent-field-name"]),
             "mock-parent-field-name",
             "mock-parent-option-name"
           ),

--- a/services/ui-src/src/utils/validation/validation.ts
+++ b/services/ui-src/src/utils/validation/validation.ts
@@ -41,7 +41,10 @@ export const mapValidationTypesToSchema = (fieldValidationTypes: AnyObject) => {
 // return created endDate schema
 export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
   const { dependentFieldName } = fieldValidationObject;
-  return endDate(dependentFieldName);
+  const fields = Array.isArray(dependentFieldName)
+    ? dependentFieldName
+    : [dependentFieldName];
+  return endDate(fields);
 };
 
 // return created nested field schema


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
The Initiatives page overhaul makes a change from using a start date and actual/expected end date to actual/expected start date and an end date. The validation currently takes a single id for the field that an end date needs to compare itself against. In the new data structure, the end date needs to validate against either the actual or expected start date, which are separate fields with different ids.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5802

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- cloudfront link: https://d29ka82ubxu7a9.cloudfront.net/
- Create a WP, navigate to the initiatives section 
- Create an initiative, and test these 5 conditions: 
    - Leave both start dates empty, enter a value for end date. No validation error should appear
    - Have end date be after expected start date. No validation error should appear
    - Have end date be before expected start date. Validation error should appear
    - Have end date be after actual start date. No validation error should appear
    - Have end date be before actual start date. Validation error should appear

<img width="654" height="466" alt="Screenshot 2026-05-16 at 1 49 27 AM" src="https://github.com/user-attachments/assets/a2129f18-e6f4-4d1f-865f-fd84f1115240" />


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
