### PR TITLE
Create legacy SAR template from legacy WP data

### DIFF
--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -12,6 +12,7 @@ import {
   getOrCreateFormTemplate,
   isFieldElement,
   isLayoutElement,
+  isLegacySAR,
 } from "./formTemplates";
 // forms
 import { wpReportJson as wp, sarReportJson as sar } from "../../forms";
@@ -328,19 +329,13 @@ describe("Test formTemplateForReportType legacy WP & SAR", () => {
     jest.clearAllMocks();
   });
 
-  const getInitiativesRoute = (formTemplate: ReportJson) =>
-    formTemplate.routes.find(
-      (route) => route.path === "/sar/state-or-territory-specific-initiatives"
-    ) as DynamicModalOverlayReportPageShape | undefined;
-
   it("returns legacy SAR template (with initiatives) when workPlanFieldData is from a legacy WP", async () => {
     const legacyFieldData = { strategy_additionalDetails: "some value" };
     const template = await formTemplateForReportType(
       ReportType.SAR,
       legacyFieldData
     );
-    const initiativesRoute = getInitiativesRoute(template);
-    expect("initiatives" in (initiativesRoute ?? {})).toBe(true);
+    expect(isLegacySAR(template)).toBe(true);
   });
 
   it("returns new SAR template when workPlanFieldData lacks 'strategy_additionalDetails'", async () => {
@@ -350,8 +345,7 @@ describe("Test formTemplateForReportType legacy WP & SAR", () => {
       ReportType.SAR,
       modernFieldData
     );
-    const initiativesRoute = getInitiativesRoute(template);
-    expect("initiatives" in (initiativesRoute ?? {})).toBeFalsy();
+    expect(isLegacySAR(template)).toBeFalsy();
   });
 
   it("does not short-circuit feature flagged templates when workPlanFieldData is absent", async () => {

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -345,7 +345,7 @@ describe("Test formTemplateForReportType legacy WP & SAR", () => {
       ReportType.SAR,
       modernFieldData
     );
-    expect(isLegacySAR(template)).toBeFalsy();
+    expect(isLegacySAR(template)).toBe(false);
   });
 
   it("does not short-circuit feature flagged templates when workPlanFieldData is absent", async () => {

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -323,6 +323,51 @@ describe("Test form contents", () => {
   });
 });
 
+describe("Test formTemplateForReportType legacy WP & SAR", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const getInitiativesRoute = (formTemplate: ReportJson) =>
+    formTemplate.routes.find(
+      (route) => route.path === "/sar/state-or-territory-specific-initiatives"
+    ) as DynamicModalOverlayReportPageShape | undefined;
+
+  it("returns legacy SAR template (with entitySteps) when workPlanFieldData is from a legacy WP", async () => {
+    const legacyFieldData = { strategy_additionalDetails: "some value" };
+    const template = await formTemplateForReportType(
+      ReportType.SAR,
+      legacyFieldData
+    );
+    const initiativesRoute = getInitiativesRoute(template);
+    expect("entitySteps" in (initiativesRoute?.initiatives?.[0] ?? {})).toBe(
+      true
+    );
+  });
+
+  it("returns new SAR template when workPlanFieldData lacks 'strategy_additionalDetails'", async () => {
+    (isFeatureFlagEnabled as jest.Mock).mockResolvedValue(true);
+    const modernFieldData = { someOtherKey: "value" };
+    const template = await formTemplateForReportType(
+      ReportType.SAR,
+      modernFieldData
+    );
+    const initiativesRoute = getInitiativesRoute(template);
+    expect(
+      "entitySteps" in (initiativesRoute?.initiatives?.[0] ?? {})
+    ).toBeFalsy();
+  });
+
+  it("does not short-circuit feature flagged templates when workPlanFieldData is absent", async () => {
+    (isFeatureFlagEnabled as jest.Mock).mockResolvedValue(false);
+    await formTemplateForReportType(ReportType.WP);
+    expect(isFeatureFlagEnabled).toHaveBeenCalled();
+
+    await formTemplateForReportType(ReportType.SAR);
+    expect(isFeatureFlagEnabled).toHaveBeenCalled();
+  });
+});
+
 describe("Test compileValidationJsonFromRoutes", () => {
   it("Compiles validation from forms of any kind", () => {
     const result = compileValidationJsonFromRoutes(

--- a/services/app-api/utils/formTemplates/formTemplates.test.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.test.ts
@@ -333,16 +333,14 @@ describe("Test formTemplateForReportType legacy WP & SAR", () => {
       (route) => route.path === "/sar/state-or-territory-specific-initiatives"
     ) as DynamicModalOverlayReportPageShape | undefined;
 
-  it("returns legacy SAR template (with entitySteps) when workPlanFieldData is from a legacy WP", async () => {
+  it("returns legacy SAR template (with initiatives) when workPlanFieldData is from a legacy WP", async () => {
     const legacyFieldData = { strategy_additionalDetails: "some value" };
     const template = await formTemplateForReportType(
       ReportType.SAR,
       legacyFieldData
     );
     const initiativesRoute = getInitiativesRoute(template);
-    expect("entitySteps" in (initiativesRoute?.initiatives?.[0] ?? {})).toBe(
-      true
-    );
+    expect("initiatives" in (initiativesRoute ?? {})).toBe(true);
   });
 
   it("returns new SAR template when workPlanFieldData lacks 'strategy_additionalDetails'", async () => {
@@ -353,9 +351,7 @@ describe("Test formTemplateForReportType legacy WP & SAR", () => {
       modernFieldData
     );
     const initiativesRoute = getInitiativesRoute(template);
-    expect(
-      "entitySteps" in (initiativesRoute?.initiatives?.[0] ?? {})
-    ).toBeFalsy();
+    expect("initiatives" in (initiativesRoute ?? {})).toBeFalsy();
   });
 
   it("does not short-circuit feature flagged templates when workPlanFieldData is absent", async () => {

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -55,7 +55,10 @@ export const formTemplateForReportType = async (
   const flagNames = Object.keys(flagsByReportType);
 
   // Legacy WP field data should always produce a legacy SAR template, regardless of feature flags
-  const isLegacySAR = reportType === ReportType.SAR && workPlanFieldData && "strategy_additionalDetails" in workPlanFieldData;
+  const isLegacySAR =
+    reportType === ReportType.SAR &&
+    workPlanFieldData &&
+    "strategy_additionalDetails" in workPlanFieldData;
   if (isLegacySAR) {
     return structuredClone(sarReportJson as ReportJson);
   }

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -55,11 +55,11 @@ export const formTemplateForReportType = async (
   const flagNames = Object.keys(flagsByReportType);
 
   // Legacy WP field data should always produce a legacy SAR template, regardless of feature flags
-  const isLegacySAR =
+  const sarWithLegacyWorkPlan =
     reportType === ReportType.SAR &&
     workPlanFieldData &&
     "strategy_additionalDetails" in workPlanFieldData;
-  if (isLegacySAR) {
+  if (sarWithLegacyWorkPlan) {
     return structuredClone(sarReportJson as ReportJson);
   }
 

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -55,11 +55,8 @@ export const formTemplateForReportType = async (
   const flagNames = Object.keys(flagsByReportType);
 
   // Legacy WP field data should always produce a legacy SAR template, regardless of feature flags
-  if (
-    reportType === ReportType.SAR &&
-    workPlanFieldData &&
-    "strategy_additionalDetails" in workPlanFieldData
-  ) {
+  const isLegacySAR = reportType === ReportType.SAR && workPlanFieldData && "strategy_additionalDetails" in workPlanFieldData;
+  if (isLegacySAR) {
     return structuredClone(sarReportJson as ReportJson);
   }
 

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -155,6 +155,16 @@ export async function getOrCreateFormTemplate(
   }
 }
 
+export const isLegacySAR = (template: ReportJson): boolean => {
+  // If you duplicate this function in ui-src, update it there too!
+  const initiativesRoute = template.routes.find(
+    (route) => route.path === "/sar/state-or-territory-specific-initiatives"
+  );
+
+  // Pre-2026 SAR templates will include an initiatives array in the SAR State or Territory Specific Initiatives route, while 2026+ templates will not
+  return initiativesRoute ? "initiatives" in initiativesRoute : false;
+};
+
 // returns flattened array of valid routes for given reportJson
 export const flattenReportRoutesArray = (
   reportJson: ReportRoute[]

--- a/services/app-api/utils/formTemplates/formTemplates.ts
+++ b/services/app-api/utils/formTemplates/formTemplates.ts
@@ -35,7 +35,10 @@ import * as wpFlags from "../../forms/routes/wp/flags";
 import * as sarFlags from "../../forms/routes/sar/flags";
 import * as financialReportFlags from "../../forms/routes/financial-report/flags";
 
-export const formTemplateForReportType = async (reportType: ReportType) => {
+export const formTemplateForReportType = async (
+  reportType: ReportType,
+  workPlanFieldData?: AnyObject
+) => {
   const routeMap: Record<ReportType, ReportJsonFile> = {
     [ReportType.WP]: wpReportJson,
     [ReportType.SAR]: sarReportJson,
@@ -50,6 +53,15 @@ export const formTemplateForReportType = async (reportType: ReportType) => {
 
   const flagsByReportType = flagMap[reportType];
   const flagNames = Object.keys(flagsByReportType);
+
+  // Legacy WP field data should always produce a legacy SAR template, regardless of feature flags
+  if (
+    reportType === ReportType.SAR &&
+    workPlanFieldData &&
+    "strategy_additionalDetails" in workPlanFieldData
+  ) {
+    return structuredClone(sarReportJson as ReportJson);
+  }
 
   // Loop through flags and replace routes if flag is enabled
   for (const flagName of flagNames) {
@@ -71,7 +83,10 @@ export async function getOrCreateFormTemplate(
   reportYear: number,
   workPlanFieldData?: AnyObject
 ) {
-  let currentFormTemplate = await formTemplateForReportType(reportType);
+  let currentFormTemplate = await formTemplateForReportType(
+    reportType,
+    workPlanFieldData
+  );
 
   if (currentFormTemplate?.routes) {
     currentFormTemplate = transformFormTemplate(

--- a/services/ui-src/src/components/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/components/tables/getEntityStatus.test.ts
@@ -69,6 +69,48 @@ describe("tables/getEntityStatus", () => {
 
       expect(result).toEqual(["field1", "field2", "nestedField3"]);
     });
+
+    test("should not throw when entity field values are null", () => {
+      // typeof null === "object", so null values must be filtered out
+      // before accessing `.key` on them.
+      const fields = [
+        {
+          id: "field1",
+          type: ReportFormFieldType.TEXT,
+          validation: ValidationType.TEXT,
+        },
+        {
+          id: "field2",
+          type: ReportFormFieldType.RADIO,
+          validation: ValidationType.RADIO,
+          props: {
+            choices: [
+              {
+                id: "choice1",
+                children: [
+                  {
+                    id: "nestedField3",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ];
+      const entity = {
+        id: "entity1",
+        type: EntityType.INITIATIVE,
+        field1: null,
+        field2: [null, { key: "choice1key" }],
+      };
+
+      expect(() => getValidationList(fields, entity)).not.toThrow();
+      expect(getValidationList(fields, entity)).toEqual([
+        "field1",
+        "field2",
+        "nestedField3",
+      ]);
+    });
   });
 
   describe("getEntityStatus()", () => {

--- a/services/ui-src/src/components/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/components/tables/getEntityStatus.test.ts
@@ -101,7 +101,7 @@ describe("tables/getEntityStatus", () => {
         id: "entity1",
         type: EntityType.INITIATIVE,
         field1: null,
-        field2: [null, { key: "choice1key" }],
+        field2: [{ key: "choice1key" }],
       };
 
       expect(getValidationList(fields, entity)).toEqual([

--- a/services/ui-src/src/components/tables/getEntityStatus.test.ts
+++ b/services/ui-src/src/components/tables/getEntityStatus.test.ts
@@ -104,7 +104,6 @@ describe("tables/getEntityStatus", () => {
         field2: [null, { key: "choice1key" }],
       };
 
-      expect(() => getValidationList(fields, entity)).not.toThrow();
       expect(getValidationList(fields, entity)).toEqual([
         "field1",
         "field2",

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -42,7 +42,7 @@ export const getValidationList = (fields: AnyObject[], entity: AnyObject) => {
   const entityNestedKeys = entityNestedSelection
     .flat()
     .map((entity) => {
-      return entity?.key;
+      return entity.key;
     })
     .filter(Boolean);
 

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -30,13 +30,10 @@ export const getValidationList = (fields: AnyObject[], entity: AnyObject) => {
     .filter(Boolean);
 
   //Loop through the user entered entity to see which nested id the user had selected
-  const entityNestedSelection: AnyObject[] = [];
-  Object.values(entity).forEach((field: AnyObject) => {
-    // typeof null === "object", so guard against null field values
-    if (field !== null && typeof field === "object") {
-      entityNestedSelection.push(field);
-    }
-  });
+  // typeof null === "object", so we need to guard against null field values
+  const entityNestedSelection = Object.values(entity).filter(
+    (field) => field !== null && typeof field === "object"
+  );
 
   //Strip it to only the key information
   const entityNestedKeys = entityNestedSelection

--- a/services/ui-src/src/components/tables/getEntityStatus.tsx
+++ b/services/ui-src/src/components/tables/getEntityStatus.tsx
@@ -32,7 +32,8 @@ export const getValidationList = (fields: AnyObject[], entity: AnyObject) => {
   //Loop through the user entered entity to see which nested id the user had selected
   const entityNestedSelection: AnyObject[] = [];
   Object.values(entity).forEach((field: AnyObject) => {
-    if (typeof field === "object") {
+    // typeof null === "object", so guard against null field values
+    if (field !== null && typeof field === "object") {
       entityNestedSelection.push(field);
     }
   });
@@ -41,7 +42,7 @@ export const getValidationList = (fields: AnyObject[], entity: AnyObject) => {
   const entityNestedKeys = entityNestedSelection
     .flat()
     .map((entity) => {
-      return entity.key;
+      return entity?.key;
     })
     .filter(Boolean);
 


### PR DESCRIPTION
### Description
This change ensures that even if the feature flag is enabled, if the WP data is from the legacy WP template, the user will see the legacy SAR template when creating a new SAR, rather than the feature flagged version.

❇️ BONUS: also fixes a nasty bug where `null` values for optional entity fields were causing the initiatives page to crash in the new WP/SAR flow. More detail on how to recreate that below.

### Related ticket(s)
CMDCT-5995

### Cloudfront URL
https://d31de7rcce6h74.cloudfront.net/

---
### How to test
**To test this appropriately, you'll need to be able to toggle the feature flag on and off to create reports with "legacy" templates as well as the new template.**

#### Old WP -> Old SAR

1. Run the app locally
2. In [featureFlags.ts](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/app-api/utils/featureFlags/featureFlags.ts#L5), change line 5 to read:
`JSON.parse({"local": true, "flags": { "abcdReport": false, "wpSarRelease2025": false}})`. Wait for the API to finish building.
3. Create/fill out/submit/approve a Work Plan. It should have the old initiatives flow, with the dashboard and overlays. You can use the `db:seed` utility to do this.
4. Verify quickly that the WP is the legacy version. When clicking "View" on an initiative, you should see the old initiative dashboard view (with Define Initiative, Evaluation Plan, Funding Sources, etc).
5. Create a new SAR using the UI or `db:seed`.
6. View the State or Territory-Specific Initiatives section of the SAR and verify that it is using the old template. Similar to the WP, there should be an initiative dashboard view.

**Old WP**
<img width="2994" height="2356" alt="Screenshot 2026-05-18 at 13-08-11 Money Follows the Person" src="https://github.com/user-attachments/assets/af394e2e-6372-497f-bfa8-f80c8889d0e1" />

**Old SAR**
<img width="2994" height="2254" alt="Screenshot 2026-05-18 at 13-11-22 Money Follows the Person" src="https://github.com/user-attachments/assets/0c240f17-f6ea-4730-9fb2-dfae90d3038c" />

#### New WP -> New SAR
1. In [featureFlags.ts](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/blob/main/services/app-api/utils/featureFlags/featureFlags.ts#L5), change line 5 to read:
`JSON.parse({"local": true, "flags": { "abcdReport": false, "wpSarRelease2025": true}})`. Wait for the API to finish building.
2. Create/fill out/submit/approve a Work Plan. It should have the NEW initiatives flow, without a dashboard, and a single overlay page per initiative.
3. Create a new SAR using the UI or `db:seed`.
4. View the State or Territory-Specific Initiatives section of the SAR and verify that it is using the NEW template. 


#### ❇️ BONUS: recreate the null values bug
If you want to understand why [b393a43](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/1447/commits/b393a43307b1a5c436c117cbec6268152dfcf658) came to be, this is for you. To recreate:

1. Switch to main (not this branch)
2. Make sure the wpSarRelease2025 feature flag is enabled
3. Create an approved WP
4. Then create a **copy over** from that WP (you need this to get the closeout fields in the initiatives page)
5. Edit one of the initiatives. In the Closeout Information section, click into the actual end date field, then leave it (don't enter info). Save and return.
6. Watch the page blow up.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
