### PR TITLE
CMDCT-6151 508 issue - footer link on focus

### DIFF
--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -236,6 +236,9 @@ const sx = {
   },
   link: {
     margin: "0.5rem 0",
+    "&:focus, &:visited:focus": {
+      color: "gray_lighter",
+    },
     ".desktop &": {
       "&:first-of-type": {
         paddingRight: "spacer1",

--- a/services/ui-src/src/components/layout/Footer.tsx
+++ b/services/ui-src/src/components/layout/Footer.tsx
@@ -236,7 +236,7 @@ const sx = {
   },
   link: {
     margin: "0.5rem 0",
-    "&:focus, &:visited:focus": {
+    "&:focus-visible, &:visited:focus-visible": {
       color: "gray_lighter",
     },
     ".desktop &": {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
Links in the footer changed to an inaccessible color on keyboard focus.

**Before:**
<img width="1770" height="2026" alt="MFP footer link issue" src="https://github.com/user-attachments/assets/0fb23d7e-2768-42f7-97b0-26b5ad4cc3ff" />


**After:**
<img width="1424" height="622" alt="MFP footer link fix" src="https://github.com/user-attachments/assets/fe2b90f9-0a5f-4816-b73f-440dabca86d3" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6151

---
### How to test
- Run local env or use the [deployed env](https://d3vh4l9c8dzhwk.cloudfront.net/)
- Log in
- On the home page (or any other page), use the `Tab` key to move keyboard focus to the footer links
- Confirm that when links in the footer have focus, they are still readable

