### PR TITLE
CMDCT-6152 508 issue - error messages not announced

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -106,8 +106,9 @@ export const DropdownField = ({
   const formErrorState: AnyObject = form?.formState?.errors;
   const errorMessage = formErrorState?.[name]?.value?.message as ReactNode;
   const parsedHint = hint ? parseCustomHtml(hint) : undefined;
-  const ariaDescribedBy = parsedHint ? `${name}-hint` : undefined;
+  const ariaDescribedBy = `${name}__error${parsedHint ? ` ${name}-hint` : ""}`;
   const nestedChildClasses = nested ? "nested ds-c-choice__checkedChild" : "";
+  const selectClasses = `ds-c-field${errorMessage ? " ds-c-field--error" : ""}`;
   const labelClass = !label ? "no-label" : "";
   const labelText =
     label && styleAsOptional ? labelTextWithOptional(label) : label;
@@ -120,17 +121,17 @@ export const DropdownField = ({
         {labelText || ""}
       </Label>
       {parsedHint && <Hint id={`${name}-hint`}>{parsedHint}</Hint>}
-      {errorMessage && <InlineErrorShim>{errorMessage}</InlineErrorShim>}
+      <InlineErrorShim id={`${name}__error`}>{errorMessage}</InlineErrorShim>
       <select
         name={name}
         id={name}
         aria-describedby={ariaDescribedBy}
         aria-label={ariaLabel}
-        aria-invalid="false"
+        aria-invalid={!!errorMessage}
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
         value={displayValue?.value}
-        className="ds-c-field"
+        className={selectClasses}
         disabled={disabled}
       >
         {formattedOptions.map((option) => (


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Because we use a HTML `<select>` for our dropdown, we need to manually handle connecting error messages to it, style it with a red border, and manually change `aria-invalid`.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6152

---
### How to test
ℹ️ If you're having a hard time dealing with VoiceOver, reach out and I can help!

- Run this PR locally or use the [deployed env](https://doskmvjyae2sa.cloudfront.net/)
- Navigate to FRF dashboard (at `/financial-report`)
- Click the `Start MFP Financial Report` button
- With the `Start MFP Financial Report` modal open, [turn on VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac) (if you're on macOS)
- Use the `Tab` key to navigate to the dropdown fields in the modal
- Once you blur one of the required fields, return to the errored field, you should be able to hear that the error message is read
- For the two required dropdown fields in the modal, you should be able to hear the error message when the error message is visible and you have that field focused
