### PR TITLE
CMDCT-6122: skips sending objects over 1MB to Kafka

### DIFF
--- a/services/app-api/handlers/kafka/postKafkaData.test.ts
+++ b/services/app-api/handlers/kafka/postKafkaData.test.ts
@@ -271,6 +271,18 @@ describe("Kafka message sending", () => {
     });
   });
 
+  it("should ignore oversized S3 payloads before fetching or sending", async () => {
+    const record = structuredClone(wpFormTemplateRecord);
+    record.s3.object.size = 1_000_000;
+    const event = { Records: [record] };
+    await handler(event);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Ignoring record: oversized S3 object")
+    );
+    expect(mockS3Get).not.toHaveBeenCalled();
+    expect(mockSendBatch).not.toHaveBeenCalled();
+  });
+
   it("should ignore events from buckets with no associated topic", async () => {
     const record = structuredClone(wpFormTemplateRecord);
     record.s3.bucket.name = "unknown-bucket";

--- a/services/app-api/handlers/kafka/postKafkaData.ts
+++ b/services/app-api/handlers/kafka/postKafkaData.ts
@@ -9,6 +9,9 @@ import {
 } from "./kafkaLib";
 import { createClient } from "../../storage/s3-lib";
 
+// Kafka rejects messages at 1 MB and above.
+const MAX_KAFKA_S3_PAYLOAD_BYTES = 1_000_000;
+
 const getConfig: GetKafkaConfig = () => {
   const { brokerString, STAGE } = process.env;
 
@@ -97,6 +100,14 @@ const getS3Topic: GetS3Topic = (record) => {
 
   if (!matchingRule) {
     console.warn(`Ignoring record: no matching s3 rule. ${bucket}#${key}`);
+    return undefined;
+  }
+
+  const objectSize = Number((record.s3.object as { size?: number }).size);
+  if (Number.isFinite(objectSize) && objectSize >= MAX_KAFKA_S3_PAYLOAD_BYTES) {
+    console.warn(
+      `Ignoring record: oversized S3 object ${bucket}#${key} (${objectSize} bytes); Kafka rejects 1MB+ messages.`
+    );
     return undefined;
   }
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
CMDCT-6122: skips sending objects over 1MB to Kafka


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6122

---
### How to test
In the deployed environment, verify an object over 1MB logs a warning in cloudwatch and is not attempted to be sent to Kafka.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
