### PR TITLE
cmdct-6332 - formatting changes to SAR PDF

### DIFF
--- a/services/app-api/forms/routes/sar/flags/wpSarRelease2025/state-or-territory-specific-initiatives.ts
+++ b/services/app-api/forms/routes/sar/flags/wpSarRelease2025/state-or-territory-specific-initiatives.ts
@@ -75,6 +75,7 @@ export const stateOrTerritorySpecificInitiativesRoute: SARStateOrTerritorySpecif
           tableType: FormTableType.ENTITY_MODAL,
           verbiage: {
             sectionTitle: "Initiative Evaluation",
+            emptyTableMessage: "No Performance Indicators",
             subtitle: [
               {
                 type: "p",
@@ -129,7 +130,7 @@ export const stateOrTerritorySpecificInitiativesRoute: SARStateOrTerritorySpecif
         // Initiative Evaluation
         // Key Metrics table
         sarKeyMetricsDynamicRowsTemplate,
-        // Findings and Sustainability
+        // Qualitative Findings
         {
           id: "initiativeEvaluation_describeQualitativeDetail",
           type: ReportFormFieldType.TEXTAREA,
@@ -143,8 +144,10 @@ export const stateOrTerritorySpecificInitiativesRoute: SARStateOrTerritorySpecif
             label:
               "Describe any qualitative findings that were recorded during this reporting period.",
             maxLength: 1800,
+            subsectionTitle: "Qualitative Findings",
           },
         },
+        // Findings and Sustainability
         {
           id: "initiativeEvaluation_achievedExpectedResults",
           type: ReportFormFieldType.RADIO,


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description

Requested change from Design for the SAR pdf:

First question after they Key Metrics should be in its own table. Before, it was displaying in a row directly after the key metrics.
Now (without key metrics and with key metrics):

<img width="695" height="303" alt="Screenshot 2026-07-08 at 1 15 40 PM" src="https://github.com/user-attachments/assets/7f22605e-7e07-43dd-b4b5-e1e2237d0828" />
<img width="775" height="490" alt="Screenshot 2026-07-08 at 1 15 52 PM" src="https://github.com/user-attachments/assets/8fa82890-749a-47a3-99bd-6e4208d23158" />



### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6332

---
### How to test
Create a WP with at least one initiative without a key metric. Approve it, then create a SAR. Check the SAR PDF matches the screenshots.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
