### PR TITLE
Cmdct 6219 - add close-out section to PDF for copied over work plans

### DIFF
--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -18,6 +18,7 @@ import {
   PageTypes,
   ReportFormFieldType,
   ValidationType,
+  AnyObject,
 } from "types";
 import {
   ExportedModalOverlayReportSection,
@@ -685,6 +686,10 @@ describe("<ExportedModalOverlayReportSection />", () => {
     });
     render(testComponent(propsWithTitleSubtitle));
     expect(screen.getAllByText("Unique Field Title").length).toBe(2);
+    // Non-close-out fields promote the label to an h5 subsection heading
+    expect(
+      screen.getAllByRole("heading", { level: 5, name: "Field Label" }).length
+    ).toBe(2);
   });
 
   test("should render field with sectionTitle", () => {
@@ -886,6 +891,147 @@ describe("<ExportedModalOverlayReportSection />", () => {
     });
     render(testComponent(propsWithDynamicObjectNoTable));
     expect(screen.getByTestId("exportTable")).toBeVisible();
+  });
+
+  // Renders a single initiative so text assertions are unambiguous.
+  const singleInitiativeReport = (overrides: AnyObject) => ({
+    ...mockWPReportWithOverlays,
+    fieldData: {
+      ...mockWPReportWithOverlays.fieldData,
+      initiative: [
+        {
+          ...mockWPReportWithOverlays.fieldData.initiative[0],
+          ...overrides,
+        },
+      ],
+    },
+  });
+
+  test("should substitute {{initiativeName}} placeholder in field title", () => {
+    const propsWithPlaceholderTitle = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "field_with_placeholder",
+              type: "text",
+              validation: "text",
+              props: {
+                title: "Close-out {{initiativeName}}",
+                subtitle: "Field subtitle text",
+                label: "Field Label",
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    mockedUseStore.mockReturnValue({
+      ...mockReportStore,
+      report: singleInitiativeReport({ initiative_name: "Test Initiative" }),
+    });
+    render(testComponent(propsWithPlaceholderTitle));
+    expect(screen.getByText("Close-out Test Initiative")).toBeVisible();
+    expect(
+      screen.queryByText("Close-out {{initiativeName}}")
+    ).not.toBeInTheDocument();
+  });
+
+  test("should hide close-out fields when initiative is not closed", () => {
+    const propsWithCloseOutField = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "closeOutInformation_projectedEndDate",
+              type: "date",
+              validation: "dateOptional",
+              forCopyoverOnly: true,
+              props: { label: "Projected end date" },
+            },
+          ],
+        },
+      },
+    };
+
+    mockedUseStore.mockReturnValue({
+      ...mockReportStore,
+      report: singleInitiativeReport({ isInitiativeClosed: false }),
+    });
+    render(testComponent(propsWithCloseOutField));
+    expect(screen.queryByText("Projected end date")).not.toBeInTheDocument();
+  });
+
+  test("should show close-out fields when initiative is closed", () => {
+    const propsWithCloseOutField = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "closeOutInformation_projectedEndDate",
+              type: "date",
+              validation: "dateOptional",
+              forCopyoverOnly: true,
+              props: {
+                title: "Close-out {{initiativeName}}",
+                subtitle: "Complete for initiatives that end soon.",
+                label: "Projected end date",
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    mockedUseStore.mockReturnValue({
+      ...mockReportStore,
+      report: singleInitiativeReport({
+        isInitiativeClosed: true,
+        initiative_name: "Test Initiative",
+      }),
+    });
+    render(testComponent(propsWithCloseOutField));
+    // Title renders as the section header with the substituted initiative name
+    expect(screen.getByText("Close-out Test Initiative")).toBeVisible();
+    // Label renders in the Indicators column, not as an h5 subsection heading
+    expect(screen.getByText("Projected end date")).toBeVisible();
+    expect(
+      screen.queryByRole("heading", { level: 5, name: "Projected end date" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("should keep non-close-out forCopyoverOnly fields hidden when closed", () => {
+    const propsWithCopyoverField = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "regular_copyover_field",
+              type: "text",
+              validation: "text",
+              forCopyoverOnly: true,
+              props: { label: "Hidden Copyover Field" },
+            },
+          ],
+        },
+      },
+    };
+
+    mockedUseStore.mockReturnValue({
+      ...mockReportStore,
+      report: singleInitiativeReport({ isInitiativeClosed: true }),
+    });
+    render(testComponent(propsWithCopyoverField));
+    expect(screen.queryByText("Hidden Copyover Field")).not.toBeInTheDocument();
   });
 
   testA11yAct(testComponent(wpMockProps), () => {

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.test.tsx
@@ -319,36 +319,44 @@ const testComponent = (props: Props) => (
   </RouterWrappedComponent>
 );
 
+// Builds a report with a single initiative so text assertions are unambiguous.
+const singleInitiativeReport = (overrides: AnyObject = {}) => ({
+  ...mockWPReportWithOverlays,
+  fieldData: {
+    ...mockWPReportWithOverlays.fieldData,
+    initiative: [
+      { ...mockWPReportWithOverlays.fieldData.initiative[0], ...overrides },
+    ],
+  },
+});
+
+// Mocks the store with the given report and renders the component.
+const renderWithReport = (
+  props: Props,
+  report: AnyObject = mockWPReportWithOverlays
+) => {
+  mockedUseStore.mockReturnValue({ ...mockReportStore, report });
+  return render(testComponent(props));
+};
+
 describe("<ExportedModalOverlayReportSection />", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test("should render modal overlay report section", () => {
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(wpMockProps));
+    renderWithReport(wpMockProps);
     expect(screen.getAllByTestId("exportedOverlayModalPage")[0]).toBeVisible();
   });
 
   test("should render correct initiative topic", () => {
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(wpMockProps));
+    renderWithReport(wpMockProps);
     expect(screen.getByText("mock WP topic")).toBeVisible();
     expect(screen.getByText("Unique initiative type")).toBeVisible();
   });
 
   test("should render for SAR", () => {
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockSARReportWithOverlays,
-    });
-    render(testComponent(sarMockProps));
+    renderWithReport(sarMockProps, mockSARReportWithOverlays);
     expect(screen.getByText("% of total projected spending")).toBeVisible();
     expect(screen.getByText("42.86%")).toBeVisible(); // (5+10)/(15+20)
   });
@@ -378,11 +386,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithCopyoverField));
+    renderWithReport(propsWithCopyoverField);
     expect(screen.queryByText("Should be skipped")).not.toBeInTheDocument();
     expect(screen.getAllByText("Regular Field").length).toBe(2);
   });
@@ -435,11 +439,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: reportWithNestedField,
-    });
-    render(testComponent(propsWithNestedField));
+    renderWithReport(propsWithNestedField, reportWithNestedField);
     expect(screen.getByText("Please describe:")).toBeVisible();
     expect(screen.getByText("Test description")).toBeVisible();
   });
@@ -492,11 +492,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: reportWithNestedField,
-    });
-    render(testComponent(propsWithNestedField));
+    renderWithReport(propsWithNestedField, reportWithNestedField);
     expect(screen.getByText("Nested Field Label")).toBeVisible();
     expect(screen.getByText("Nested value")).toBeVisible();
   });
@@ -549,11 +545,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: reportWithUnselectedParent,
-    });
-    render(testComponent(propsWithNestedField));
+    renderWithReport(propsWithNestedField, reportWithUnselectedParent);
     expect(screen.queryByText("Should not render")).not.toBeInTheDocument();
   });
 
@@ -591,11 +583,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithChoicesChildren));
+    renderWithReport(propsWithChoicesChildren);
     expect(screen.getAllByText("Parent Choice Field").length).toBe(2);
   });
 
@@ -650,11 +638,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: reportWithStartDate,
-    });
-    render(testComponent(propsWithStartDate));
+    renderWithReport(propsWithStartDate, reportWithStartDate);
     expect(screen.getAllByText("Expected start date").length).toBe(2);
   });
 
@@ -680,11 +664,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithTitleSubtitle));
+    renderWithReport(propsWithTitleSubtitle);
     expect(screen.getAllByText("Unique Field Title").length).toBe(2);
     // Non-close-out fields promote the label to an h5 subsection heading
     expect(
@@ -713,11 +693,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithSectionTitle));
+    renderWithReport(propsWithSectionTitle);
     expect(screen.getAllByText("Unique Section Title Test").length).toBe(2);
   });
 
@@ -742,11 +718,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithSubsectionTitle));
+    renderWithReport(propsWithSubsectionTitle);
     expect(screen.getAllByText("Unique Subsection Title Test").length).toBe(2);
   });
 
@@ -771,11 +743,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithDescribeInitiative));
+    renderWithReport(propsWithDescribeInitiative);
     expect(screen.getAllByText("Unique Describe Initiative").length).toBe(2);
     expect(
       screen.getAllByText(
@@ -832,11 +800,7 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithDynamicObject));
+    renderWithReport(propsWithDynamicObject);
     expect(screen.getAllByText("Unique Test Table").length).toBe(2);
   });
 
@@ -885,26 +849,8 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: mockWPReportWithOverlays,
-    });
-    render(testComponent(propsWithDynamicObjectNoTable));
+    renderWithReport(propsWithDynamicObjectNoTable);
     expect(screen.getByTestId("exportTable")).toBeVisible();
-  });
-
-  // Renders a single initiative so text assertions are unambiguous.
-  const singleInitiativeReport = (overrides: AnyObject) => ({
-    ...mockWPReportWithOverlays,
-    fieldData: {
-      ...mockWPReportWithOverlays.fieldData,
-      initiative: [
-        {
-          ...mockWPReportWithOverlays.fieldData.initiative[0],
-          ...overrides,
-        },
-      ],
-    },
   });
 
   test("should substitute {{initiativeName}} placeholder in field title", () => {
@@ -929,18 +875,17 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: singleInitiativeReport({ initiative_name: "Test Initiative" }),
-    });
-    render(testComponent(propsWithPlaceholderTitle));
+    renderWithReport(
+      propsWithPlaceholderTitle,
+      singleInitiativeReport({ initiative_name: "Test Initiative" })
+    );
     expect(screen.getByText("Close-out Test Initiative")).toBeVisible();
     expect(
       screen.queryByText("Close-out {{initiativeName}}")
     ).not.toBeInTheDocument();
   });
 
-  test("should hide close-out fields when initiative is not closed", () => {
+  test("should hide close-out fields for non-copied reports", () => {
     const propsWithCloseOutField = {
       section: {
         ...wpMockProps.section,
@@ -959,15 +904,14 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: singleInitiativeReport({ isInitiativeClosed: false }),
+    renderWithReport(propsWithCloseOutField, {
+      ...singleInitiativeReport({}),
+      isCopied: false,
     });
-    render(testComponent(propsWithCloseOutField));
     expect(screen.queryByText("Projected end date")).not.toBeInTheDocument();
   });
 
-  test("should show close-out fields when initiative is closed", () => {
+  test("should show close-out fields for copied reports", () => {
     const propsWithCloseOutField = {
       section: {
         ...wpMockProps.section,
@@ -990,14 +934,10 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: singleInitiativeReport({
-        isInitiativeClosed: true,
-        initiative_name: "Test Initiative",
-      }),
+    renderWithReport(propsWithCloseOutField, {
+      ...singleInitiativeReport({ initiative_name: "Test Initiative" }),
+      isCopied: true,
     });
-    render(testComponent(propsWithCloseOutField));
     // Title renders as the section header with the substituted initiative name
     expect(screen.getByText("Close-out Test Initiative")).toBeVisible();
     // Label renders in the Indicators column, not as an h5 subsection heading
@@ -1007,7 +947,76 @@ describe("<ExportedModalOverlayReportSection />", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("should keep non-close-out forCopyoverOnly fields hidden when closed", () => {
+  test("should show 'Closed by' in the close-out section for a closed WP initiative", () => {
+    const propsWithCloseOutField = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "closeOutInformation_projectedEndDate",
+              type: "date",
+              validation: "dateOptional",
+              forCopyoverOnly: true,
+              props: {
+                title: "Close-out {{initiativeName}}",
+                subtitle: "Complete for initiatives that end soon.",
+                label: "Projected end date",
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    renderWithReport(propsWithCloseOutField, {
+      ...singleInitiativeReport({
+        initiative_name: "Test Initiative",
+        isInitiativeClosed: true,
+        closedBy: "Jane Doe",
+      }),
+      isCopied: true,
+    });
+    expect(screen.getByText("Closed by")).toBeVisible();
+    expect(screen.getByText("Jane Doe")).toBeVisible();
+  });
+
+  test("should not show 'Closed by' when the WP initiative is not closed", () => {
+    const propsWithCloseOutField = {
+      section: {
+        ...wpMockProps.section,
+        overlayForm: {
+          id: "test_form",
+          fields: [
+            {
+              id: "closeOutInformation_projectedEndDate",
+              type: "date",
+              validation: "dateOptional",
+              forCopyoverOnly: true,
+              props: {
+                title: "Close-out {{initiativeName}}",
+                subtitle: "Complete for initiatives that end soon.",
+                label: "Projected end date",
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    renderWithReport(propsWithCloseOutField, {
+      ...singleInitiativeReport({
+        initiative_name: "Test Initiative",
+        isInitiativeClosed: false,
+        closedBy: "Jane Doe",
+      }),
+      isCopied: true,
+    });
+    expect(screen.queryByText("Closed by")).not.toBeInTheDocument();
+  });
+
+  test("should keep non-close-out forCopyoverOnly fields hidden for copied reports", () => {
     const propsWithCopyoverField = {
       section: {
         ...wpMockProps.section,
@@ -1026,11 +1035,10 @@ describe("<ExportedModalOverlayReportSection />", () => {
       },
     };
 
-    mockedUseStore.mockReturnValue({
-      ...mockReportStore,
-      report: singleInitiativeReport({ isInitiativeClosed: true }),
+    renderWithReport(propsWithCopyoverField, {
+      ...singleInitiativeReport({}),
+      isCopied: true,
     });
-    render(testComponent(propsWithCopyoverField));
     expect(screen.queryByText("Hidden Copyover Field")).not.toBeInTheDocument();
   });
 

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -7,6 +7,7 @@ import {
   updateRenderFields,
   isFieldElement,
   parseFormFieldInfo,
+  translate,
 } from "utils";
 // components
 import {
@@ -431,6 +432,7 @@ const EntityFieldsTable = ({
   const tableRows: React.ReactElement[] = [];
   const entityType = entity.type;
   const entityId = entity.id;
+  const initiativeName = entity.initiative_name;
 
   const renderFieldRow = (formField: FormField | FormLayoutElement) => {
     const isDynamicRowsTemplate =
@@ -562,11 +564,15 @@ const EntityFieldsTable = ({
       const fieldSubtitle = (formField as any).props.subtitle;
       const fieldLabel = (formField as any).props.label;
 
+      // Close-out fields carry a title/subtitle as a section header, but their
+      // label should stay in the Indicators column rather than become a heading.
+      const isCloseOutField = formField.id?.startsWith("closeOutInformation_");
+
       const modifiedField = {
         ...formField,
         props: {
           ...formField.props,
-          label: "",
+          label: isCloseOutField ? formField.props?.label : "",
         },
       };
 
@@ -582,12 +588,14 @@ const EntityFieldsTable = ({
           >
             <Box sx={{ margin: 0, marginBottom: 0, marginTop: "1.5rem" }}>
               <Heading as="h4" sx={sx.sectionHeading}>
-                {fieldTitle}
+                {translate(fieldTitle, { initiativeName })}
               </Heading>
               <Text sx={sx.helperText}>{parseCustomHtml(fieldSubtitle)}</Text>
-              <Heading as="h5" sx={sx.subsectionHeading}>
-                {fieldLabel}
-              </Heading>
+              {!isCloseOutField && (
+                <Heading as="h5" sx={sx.subsectionHeading}>
+                  {fieldLabel}
+                </Heading>
+              )}
               <Table
                 content={{
                   headRow: [tableHeaders.indicator, tableHeaders.response],
@@ -634,7 +642,7 @@ const EntityFieldsTable = ({
           >
             <Box sx={{ margin: 0, marginBottom: 0, marginTop: "1.5rem" }}>
               <Heading as="h4" sx={sx.sectionHeading}>
-                {fieldOrSectionTitle}
+                {translate(fieldOrSectionTitle, { initiativeName })}
               </Heading>
               {helperText && <Text sx={sx.helperText}>{helperText}</Text>}
               <Table
@@ -675,7 +683,7 @@ const EntityFieldsTable = ({
           >
             <Box sx={{ margin: 0, marginBottom: 0, marginTop: "1.5rem" }}>
               <Heading as="h5" sx={sx.subsectionHeading}>
-                {subsectionTitle}
+                {translate(subsectionTitle, { initiativeName })}
               </Heading>
               <Table
                 content={{
@@ -716,7 +724,11 @@ const EntityFieldsTable = ({
   };
 
   flattenedFields.forEach((field: FormField | FormLayoutElement) => {
-    if ((field as any).forCopyoverOnly) {
+    // Close-out fields are flagged forCopyoverOnly, but should be shown in the
+    // export once the initiative has been closed out.
+    const isCloseOutField = field.id?.startsWith("closeOutInformation_");
+    const showClosedOutField = isCloseOutField && entity.isInitiativeClosed;
+    if ((field as any).forCopyoverOnly && !showClosedOutField) {
       return;
     }
 

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -652,7 +652,7 @@ const EntityFieldsTable = ({
           >
             <Box sx={{ margin: 0, marginBottom: 0, marginTop: "1.5rem" }}>
               <Heading as="h4" sx={sx.sectionHeading}>
-                {translate(fieldOrSectionTitle, { initiativeName })}
+                {fieldOrSectionTitle}
               </Heading>
               {helperText && <Text sx={sx.helperText}>{helperText}</Text>}
               <Table
@@ -693,7 +693,7 @@ const EntityFieldsTable = ({
           >
             <Box sx={{ margin: 0, marginBottom: 0, marginTop: "1.5rem" }}>
               <Heading as="h5" sx={sx.subsectionHeading}>
-                {translate(subsectionTitle, { initiativeName })}
+                {subsectionTitle}
               </Heading>
               <Table
                 content={{

--- a/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
+++ b/services/ui-src/src/components/export/ExportedModalOverlayReportSection.tsx
@@ -596,6 +596,16 @@ const EntityFieldsTable = ({
                   {fieldLabel}
                 </Heading>
               )}
+              {isCloseOutField &&
+                report?.reportType === ReportType.WP &&
+                entity.isInitiativeClosed && (
+                  <Text sx={sx.helperText} data-testid="exportRow">
+                    <Text as="span" sx={{ fontWeight: "bold" }}>
+                      Closed by
+                    </Text>
+                    <Text>{entity.closedBy}</Text>
+                  </Text>
+                )}
               <Table
                 content={{
                   headRow: [tableHeaders.indicator, tableHeaders.response],
@@ -724,11 +734,11 @@ const EntityFieldsTable = ({
   };
 
   flattenedFields.forEach((field: FormField | FormLayoutElement) => {
-    // Close-out fields are flagged forCopyoverOnly, but should be shown in the
-    // export once the initiative has been closed out.
+    // Close-out fields should be shown in the
+    // export only for copied-over reports.
     const isCloseOutField = field.id?.startsWith("closeOutInformation_");
-    const showClosedOutField = isCloseOutField && entity.isInitiativeClosed;
-    if ((field as any).forCopyoverOnly && !showClosedOutField) {
+    const showCloseOutField = isCloseOutField && report?.isCopied;
+    if ((field as any).forCopyoverOnly && !showCloseOutField) {
       return;
     }
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description


Close-out information is now included in the PDF for copied over WPs.

[Figma ](https://www.figma.com/design/eXft0cALwk387Ay3L6pCkY/MFP-WP---SAR--25--26-Updates--Internal-?node-id=531-1795&p=f&t=5npUrrdUJyu9vLJM-0)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6219

---
### How to test
Easier to test locally: 
run `yarn db:seed`, create an approved WP, then go in and manually create another WP. 
Go into it and in the initiatives, enter one and close it out.
Open the PDF to confirm that all initiatives have the close-out section, and that the closed-out initiative has the correct filled out information.
Also confirm that the first WP PDF does not have the close-out information.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
